### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -73,8 +73,8 @@ class ZammadClient:
         try:
             with open(secret_file) as f:
                 return f.read().strip()
-        except OSError as e:
-            logger.warning(f"Failed to read secret from {secret_file}: {e}")
+        except OSError:
+            logger.warning("Failed to read secret file.")
             return None
 
     def search_tickets(

--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -74,7 +74,7 @@ class ZammadClient:
             with open(secret_file) as f:
                 return f.read().strip()
         except OSError:
-            logger.warning("Failed to read secret file.")
+            logger.warning(f"Failed to read secret for environment variable '{env_var}'.")
             return None
 
     def search_tickets(


### PR DESCRIPTION
Potential fix for [https://github.com/basher83/Zammad-MCP/security/code-scanning/1](https://github.com/basher83/Zammad-MCP/security/code-scanning/1)

To fix the issue, we should avoid logging the file path of the secret and the exception details directly. Instead, we can log a generic warning message that does not include sensitive information. This ensures that no sensitive data is exposed in the logs while still providing useful feedback for debugging purposes.

The fix involves modifying the logging statement on line 77 to remove the inclusion of `secret_file` and `e`. A generic message such as "Failed to read secret file" can be used instead. No additional imports or dependencies are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated warning messages for failed secret file reads to be more generic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->