### PR TITLE
Potential fix for code scanning alert no. 344: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,4 +1,6 @@
 name: Sync Labels via Central Definition
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/basher83/Zammad-MCP/security/code-scanning/344](https://github.com/basher83/Zammad-MCP/security/code-scanning/344)

To fix the problem, add a `permissions` block at the top level of the workflow file, just after the `name:` and before the `on:` block. This block should specify the minimal permissions required for the workflow to function. Since the workflow is for syncing labels, it likely only needs `contents: read` and possibly `issues: write` if it modifies labels on issues. However, as a minimal starting point and in line with the CodeQL suggestion, we can set `contents: read`. If more permissions are needed, they can be added later. The change should be made in `.github/workflows/sync-labels.yml`, inserting the `permissions:` block after the `name:` line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
