### PR TITLE
feat: add Conductor workspace configuration

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+    "scripts": {
+        "setup": "./scripts/conductor-setup.sh",
+        "run": ""
+    }
+}

--- a/scripts/conductor-setup.sh
+++ b/scripts/conductor-setup.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "🚀 Setting up Zammad MCP workspace..."
+echo ""
+
+# Check for required tools
+echo "🔍 Checking for required tools..."
+
+if ! command -v mise >/dev/null 2>&1; then
+    echo "❌ Error: mise is not installed"
+    echo "Please install mise: https://mise.jdx.dev/getting-started.html"
+    exit 1
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "❌ Error: uv is not installed"
+    echo "mise will install uv automatically during setup"
+fi
+
+echo "✅ Required tools available"
+echo ""
+
+# Copy mise.local.toml if it exists in the root repo
+if [ -n "${CONDUCTOR_ROOT_PATH:-}" ] && [ -f "$CONDUCTOR_ROOT_PATH/mise.local.toml" ]; then
+    echo "📋 Copying mise.local.toml from root repository..."
+    cp "$CONDUCTOR_ROOT_PATH/mise.local.toml" mise.local.toml
+    echo "✅ mise.local.toml copied"
+else
+    echo "⚠️  Warning: mise.local.toml not found in root repository"
+    echo "You'll need to create mise.local.toml with your Zammad credentials:"
+    echo ""
+    echo "[env]"
+    echo "ZAMMAD_URL = \"https://your-instance.zammad.com/api/v1\""
+    echo "ZAMMAD_HTTP_TOKEN = \"your-api-token-here\""
+    echo ""
+fi
+
+# Run mise setup task
+echo "📦 Running mise setup..."
+mise run setup
+
+echo ""
+echo "✅ Workspace setup complete!"
+echo ""
+echo "Next steps:"
+echo "  1. Ensure mise.local.toml has your Zammad credentials"
+echo "  2. Run tests: uv run pytest"
+echo "  3. Run quality checks: ./scripts/quality-check.sh"


### PR DESCRIPTION
## Summary

- Add `conductor.json` configuration for Conductor workspace management
- Add `scripts/conductor-setup.sh` for automated workspace setup
- Enables seamless workspace creation and setup for all contributors

## Changes

### conductor.json
- Defines setup script path for new workspaces
- Empty run script (MCP server, not a standalone dev server)

### scripts/conductor-setup.sh
- Verifies required tools (mise, uv) with fail-fast error handling
- Copies `mise.local.toml` from root repo if available
- Runs `mise run setup` for dependency and hook installation
- Provides helpful configuration guidance
- Passed shellcheck validation

## Test Plan

- [x] Script runs successfully in new workspace
- [x] Dependencies installed via `mise run setup`
- [x] Pre-commit hooks installed correctly
- [x] Shellcheck validation passed
- [x] Helpful warnings displayed when `mise.local.toml` is missing

## Next Steps

Once merged to main, all new workspaces will automatically:
1. Set up Python dependencies
2. Install pre-commit hooks
3. Copy environment configuration from root repo
4. Be ready for development immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated workspace setup for Zammad MCP development. The setup process verifies required tools, manages environment configuration, and provides guidance for completing the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->