### PR TITLE
fix: resolve Docker build and authentication issues (#32, #33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Docker image build to properly install the mcp-zammad package (#32)
+- Improved error message when ZAMMAD_TOKEN is used instead of ZAMMAD_HTTP_TOKEN (#33)
+- Added client configuration tests for better coverage
+
 ### Changed
 
 - Simplified deployment by removing Docker Compose in favor of direct `docker run` and `uvx` commands

--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -44,6 +44,12 @@ class ZammadClient:
             raise ConfigException("Zammad URL is required. Set ZAMMAD_URL environment variable.")
 
         if not any([self.http_token, self.oauth2_token, (self.username and self.password)]):
+            # Check if user mistakenly used ZAMMAD_TOKEN
+            if os.getenv("ZAMMAD_TOKEN"):
+                raise ConfigException(
+                    "Found ZAMMAD_TOKEN but this server expects ZAMMAD_HTTP_TOKEN. "
+                    "Please rename your environment variable from ZAMMAD_TOKEN to ZAMMAD_HTTP_TOKEN."
+                )
             raise ConfigException(
                 "Authentication credentials required. Set either ZAMMAD_HTTP_TOKEN, "
                 "ZAMMAD_OAUTH2_TOKEN, or both ZAMMAD_USERNAME and ZAMMAD_PASSWORD."

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,59 @@
+"""Tests for Zammad client configuration and error handling."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_zammad.client import ConfigException, ZammadClient
+
+
+def test_client_requires_url() -> None:
+    """Test that client raises error when URL is missing."""
+    with patch.dict(os.environ, {}, clear=True), pytest.raises(ConfigException, match="Zammad URL is required"):
+        ZammadClient()
+
+
+def test_client_requires_authentication() -> None:
+    """Test that client raises error when authentication is missing."""
+    with (
+        patch.dict(os.environ, {"ZAMMAD_URL": "https://test.zammad.com/api/v1"}, clear=True),
+        pytest.raises(ConfigException, match="Authentication credentials required"),
+    ):
+        ZammadClient()
+
+
+def test_client_detects_wrong_token_var() -> None:
+    """Test that client provides helpful error when ZAMMAD_TOKEN is used instead of ZAMMAD_HTTP_TOKEN."""
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "ZAMMAD_URL": "https://test.zammad.com/api/v1",
+                "ZAMMAD_TOKEN": "test-token",  # Wrong variable name
+            },
+            clear=True,
+        ),
+        pytest.raises(ConfigException) as exc_info,
+    ):
+        ZammadClient()
+
+    assert "Found ZAMMAD_TOKEN but this server expects ZAMMAD_HTTP_TOKEN" in str(exc_info.value)
+    assert "Please rename your environment variable" in str(exc_info.value)
+
+
+@patch("mcp_zammad.client.ZammadAPI")
+def test_client_accepts_http_token(mock_api: MagicMock) -> None:
+    """Test that client works correctly with ZAMMAD_HTTP_TOKEN."""
+    with patch.dict(
+        os.environ,
+        {
+            "ZAMMAD_URL": "https://test.zammad.com/api/v1",
+            "ZAMMAD_HTTP_TOKEN": "test-token",
+        },
+        clear=True,
+    ):
+        client = ZammadClient()
+        assert client.url == "https://test.zammad.com/api/v1"
+        assert client.http_token == "test-token"
+        mock_api.assert_called_once()


### PR DESCRIPTION
## Summary
- Fixed Docker image build by properly installing mcp-zammad package
- Added helpful error message for users using wrong token variable
- Added client configuration tests

## Problem
1. **Issue #32**: Docker container failed to start with `ModuleNotFoundError: No module named 'mcp_zammad'`
2. **Issue #33**: Users using `ZAMMAD_TOKEN` instead of `ZAMMAD_HTTP_TOKEN` got unhelpful error message

## Solution
1. **Docker Fix**: Modified Dockerfile to properly install the package using `uv pip install -e .` in the builder stage
2. **Error Message**: Added explicit check for `ZAMMAD_TOKEN` environment variable with helpful error message directing users to use `ZAMMAD_HTTP_TOKEN`
3. **Tests**: Added comprehensive client configuration tests to ensure authentication errors are clear

## Test Plan
- [x] Built Docker image locally and verified mcp-zammad command exists
- [x] Verified module can be imported in container
- [x] Added unit tests for client configuration scenarios
- [x] All existing tests pass

Fixes #32
Fixes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message when an incorrect environment variable (`ZAMMAD_TOKEN`) is used, guiding users to use `ZAMMAD_HTTP_TOKEN` instead.
  * Fixed Docker image build process to ensure proper installation of the mcp-zammad package.

* **Tests**
  * Added tests for client configuration and error handling related to environment variables.

* **Chores**
  * Updated documentation to reflect recent fixes in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->