### PR TITLE
Fix expand parameter: use string "true" instead of Python bool

### DIFF
--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -134,7 +134,7 @@ class ZammadClient:
         per_page: int = 25,
     ) -> list[dict[str, Any]]:
         """Search tickets with various filters."""
-        filters = {"page": page, "per_page": per_page, "expand": True}
+        filters = {"page": page, "per_page": per_page, "expand": "true"}
 
         # Build search query
         search_parts = []
@@ -300,7 +300,7 @@ class ZammadClient:
         per_page: int = 25,
     ) -> list[dict[str, Any]]:
         """Search users."""
-        filters = {"page": page, "per_page": per_page, "expand": True}
+        filters = {"page": page, "per_page": per_page, "expand": "true"}
         result = self.api.user.search(query, filters=filters)
         return list(result)
 
@@ -340,7 +340,7 @@ class ZammadClient:
         per_page: int = 25,
     ) -> list[dict[str, Any]]:
         """Search organizations."""
-        filters = {"page": page, "per_page": per_page, "expand": True}
+        filters = {"page": page, "per_page": per_page, "expand": "true"}
         result = self.api.organization.search(query, filters=filters)
         return list(result)
 

--- a/tests/test_client_methods.py
+++ b/tests/test_client_methods.py
@@ -55,7 +55,7 @@ class TestZammadClientMethods:
         assert len(result) == EXPECTED_TWO_RESULTS
         assert result[0]["name"] == "Org 1"
         mock_instance.organization.search.assert_called_once_with(
-            "test", filters={"page": 1, "per_page": 25, "expand": True}
+            "test", filters={"page": 1, "per_page": 25, "expand": "true"}
         )
 
     def test_update_ticket(self, mock_zammad_api: Mock) -> None:
@@ -128,7 +128,7 @@ class TestZammadClientMethods:
 
         assert len(result) == 2
         assert result[0]["email"] == "user1@example.com"
-        mock_instance.user.search.assert_called_once_with("test", filters={"page": 1, "per_page": 10, "expand": True})
+        mock_instance.user.search.assert_called_once_with("test", filters={"page": 1, "per_page": 10, "expand": "true"})
 
     def test_get_current_user(self, mock_zammad_api: Mock) -> None:
         """Test get_current_user method."""
@@ -265,7 +265,7 @@ class TestZammadClientMethods:
         assert len(result) == 1
         expected_query = "test AND state.name:open AND priority.name:high AND group.name:Support AND owner.login:agent1 AND customer.email:customer@example.com"
         mock_instance.ticket.search.assert_called_once_with(
-            expected_query, filters={"page": 2, "per_page": 50, "expand": True}
+            expected_query, filters={"page": 2, "per_page": 50, "expand": "true"}
         )
 
     def test_search_tickets_no_query(self, mock_zammad_api: Mock) -> None:
@@ -279,7 +279,7 @@ class TestZammadClientMethods:
         result = client.search_tickets()
 
         assert len(result) == 1
-        mock_instance.ticket.all.assert_called_once_with(filters={"page": 1, "per_page": 25, "expand": True})
+        mock_instance.ticket.all.assert_called_once_with(filters={"page": 1, "per_page": 25, "expand": "true"})
 
     def test_get_ticket_with_articles(self, mock_zammad_api: Mock) -> None:
         """Test get_ticket with article pagination."""

--- a/tests/test_expand_param_fix.py
+++ b/tests/test_expand_param_fix.py
@@ -1,0 +1,195 @@
+"""Tests proving the expand parameter bug and fix.
+
+Bug: The Zammad API is case-sensitive for the `expand` query parameter.
+Python's `requests` library serializes bool `True` as the string "True"
+(capital T), but Zammad only recognizes lowercase "true". When "True" is
+sent, the API returns a nested dict format instead of a flat list, causing
+`Ticket(**item)` to fail with "argument after ** must be a mapping, not str".
+
+Fix: Use the string "true" instead of Python bool `True` for the expand
+parameter in all filter dicts passed to zammad_py.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_zammad.client import ZammadClient
+from mcp_zammad.models import Ticket
+
+# -- Sample data matching real Zammad API responses --
+
+# What Zammad returns when expand=true (lowercase) — a flat list of dicts
+EXPANDED_TICKET_LIST = [
+    {
+        "id": 157656,
+        "number": "202602261700956",
+        "title": "Test Ticket 1",
+        "group_id": 8,
+        "group": "Support",
+        "state_id": 2,
+        "state": "open",
+        "priority_id": 2,
+        "priority": "2 normal",
+        "customer_id": 4541,
+        "owner_id": 6009,
+        "organization_id": 22,
+        "created_by_id": 6009,
+        "updated_by_id": 4541,
+        "created_at": "2026-02-26T21:36:59.832Z",
+        "updated_at": "2026-03-03T21:46:36.412Z",
+    },
+]
+
+# What Zammad returns when expand=True (capital T) or expand missing — nested dict
+UNEXPANDED_TICKET_DICT = {
+    "tickets": [157656],
+    "tickets_count": 1,
+    "assets": {
+        "Ticket": {
+            "157656": {
+                "id": 157656,
+                "number": "202602261700956",
+                "title": "Test Ticket 1",
+                "group_id": 8,
+                "state_id": 2,
+                "priority_id": 2,
+                "customer_id": 4541,
+                "owner_id": 6009,
+                "organization_id": 22,
+                "created_by_id": 6009,
+                "updated_by_id": 4541,
+                "created_at": "2026-02-26T21:36:59.832Z",
+                "updated_at": "2026-03-03T21:46:36.412Z",
+            }
+        }
+    },
+}
+
+
+class TestExpandParameterBug:
+    """Tests demonstrating the expand parameter bug and its fix."""
+
+    @pytest.fixture
+    def mock_zammad_api(self):
+        with patch("mcp_zammad.client.ZammadAPI") as mock_api:
+            yield mock_api
+
+    def test_expand_param_is_string_not_bool(self, mock_zammad_api: Mock) -> None:
+        """Verify the fix: expand parameter must be string "true", not bool True.
+
+        zammad_py checks `if "expand" not in params` before setting its own
+        default. When we pass bool True, zammad_py skips its override and
+        Python's requests serializes True -> "True" (capital T). Zammad
+        ignores this and returns the nested dict format.
+        """
+        mock_instance = Mock()
+        mock_instance.ticket.search.return_value = EXPANDED_TICKET_LIST
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+        client.search_tickets(state="open")
+
+        call_args = mock_instance.ticket.search.call_args
+        filters = call_args[1]["filters"]
+
+        # The fix: expand must be the string "true", not Python bool True
+        assert filters["expand"] == "true"
+        assert isinstance(filters["expand"], str), (
+            "expand must be a string, not bool. "
+            "Python bool True serializes to 'True' (capital T) which Zammad ignores."
+        )
+
+    def test_expand_param_string_in_search_users(self, mock_zammad_api: Mock) -> None:
+        """Verify expand is string "true" for user search."""
+        mock_instance = Mock()
+        mock_instance.user.search.return_value = []
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+        client.search_users("test")
+
+        filters = mock_instance.user.search.call_args[1]["filters"]
+        assert filters["expand"] == "true"
+        assert isinstance(filters["expand"], str)
+
+    def test_expand_param_string_in_search_organizations(self, mock_zammad_api: Mock) -> None:
+        """Verify expand is string "true" for organization search."""
+        mock_instance = Mock()
+        mock_instance.organization.search.return_value = []
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+        client.search_organizations("test")
+
+        filters = mock_instance.organization.search.call_args[1]["filters"]
+        assert filters["expand"] == "true"
+        assert isinstance(filters["expand"], str)
+
+    def test_expand_param_string_in_ticket_all(self, mock_zammad_api: Mock) -> None:
+        """Verify expand is string "true" when listing all tickets (no query)."""
+        mock_instance = Mock()
+        mock_instance.ticket.all.return_value = EXPANDED_TICKET_LIST
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+        client.search_tickets()  # no query -> falls through to ticket.all()
+
+        filters = mock_instance.ticket.all.call_args[1]["filters"]
+        assert filters["expand"] == "true"
+        assert isinstance(filters["expand"], str)
+
+
+class TestUnexpandedResponseFailure:
+    """Tests proving that the unexpanded (nested dict) response causes failures."""
+
+    def test_iterating_unexpanded_dict_yields_strings(self) -> None:
+        """Demonstrate the root cause: iterating a dict yields key strings.
+
+        When Zammad returns the nested format (expand not recognized),
+        list(response) produces dict keys like ["tickets", "tickets_count", "assets"].
+        The code then tries Ticket(**"tickets") which fails.
+        """
+        # Simulating what happens when zammad_py wraps the unexpanded response
+        items = list(UNEXPANDED_TICKET_DICT)
+
+        assert items == ["tickets", "tickets_count", "assets"]
+        assert all(isinstance(item, str) for item in items)
+
+        # This is exactly what fails in server.py line 940:
+        #   tickets = [Ticket(**ticket) for ticket in tickets_data]
+        with pytest.raises(TypeError, match="must be a mapping, not str"):
+            Ticket(**items[0])
+
+    def test_iterating_expanded_list_yields_dicts(self) -> None:
+        """Demonstrate the fix: expanded response yields ticket dicts.
+
+        When Zammad correctly receives expand=true (lowercase), it returns
+        a flat list of ticket dicts that can be unpacked into Ticket models.
+        """
+        items = list(EXPANDED_TICKET_LIST)
+
+        assert len(items) == 1
+        assert isinstance(items[0], dict)
+
+        # This works correctly
+        ticket = Ticket(**items[0])
+        assert ticket.id == 157656
+        assert ticket.title == "Test Ticket 1"
+
+
+class TestBoolVsStringSerialization:
+    """Tests showing how Python requests serializes bool vs string."""
+
+    def test_bool_true_serializes_to_capital_t(self) -> None:
+        """Python bool True becomes 'True' (capital T) in query strings.
+
+        The `requests` library calls str() on parameter values, and
+        str(True) == 'True'. Zammad requires lowercase 'true'.
+        """
+        assert str(True) == "True"
+        assert str(True) != "true"
+
+    def test_string_true_stays_lowercase(self) -> None:
+        """String "true" stays as-is in query strings."""
+        assert str("true") == "true"


### PR DESCRIPTION
## Summary
- The Zammad API is case-sensitive for the `expand` query parameter
- Python's `requests` library serializes `bool True` as `"True"` (capital T), but Zammad only recognizes lowercase `"true"`
- This causes the API to return the nested `{"tickets": [...], "assets": {...}}` dict format instead of a flat list
- Iterating that dict yields key strings (`"tickets"`, `"tickets_count"`, `"assets"`), and `Ticket(**"tickets")` fails with `argument after ** must be a mapping, not str`
- Fixed by changing `"expand": True` to `"expand": "true"` in all 3 occurrences in `client.py`

## Root cause chain
1. `client.py` passes `"expand": True` (Python bool) in filters
2. `zammad_py` checks `if "expand" not in params` — since it IS present, it doesn't override with `"true"` (string)
3. `requests` serializes `True` → `"True"` (capital T) in the URL query string
4. Zammad API ignores `expand=True` and returns nested dict format
5. `list(result)` yields dict keys as strings
6. `Ticket(**"tickets")` raises `TypeError`

## Test plan
- [x] Added `test_expand_param_fix.py` with tests proving the bug mechanism and fix
- [x] Updated existing tests in `test_client_methods.py` to match new string value
- [ ] Verify with a live Zammad instance that `search_tickets`, `search_users`, and `search_organizations` return correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the expand parameter handling in API calls to search and list tickets, users, and organizations to ensure responses are correctly formatted and processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->