### PR TITLE
Fixes #242 - feat(client): optional ZAMMAD_INSECURE for TLS verification bypass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,8 @@ ZAMMAD_HTTP_TOKEN=your-api-token-here
 
 # Optional: Disable TLS certificate verification (NOT recommended for production)
 # Use only for self-signed/internal cert chains when you trust the network path.
-# ZAMMAD_INSECURE=false
+# Truthy values only: 1, true, yes, on. Unset (default) keeps TLS verification enabled.
+# ZAMMAD_INSECURE=true
 
 # Optional: Logging level (default: INFO)
 # Valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@ ZAMMAD_HTTP_TOKEN=your-api-token-here
 # ZAMMAD_USERNAME=your-username
 # ZAMMAD_PASSWORD=your-password
 
+# Optional: Disable TLS certificate verification (NOT recommended for production)
+# Use only for self-signed/internal cert chains when you trust the network path.
+# ZAMMAD_INSECURE=false
+
 # Optional: Logging level (default: INFO)
 # Valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL
 # LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -84,8 +84,10 @@ For production or containerized deployments:
 docker run --rm -i \
   -e ZAMMAD_URL=https://your-instance.zammad.com/api/v1 \
   -e ZAMMAD_HTTP_TOKEN=your-api-token \
-  -e ZAMMAD_INSECURE=true \
   ghcr.io/basher83/zammad-mcp:latest
+
+# If you must skip TLS verification (self-signed / internal CA), add:
+#   -e ZAMMAD_INSECURE=true
 
 # Using Docker secrets for better security
 docker run --rm -i \
@@ -164,7 +166,8 @@ The server requires Zammad API credentials. Use a `.env` file:
    # ZAMMAD_PASSWORD=your-password
 
    # Optional: Disable TLS certificate verification (NOT recommended for production)
-   # ZAMMAD_INSECURE=false
+   # Truthy values only: 1, true, yes, on. Unset (default) keeps TLS verification enabled.
+   # ZAMMAD_INSECURE=true
 
    # Optional: Logging level (default: INFO)
    # Valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ For production or containerized deployments:
 docker run --rm -i \
   -e ZAMMAD_URL=https://your-instance.zammad.com/api/v1 \
   -e ZAMMAD_HTTP_TOKEN=your-api-token \
+  -e ZAMMAD_INSECURE=true \
   ghcr.io/basher83/zammad-mcp:latest
 
 # Using Docker secrets for better security
@@ -161,6 +162,9 @@ The server requires Zammad API credentials. Use a `.env` file:
    # Option 3: Username/Password
    # ZAMMAD_USERNAME=your-username
    # ZAMMAD_PASSWORD=your-password
+
+   # Optional: Disable TLS certificate verification (NOT recommended for production)
+   # ZAMMAD_INSECURE=false
 
    # Optional: Logging level (default: INFO)
    # Valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL
@@ -530,6 +534,7 @@ To generate an API token in Zammad:
 - Verify your Zammad URL includes the protocol (https://)
 - Check that your API token has the necessary permissions
 - Ensure your Zammad instance is accessible from your network
+- For self-signed/internal certs only: set `ZAMMAD_INSECURE=true` to bypass TLS verification
 
 ### Authentication Errors
 

--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -5,6 +5,7 @@ import os
 from typing import Any
 from urllib.parse import urlparse
 
+import urllib3
 from zammad_py import ZammadAPI
 from zammad_py.exceptions import ConfigException
 
@@ -21,6 +22,7 @@ class ZammadClient:
         password: str | None = None,
         http_token: str | None = None,
         oauth2_token: str | None = None,
+        insecure: bool | None = None,
     ):
         """Initialize Zammad client with environment variables or provided credentials.
 
@@ -40,6 +42,7 @@ class ZammadClient:
         self.oauth2_token = (
             oauth2_token or self._read_secret_file("ZAMMAD_OAUTH2_TOKEN_FILE") or os.getenv("ZAMMAD_OAUTH2_TOKEN")
         )
+        self.insecure = insecure if insecure is not None else self._parse_bool_env("ZAMMAD_INSECURE")
 
         if not self.url:
             raise ConfigException("Zammad URL is required. Set ZAMMAD_URL environment variable.")
@@ -66,6 +69,20 @@ class ZammadClient:
             http_token=self.http_token,
             oauth2_token=self.oauth2_token,
         )
+        if self.insecure:
+            # Allow connecting to instances with self-signed/missing CA certs.
+            session = getattr(self.api, "session", None)
+            if session is None:
+                connection = getattr(self.api, "_connection", None)
+                session = getattr(connection, "session", None) if connection is not None else None
+            if session is None:
+                raise ConfigException(
+                    "ZAMMAD_INSECURE is enabled but the installed zammad-py client does not expose a "
+                    "requests session; TLS verification cannot be disabled."
+                )
+            session.verify = False
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+            logger.warning("TLS certificate verification is disabled (ZAMMAD_INSECURE=true).")
 
     def _validate_url(self, url: str) -> None:
         """Validate URL format to prevent SSRF attacks."""
@@ -121,6 +138,11 @@ class ZammadClient:
         except OSError:
             logger.warning(f"Failed to read secret for environment variable '{env_var}'.")
             return None
+
+    def _parse_bool_env(self, env_var: str) -> bool:
+        """Parse common truthy values from environment variables."""
+        value = os.getenv(env_var, "").strip().lower()
+        return value in {"1", "true", "yes", "on"}
 
     def search_tickets(
         self,

--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -5,7 +5,6 @@ import os
 from typing import Any
 from urllib.parse import urlparse
 
-import urllib3
 from zammad_py import ZammadAPI
 from zammad_py.exceptions import ConfigException
 
@@ -42,7 +41,7 @@ class ZammadClient:
         self.oauth2_token = (
             oauth2_token or self._read_secret_file("ZAMMAD_OAUTH2_TOKEN_FILE") or os.getenv("ZAMMAD_OAUTH2_TOKEN")
         )
-        self.insecure = insecure if insecure is not None else self._parse_bool_env("ZAMMAD_INSECURE")
+        self.insecure = insecure if insecure is not None else ZammadClient._parse_bool_env("ZAMMAD_INSECURE")
 
         if not self.url:
             raise ConfigException("Zammad URL is required. Set ZAMMAD_URL environment variable.")
@@ -76,13 +75,16 @@ class ZammadClient:
                 connection = getattr(self.api, "_connection", None)
                 session = getattr(connection, "session", None) if connection is not None else None
             if session is None:
-                raise ConfigException(
+                msg = (
                     "ZAMMAD_INSECURE is enabled but the installed zammad-py client does not expose a "
                     "requests session; TLS verification cannot be disabled."
                 )
+                raise ConfigException(msg)
             session.verify = False
-            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-            logger.warning("TLS certificate verification is disabled (ZAMMAD_INSECURE=true).")
+            logger.warning(
+                "TLS certificate verification is disabled (ZAMMAD_INSECURE=true). "
+                "urllib3 may emit InsecureRequestWarning on requests; fix or trust the server certificate when possible."
+            )
 
     def _validate_url(self, url: str) -> None:
         """Validate URL format to prevent SSRF attacks."""
@@ -139,7 +141,8 @@ class ZammadClient:
             logger.warning(f"Failed to read secret for environment variable '{env_var}'.")
             return None
 
-    def _parse_bool_env(self, env_var: str) -> bool:
+    @staticmethod
+    def _parse_bool_env(env_var: str) -> bool:
         """Parse common truthy values from environment variables."""
         value = os.getenv(env_var, "").strip().lower()
         return value in {"1", "true", "yes", "on"}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -59,6 +59,36 @@ def test_client_accepts_http_token(mock_api: MagicMock) -> None:
         mock_api.assert_called_once()
 
 
+@patch("mcp_zammad.client.ZammadAPI")
+def test_client_insecure_mode_from_env(mock_api: MagicMock) -> None:
+    """Test that insecure mode disables TLS verification."""
+    mock_instance = mock_api.return_value
+
+    with patch.dict(
+        os.environ,
+        {
+            "ZAMMAD_URL": "https://test.zammad.com/api/v1",
+            "ZAMMAD_HTTP_TOKEN": "test-token",
+            "ZAMMAD_INSECURE": "true",
+        },
+        clear=True,
+    ):
+        client = ZammadClient()
+
+    assert client.insecure is True
+    assert mock_instance.session.verify is False
+
+
+@patch("mcp_zammad.client.ZammadAPI")
+def test_client_insecure_mode_from_param(mock_api: MagicMock) -> None:
+    """Test that insecure constructor flag disables TLS verification."""
+    mock_instance = mock_api.return_value
+    client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token", insecure=True)
+
+    assert client.insecure is True
+    assert mock_instance.session.verify is False
+
+
 def test_url_validation_no_protocol() -> None:
     """Test that URL validation rejects URLs without protocol."""
     with (

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,11 +1,15 @@
 """Tests for Zammad client configuration and error handling."""
 
+import logging
 import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from mcp_zammad.client import ConfigException, ZammadClient
+
+# Non-secret placeholder for tests (avoids bandit S106 on http_token kwargs)
+_TEST_HTTP_TOKEN = "test-http-token"
 
 
 def test_client_requires_url() -> None:
@@ -80,13 +84,52 @@ def test_client_insecure_mode_from_env(mock_api: MagicMock) -> None:
 
 
 @patch("mcp_zammad.client.ZammadAPI")
-def test_client_insecure_mode_from_param(mock_api: MagicMock) -> None:
+def test_client_insecure_mode_from_param(mock_api: MagicMock, caplog: pytest.LogCaptureFixture) -> None:
     """Test that insecure constructor flag disables TLS verification."""
     mock_instance = mock_api.return_value
-    client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token", insecure=True)
+    with caplog.at_level(logging.WARNING):
+        client = ZammadClient(
+            url="https://test.zammad.com/api/v1", http_token=_TEST_HTTP_TOKEN, insecure=True
+        )
 
     assert client.insecure is True
     assert mock_instance.session.verify is False
+    assert "TLS certificate verification is disabled" in caplog.text
+
+
+@patch("mcp_zammad.client.ZammadAPI")
+def test_client_insecure_mode_uses_connection_fallback(mock_api: MagicMock) -> None:
+    """When ZammadAPI.session is absent, use _connection.session if present."""
+    mock_instance = mock_api.return_value
+    mock_instance.session = None
+    fallback_session = MagicMock()
+    mock_connection = MagicMock()
+    mock_connection.session = fallback_session
+    mock_instance._connection = mock_connection
+
+    client = ZammadClient(
+        url="https://test.zammad.com/api/v1",
+        http_token=_TEST_HTTP_TOKEN,
+        insecure=True,
+    )
+
+    assert client.insecure is True
+    assert fallback_session.verify is False
+
+
+@patch("mcp_zammad.client.ZammadAPI")
+def test_client_insecure_mode_raises_when_no_session(mock_api: MagicMock) -> None:
+    """Raise ConfigException when insecure is set but no requests session is available."""
+    mock_instance = mock_api.return_value
+    mock_instance.session = None
+    mock_instance._connection = None
+
+    with pytest.raises(ConfigException, match="does not expose a"):
+        ZammadClient(
+            url="https://test.zammad.com/api/v1",
+            http_token=_TEST_HTTP_TOKEN,
+            insecure=True,
+        )
 
 
 def test_url_validation_no_protocol() -> None:


### PR DESCRIPTION
- Set requests session verify=False using zammad-py 3.x ZammadAPI.session
- Fallback for older _connection.session layout; clear error if unsupported
- Document ZAMMAD_INSECURE in README and .env.example; add tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ZAMMAD_INSECURE option to optionally disable TLS certificate verification for self-signed/internal certificates.

* **Documentation**
  * Updated README and .env example with usage guidance, Docker examples, accepted truthy values, and troubleshooting notes for connection issues.

* **Tests**
  * Added tests covering the TLS verification bypass behavior and related error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->