### PR TITLE
Deconflict dependency bots and harden PR CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,10 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Etc/UTC"
-    open-pull-requests-limit: 10
+    # Renovate owns routine version updates for this repo. Keep Dependabot
+    # configured but disabled for version-update PRs so GitHub security updates
+    # can remain enabled without competing lockfile branches.
+    open-pull-requests-limit: 0
     assignees:
       - "basher83"
     commit-message:

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -27,6 +27,10 @@ permissions:
 
 jobs:
   codacy-security-scan:
+    env:
+      CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
@@ -42,10 +46,10 @@ jobs:
       # Login to Docker Hub to avoid rate limits
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
-        if: github.repository == 'basher83/Zammad-MCP' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
@@ -54,7 +58,7 @@ jobs:
         with:
           # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
           # You can also omit the token and run the tools that support default configurations
-          project-token: ${{ github.repository == 'basher83/Zammad-MCP' && secrets.CODACY_PROJECT_TOKEN || '' }}
+          project-token: ${{ env.CODACY_PROJECT_TOKEN }}
           verbose: true
           output: results.sarif
           format: sarif

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -27,10 +27,6 @@ permissions:
 
 jobs:
   codacy-security-scan:
-    env:
-      CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
@@ -43,13 +39,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Check Docker Hub credential availability
+        id: dockerhub_credentials
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        run: |
+          if [ -n "$DOCKERHUB_USERNAME" ] && [ -n "$DOCKERHUB_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # Login to Docker Hub to avoid rate limits
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
-        if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
+        if: steps.dockerhub_credentials.outputs.available == 'true'
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
@@ -58,7 +66,7 @@ jobs:
         with:
           # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
           # You can also omit the token and run the tools that support default configurations
-          project-token: ${{ env.CODACY_PROJECT_TOKEN }}
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           verbose: true
           output: results.sarif
           format: sarif

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,6 @@ jobs:
   test-and-coverage:
     runs-on: ubuntu-latest
     if: github.repository == 'basher83/Zammad-MCP'
-    env:
-      CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
     permissions:
       contents: read
       
@@ -55,16 +53,27 @@ jobs:
           if cov < 65:
               sys.exit(f"Coverage {cov:.1f}% below required 65%")
           PY
+      - name: Check Codacy token availability
+        id: codacy_token
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        run: |
+          if [ -n "$CODACY_PROJECT_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload coverage to Codacy
         # Coverage upload is reporting, not validation. Dependabot and fork PRs
         # may not have repository secrets, so skip cleanly when the token is not
         # present and keep the required test job focused on tests/coverage.
         if: >-
           github.event_name != 'workflow_dispatch' &&
-          env.CODACY_PROJECT_TOKEN != ''
+          steps.codacy_token.outputs.available == 'true'
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699  # v1.3.0
         with:
-          project-token: ${{ env.CODACY_PROJECT_TOKEN }}
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage.xml
           language: python
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,8 @@ jobs:
   test-and-coverage:
     runs-on: ubuntu-latest
     if: github.repository == 'basher83/Zammad-MCP'
+    env:
+      CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
     permissions:
       contents: read
       
@@ -54,15 +56,15 @@ jobs:
               sys.exit(f"Coverage {cov:.1f}% below required 65%")
           PY
       - name: Upload coverage to Codacy
-        # Only upload on push to main or same-repository PRs where repository
-        # secrets are available. Fork PRs still run tests and publish artifacts.
+        # Coverage upload is reporting, not validation. Dependabot and fork PRs
+        # may not have repository secrets, so skip cleanly when the token is not
+        # present and keep the required test job focused on tests/coverage.
         if: >-
           github.event_name != 'workflow_dispatch' &&
-          (github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.full_name == github.repository)
+          env.CODACY_PROJECT_TOKEN != ''
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699  # v1.3.0
         with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          project-token: ${{ env.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage.xml
           language: python
 

--- a/docs/dev/renovate-and-branch-rules.md
+++ b/docs/dev/renovate-and-branch-rules.md
@@ -1,21 +1,32 @@
 # Dependency & Branch Protection Strategy for `Zammad-MCP`
 
-This document describes how dependency updates and branch protection are configured for the [`basher83/Zammad-MCP`](https://github.com/basher83/Zammad-MCP) repository.
+This document describes how dependency updates, branch protection, and dependency-bot CI are configured for the [`basher83/Zammad-MCP`](https://github.com/basher83/Zammad-MCP) repository.
 
 It covers:
 
-- How Renovate is configured for this repo
+- How Renovate and Dependabot responsibilities are split
+- How dependency-bot PRs interact with secret-dependent integrations
 - Which updates auto‑merge to `main` (“no visible PR”)
 - Which updates always require human attention
 - How branch protection and required checks interact with Renovate
 
 ---
 
-## 1. Renovate Overview
+## 1. Dependency Bot Ownership
+
+Renovate owns routine version-update PRs for this repository. Dependabot remains available for GitHub's security-alert and security-update workflows, but Dependabot version updates are intentionally disabled in `.github/dependabot.yml` with `open-pull-requests-limit: 0`.
+
+This avoids two bots opening competing `uv.lock`, GitHub Actions, or Docker update branches for the same dependency surface. In practice, normal dependency maintenance should come from Renovate, while Dependabot is treated as the security-alert backstop.
+
+Dependency-bot PRs must still run the required validation jobs. Secret-dependent reporting and publishing integrations are optional for PR validation and must skip cleanly when secrets are unavailable.
+
+GitHub treats Dependabot-triggered `pull_request` workflows like forked PRs: they receive a read-only token and do not receive normal Actions secrets. If the repository needs secret-backed behavior on Dependabot PRs, configure matching Dependabot secrets in GitHub and keep the workflow guarded so the absence of those secrets does not fail validation.
+
+## 2. Renovate Overview
 
 `Zammad-MCP` uses [Renovate](https://docs.renovatebot.com/) with a centralized configuration stored in [`basher83/renovate-config`](https://github.com/basher83/renovate-config).
 
-### 1.1 Repo-level Renovate config
+### 2.1 Repo-level Renovate config
 
 `renovate.json` in this repo:
 
@@ -62,11 +73,11 @@ Key points:
   - Are assigned to `@basher83`.
   - Use `chore(deps):` as the commit message prefix.
 - Extra repo‑specific rule:
-  - **`zammad-py` major updates require explicit approval** in the Dependency Dashboard.
+  - Major updates to `zammad-py` require explicit approval in the Dependency Dashboard.
 
 ---
 
-## 2. What Auto‑Merges vs. What Requires Review
+## 3. What Auto‑Merges vs. What Requires Review
 
 The overall philosophy:
 
@@ -75,7 +86,7 @@ The overall philosophy:
 
 Below is how this breaks down by dependency type.
 
-### 2.1 Python dependencies (`presets/python.json` & `python-mcp.json`)
+### 3.1 Python dependencies (`presets/python.json` & `python-mcp.json`)
 
 **Auto‑merge (PR merges & disappears, once checks pass):**
 
@@ -112,7 +123,7 @@ These groups are configured with `automerge: true` (no `automergeType` override)
 - `zammad-py` (Zammad API client) **major updates**:
   - `dependencyDashboardApproval: true` → PR will not auto‑merge; requires explicit approval.
 
-### 2.2 GitHub Actions (`presets/github-actions-security.json`)
+### 3.2 GitHub Actions (`presets/github-actions-security.json`)
 
 Goals:
 
@@ -143,7 +154,7 @@ Goals:
 - For these, `matchUpdateTypes: ["minor","major"]` + `dependencyDashboardApproval: true`.
 - Result: PRs open and won’t auto‑merge until you explicitly approve via the Dependency Dashboard.
 
-### 2.3 Docker (`presets/docker.json`)
+### 3.3 Docker (`presets/docker.json`)
 
 Goals:
 
@@ -170,11 +181,11 @@ Goals:
 
 ---
 
-## 3. Branch Protection for `main`
+## 4. Branch Protection for `main`
 
 Branch protection is configured via a ruleset named **“Protection Rules”** and applies to `~DEFAULT_BRANCH` (i.e. `main`).
 
-### 3.1 Ruleset summary
+### 4.1 Ruleset summary
 
 ```jsonc
 {
@@ -240,23 +251,27 @@ Branch protection is configured via a ruleset named **“Protection Rules”** a
 
 ---
 
-## 4. How Renovate and Branch Rules Work Together
+## 5. Secret-Dependent CI Policy
+
+Required PR validation must not depend on repository, Codacy, Docker Hub, or publishing credentials. The repo follows this split:
+
+`test-and-coverage` is required. It runs tests, enforces the coverage threshold, and uploads coverage artifacts on every PR. The Codacy coverage upload runs only when `CODACY_PROJECT_TOKEN` is available.
+
+`security-scan` is required. It runs Bandit and dependency scanning without requiring external credentials. Uploads that rely on the built-in `GITHUB_TOKEN` remain part of the job.
+
+`Codacy Security Scan` is a reporting workflow. Docker Hub login runs only when both `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` are available. The Codacy project token is passed through when present and omitted otherwise.
+
+`Build and Publish Docker Image` validates the Docker build on PRs but only pushes images and creates attestations on non-PR events. Transient BuildKit or registry errors should be retried; they are not normally fixed by changing dependency-update PR branches.
+
+## 6. How Renovate and Branch Rules Work Together
 
 Putting it all together:
 
 1. Renovate detects an update that matches an **automerge** rule.
 2. Renovate opens a PR against `main`.
-3. GitHub runs the required checks:
-   - `Tests and Coverage` → `test-and-coverage`
-   - `Security Scan` → `security-scan`
-4. If both required checks succeed:
-   - Branch rules allow merging (no required approvals).
-   - Renovate merges the PR into `main`.
-   - PR is closed (often quickly), giving the “no visible PR” experience.
-5. If checks fail **or** the update requires approval (e.g. `zammad-py` major, MCP major, sensitive Actions, critical Docker images):
-   - Renovate **does not** merge.
-   - PR remains open.
-   - For rules using `dependencyDashboardApproval: true`, Renovate waits for explicit approval from the Dependency Dashboard.
+3. GitHub runs the required checks: `Tests and Coverage` as `test-and-coverage`, and `Security Scan` as `security-scan`.
+4. If both required checks succeed, branch rules allow merging without required approvals, Renovate merges the PR into `main`, and the PR closes. This is the “no visible PR” experience when updates move quickly.
+5. If checks fail or the update requires approval, such as a `zammad-py` major, MCP major, sensitive Actions update, or critical Docker image update, Renovate does not merge. The PR remains open, and rules using `dependencyDashboardApproval: true` wait for explicit approval from the Dependency Dashboard.
 
 This gives a clear separation between:
 
@@ -265,7 +280,7 @@ This gives a clear separation between:
 
 ---
 
-## 5. Quick Reference
+## 7. Quick Reference
 
 ### Auto‑merged (once tests & security checks pass)
 
@@ -303,7 +318,7 @@ This gives a clear separation between:
 
 ---
 
-## 6. How to Adjust This in Future
+## 8. How to Adjust This in Future
 
 - To make more things **auto‑merge**:
   - Add/adjust `packageRules` with `automerge: true` in `basher83/renovate-config`.

--- a/docs/dev/renovate-and-branch-rules.md
+++ b/docs/dev/renovate-and-branch-rules.md
@@ -259,7 +259,7 @@ Required PR validation must not depend on repository, Codacy, Docker Hub, or pub
 
 `security-scan` is required. It runs Bandit and dependency scanning without requiring external credentials. Uploads that rely on the built-in `GITHUB_TOKEN` remain part of the job.
 
-`Codacy Security Scan` is a reporting workflow. Docker Hub login runs only when both `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` are available. The Codacy project token is passed through when present and omitted otherwise.
+`Codacy Security Scan` is a reporting workflow. Docker Hub login runs only when both `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` are available. The Codacy `project-token` input is sourced from repository secrets and may be empty in contexts where secrets are not provided.
 
 `Build and Publish Docker Image` validates the Docker build on PRs but only pushes images and creates attestations on non-PR events. Transient BuildKit or registry errors should be retried; they are not normally fixed by changing dependency-update PR branches.
 


### PR DESCRIPTION
## Summary
- Split dependency-bot ownership so Renovate handles routine updates and Dependabot version PRs stay disabled.
- Make Codacy coverage and Docker Hub login skip cleanly when repository secrets are unavailable on dependency-bot PRs.
- Update the dependency policy docs to reflect the new Renovate/Dependabot split and secret-dependent CI behavior.

## Testing
- `uv run pre-commit run --files .github/dependabot.yml .github/workflows/tests.yml .github/workflows/codacy.yml docs/dev/renovate-and-branch-rules.md`
- `actionlint` on the affected workflow files surfaced only pre-existing ShellCheck warnings in existing summary scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled Dependabot version-update PRs to avoid overlap with Renovate; streamlined dependency update behavior.
  * Improved CI/CD logic to conditionally run secret-dependent steps (e.g., token/login) only when secrets are available.

* **Documentation**
  * Expanded guidance on dependency bot ownership, secret-dependent CI policy, branch rules, and quick-reference workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->