### PR TITLE
[codex] add Zammad-MCP triage automation

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -49,6 +49,7 @@ exclude_paths:
   - '.git/**'
   - 'docs/**'
   - 'scripts/**'
+  - '.codex/**'
   - 'htmlcov/**'
   - '.coverage'
   - 'dist/**'

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -22,8 +22,8 @@ reviews:
   assess_linked_issues: true
   related_issues: true
   related_prs: true
-  suggested_labels: true
-  auto_apply_labels: true
+  suggested_labels: false
+  auto_apply_labels: false
   suggested_reviewers: true
   auto_assign_reviewers: true
   poem: false

--- a/.codex/skills/zammad-mcp-issue-digest/SKILL.md
+++ b/.codex/skills/zammad-mcp-issue-digest/SKILL.md
@@ -9,7 +9,7 @@ description: Run issue digest and issue triage workflows for basher83/Zammad-MCP
 
 Produce a headline-first, repo-owner digest of `basher83/Zammad-MCP` issues for requested labels over the previous 24 hours by default. Honor a different duration when the user asks for one, for example `past week`, `48 hours`, or `30d`.
 
-For triage automation, classify issues with deterministic rules first and optional LLM JSON as an additive signal. Apply labels only. Do not comment on source issues, close issues, or close duplicates in v1. Duplicate candidates belong in JSON output and the maintainer tracking digest.
+For triage automation, classify issues with deterministic rules first. The CLI accepts optional LLM JSON as an additive signal for local or future isolated generator runs, but the repository Actions run deterministic-only in v1. Apply labels only. Do not comment on source issues, close issues, or close duplicates in v1. Duplicate candidates belong in JSON output and the maintainer tracking digest.
 
 Default to a summary-only response. Include a details table only when the user asks for details, a full digest, a table, or similar.
 

--- a/.codex/skills/zammad-mcp-issue-digest/SKILL.md
+++ b/.codex/skills/zammad-mcp-issue-digest/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: zammad-mcp-issue-digest
+description: Run issue digest and issue triage workflows for basher83/Zammad-MCP, including small-repo owner attention, deterministic labels, optional LLM label suggestions, duplicate candidates, Renovate/Dependabot policy drift, and the scheduled maintainer tracking digest.
+---
+
+# Zammad-MCP Issue Digest
+
+## Objective
+
+Produce a headline-first, repo-owner digest of `basher83/Zammad-MCP` issues for requested labels over the previous 24 hours by default. Honor a different duration when the user asks for one, for example `past week`, `48 hours`, or `30d`.
+
+For triage automation, classify issues with deterministic rules first and optional LLM JSON as an additive signal. Apply labels only. Do not comment on source issues, close issues, or close duplicates in v1. Duplicate candidates belong in JSON output and the maintainer tracking digest.
+
+Default to a summary-only response. Include a details table only when the user asks for details, a full digest, a table, or similar.
+
+This skill mirrors the upstream `codex-issue-digest` pattern but is scoped to this repository's labels and operating model. It is meant for triage and owner attention, not broad GitHub reporting.
+
+## Inputs
+
+Accept any of these:
+
+- Area labels such as `area:python`, `area:ci-cd`, `area:security`, `area:docs`, `area:web`, `area:infra`, `area:mcp-tools`, `area:zammad-api`, or `area:transport`.
+- Bot/dependency labels such as `bot:renovate`, `bot:dependabot`, `dependencies`, `renovate`, `github-actions`, `docker`, or `python:uv`.
+- `all areas` / `all labels` to scan across current Zammad-MCP area and bot labels.
+- Optional repo override, default `basher83/Zammad-MCP`.
+- Optional time window, default previous 24 hours.
+
+When the user says "dependency digest" or asks about Renovate/Dependabot without naming labels, use `--labels dependencies bot:renovate bot:dependabot renovate github-actions docker python:uv`.
+
+When the user asks generally for repo issue status without labels, use `--all-labels`. This repository has a small issue set and sparse labeling, so all-label mode intentionally scans all recently updated issues and treats missing type labels as `unclassified`.
+
+## Workflow
+
+Run targeted issue triage when a new or reopened issue needs labels:
+
+```bash
+python3 .codex/skills/zammad-mcp-issue-digest/scripts/triage_issue.py --issue 212 --dry-run --json
+```
+
+Backfill open issues before enabling or after changing label rules:
+
+```bash
+python3 .codex/skills/zammad-mcp-issue-digest/scripts/triage_issue.py --backfill --state open --dry-run --json
+```
+
+Use `--apply` only when the maintainer has asked to mutate labels. The script will create missing controlled labels as needed and then add labels to the issue.
+
+For the scheduled maintainer tracking issue, collect the issue digest and combine it with the PR digest through `post_triage_digest.py`. The tracking issue title is `[triage] Zammad-MCP maintainer digest`.
+
+1. Run the collector from a current `Zammad-MCP` repo checkout:
+
+```bash
+python3 .codex/skills/zammad-mcp-issue-digest/scripts/collect_issue_digest.py --all-labels --window-hours 24
+```
+
+Use `--window "past week"` or `--window-hours 168` when the user asks for a non-default duration.
+
+Use label-specific runs when requested:
+
+```bash
+python3 .codex/skills/zammad-mcp-issue-digest/scripts/collect_issue_digest.py --labels area:python area:ci-cd --window "past week"
+```
+
+Use the dependency-maintenance run for Renovate/Dependabot triage:
+
+```bash
+python3 .codex/skills/zammad-mcp-issue-digest/scripts/collect_issue_digest.py --labels dependencies bot:renovate bot:dependabot renovate github-actions docker python:uv --window "past week"
+```
+
+1. Treat the collector JSON as source of truth. It includes new issues, new comments, reactions, current labels, `summary_inputs`, `digest_rows`, source metadata, and the time window.
+
+1. Choose output mode from the user's request. Default mode starts with `## Summary` and does not include `## Details`. Details mode starts with `## Summary`, then includes `## Details`.
+
+1. In `## Summary`, write a single headline or judgment as the first nonblank line. On quiet runs, prefer exactly:
+
+```markdown
+No major issues reported by users.
+```
+
+Use that when there are no elevated rows, no repeated theme, and nothing needing owner action.
+
+1. For active runs, lead with the count or theme, then list only the issues or clusters that need attention. Use inline numbered references from `ref_markdown`, for example `[1](https://github.com/basher83/Zammad-MCP/issues/123)`. Do not add a separate footnotes section.
+
+1. Cluster only when issues share the same repo problem. Good Zammad-MCP clusters include FastMCP migration/runtime behavior, Zammad API coverage, auth/security hardening, CI and release workflow, docs drift, and dependency-bot governance. Do not cluster merely because several issues share a broad `area:*` label.
+
+1. Treat dependency bot items specially. Surface Dependabot version-update PRs as policy drift if routine Dependabot PRs appear after the repo disabled them. Surface Renovate blocked/approval-needed items when they affect required checks, Python/MCP pins, Docker image pins, or GitHub Actions security updates.
+
+1. In `## Details`, include a compact table only when useful. Prefer columns for marker, area, type, description, interactions, and refs. Keep it short and omit low-signal rows when the summary already covers them.
+
+1. Mention the collector `script_version`, repo checkout `git_head`, and time window in one compact source line. In default mode, put this before the final details prompt.
+
+1. In default mode, end with a short prompt such as:
+
+```markdown
+Want details? I can expand this into the issue table.
+```
+
+## Attention Rules
+
+The collector uses small-repo attention markers. The baseline is 2 human interactions for elevated attention and 4 for very high attention over 24 hours. Longer windows scale those cutoffs by the square root of the window length, not linearly, and cap at 4 and 8 interactions because this repository has fewer than 50 total issues and very low comment volume.
+
+Human interactions are human-authored new issue posts, human-authored new comments, and human reactions created during the window. Bot posts and bot reactions are excluded.
+
+Use the JSON `attention_marker` exactly. Do not invent new marker symbols. Explain it as high user interaction when needed.
+
+## Validation
+
+Validate the triage classifier:
+
+```bash
+uv run pytest .codex/skills/zammad-mcp-issue-digest/scripts/test_triage_issue.py
+```
+
+Dry run recent repo issue activity:
+
+```bash
+python3 .codex/skills/zammad-mcp-issue-digest/scripts/collect_issue_digest.py --all-labels --window "past week" --limit-issues 20
+```
+
+Dry run dependency bot activity:
+
+```bash
+python3 .codex/skills/zammad-mcp-issue-digest/scripts/collect_issue_digest.py --labels dependencies bot:renovate bot:dependabot renovate github-actions docker python:uv --window "past week" --limit-issues 20
+```

--- a/.codex/skills/zammad-mcp-issue-digest/agents/openai.yaml
+++ b/.codex/skills/zammad-mcp-issue-digest/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Zammad-MCP Issue Digest"
+  short_description: "Summarize Zammad-MCP issue activity"
+  default_prompt: "Use $zammad-mcp-issue-digest to summarize recent Zammad-MCP issue activity."
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/zammad-mcp-issue-digest/scripts/collect_issue_digest.py
+++ b/.codex/skills/zammad-mcp-issue-digest/scripts/collect_issue_digest.py
@@ -1,0 +1,984 @@
+#!/usr/bin/env python3
+# mypy: ignore-errors
+# ruff: noqa: PLR2004,SIM108
+"""Collect recent basher83/Zammad-MCP issue activity for repo-focused digests."""
+
+import argparse
+import json
+import math
+import re
+import subprocess  # nosec B404
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from urllib.parse import quote
+
+SCRIPT_VERSION = 1
+QUALIFYING_KIND_LABELS = (
+    "type:bug",
+    "type:feature",
+    "type:security",
+    "type:performance",
+    "type:docs",
+    "type:chore",
+    "dependencies",
+)
+AREA_LABEL_PREFIXES = ("area:", "bot:")
+EXCLUDED_ALL_LABELS = {
+    "dependencies",
+    "renovate",
+    "github-actions",
+    "docker",
+    "security",
+    "python:uv",
+    "✨ enhancement",
+    "📚 documentation",
+    "🔧 ci/cd",
+    "⚡ api",
+    "🏷️ auto-labeled",
+    "👨‍🚀 crew-backend",
+    "📝 crew-docs",
+    "💎 breaking-change",
+}
+REACTION_KEYS = ("+1", "-1", "laugh", "hooray", "confused", "heart", "rocket", "eyes")
+BASE_ATTENTION_WINDOW_HOURS = 24.0
+ONE_ATTENTION_INTERACTION_THRESHOLD = 2
+TWO_ATTENTION_INTERACTION_THRESHOLD = 4
+MAX_ONE_ATTENTION_INTERACTION_THRESHOLD = 4
+MAX_TWO_ATTENTION_INTERACTION_THRESHOLD = 8
+ALL_LABEL_PHRASES = {"all", "all areas", "all labels", "all-areas", "all-labels", "*"}
+UNCLASSIFIED_KIND_LABEL = "unclassified"
+
+
+class GhCommandError(RuntimeError):
+    pass
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Collect recent GitHub issue activity for a Zammad-MCP issue digest.")
+    parser.add_argument(
+        "--repo",
+        default="basher83/Zammad-MCP",
+        help="OWNER/REPO, default basher83/Zammad-MCP",
+    )
+    parser.add_argument(
+        "--labels",
+        nargs="+",
+        default=[],
+        help="Area or bot labels to digest, for example: area:python area:ci-cd bot:renovate",
+    )
+    parser.add_argument(
+        "--all-labels",
+        action="store_true",
+        help="Collect qualifying issues across all Zammad-MCP area and bot labels",
+    )
+    parser.add_argument(
+        "--window",
+        help='Lookback duration such as "24h", "7d", "1w", or "past week"',
+    )
+    parser.add_argument("--window-hours", type=float, default=24.0, help="Lookback window")
+    parser.add_argument("--since", help="UTC ISO timestamp override for the window start")
+    parser.add_argument("--until", help="UTC ISO timestamp override for the window end")
+    parser.add_argument(
+        "--limit-issues",
+        type=int,
+        default=200,
+        help="Maximum candidate issues to hydrate after search",
+    )
+    parser.add_argument("--body-chars", type=int, default=1200, help="Issue body excerpt length")
+    parser.add_argument("--comment-chars", type=int, default=900, help="Comment excerpt length")
+    parser.add_argument(
+        "--max-comment-pages",
+        type=int,
+        default=3,
+        help=(
+            "Maximum pages of issue comments to hydrate per issue after applying the "
+            "window filter. Use 0 with --fetch-all-comments for no page cap."
+        ),
+    )
+    parser.add_argument(
+        "--fetch-all-comments",
+        action="store_true",
+        help="Hydrate complete issue comment histories instead of only window-updated comments.",
+    )
+    return parser.parse_args()
+
+
+def parse_timestamp(value, arg_name):
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as err:
+        raise ValueError(f"{arg_name} must be an ISO timestamp") from err
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def format_timestamp(value):
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def resolve_window(args):
+    until = parse_timestamp(args.until, "--until") or datetime.now(timezone.utc)
+    since = parse_timestamp(args.since, "--since")
+    if since is None:
+        hours = parse_duration_hours(getattr(args, "window", None))
+        if hours is None:
+            hours = getattr(args, "window_hours", 24.0)
+        if hours <= 0:
+            raise ValueError("window duration must be > 0")
+        since = until - timedelta(hours=hours)
+    if since >= until:
+        raise ValueError("--since must be before --until")
+    return since, until
+
+
+def parse_duration_hours(value):
+    if value is None:
+        return None
+    text = value.strip().casefold().replace("_", " ")
+    if not text:
+        return None
+    text = re.sub(r"^(past|last)\s+", "", text)
+    aliases = {
+        "day": 24.0,
+        "24h": 24.0,
+        "week": 168.0,
+        "7d": 168.0,
+    }
+    if text in aliases:
+        return aliases[text]
+    match = re.fullmatch(r"(\d+(?:\.\d+)?)\s*(h|hr|hrs|hour|hours)", text)
+    if match:
+        return float(match.group(1))
+    match = re.fullmatch(r"(\d+(?:\.\d+)?)\s*(d|day|days)", text)
+    if match:
+        return float(match.group(1)) * 24.0
+    match = re.fullmatch(r"(\d+(?:\.\d+)?)\s*(w|week|weeks)", text)
+    if match:
+        return float(match.group(1)) * 168.0
+    raise ValueError(f"Unsupported duration: {value}")
+
+
+def normalize_requested_labels(labels, all_labels=False):
+    out = []
+    seen = set()
+    for raw in labels:
+        for piece in raw.split(","):
+            label = piece.strip()
+            if not label:
+                continue
+            key = label.casefold()
+            if key not in seen:
+                out.append(label)
+                seen.add(key)
+    phrase = " ".join(label.casefold() for label in out)
+    if all_labels or phrase in ALL_LABEL_PHRASES:
+        return [], True
+    if not out:
+        raise ValueError("At least one Zammad-MCP area/bot label is required, or use --all-labels")
+    return out, False
+
+
+def quote_label(label):
+    if re.fullmatch(r"[A-Za-z0-9_.:-]+", label):
+        return f"label:{label}"
+    escaped = label.replace('"', '\\"')
+    return f'label:"{escaped}"'
+
+
+def build_search_queries(repo, owner_labels, since, kind_labels=QUALIFYING_KIND_LABELS, all_labels=False):
+    since_date = since.date().isoformat()
+    queries = []
+    if all_labels:
+        return [
+            " ".join(
+                [
+                    f"repo:{repo}",
+                    "is:issue",
+                    f"updated:>={since_date}",
+                ]
+            )
+        ]
+    for owner_label in owner_labels:
+        for kind_label in kind_labels:
+            queries.append(
+                " ".join(
+                    [
+                        f"repo:{repo}",
+                        "is:issue",
+                        f"updated:>={since_date}",
+                        quote_label(owner_label),
+                        quote_label(kind_label),
+                    ]
+                )
+            )
+    return queries
+
+
+def _format_gh_error(cmd, err):
+    stdout = (err.stdout or "").strip()
+    stderr = (err.stderr or "").strip()
+    parts = [f"GitHub CLI command failed: {' '.join(cmd)}"]
+    if stdout:
+        parts.append(f"stdout: {stdout}")
+    if stderr:
+        parts.append(f"stderr: {stderr}")
+    return "\n".join(parts)
+
+
+def gh_json(args):
+    cmd = ["gh", *args]
+    try:
+        proc = subprocess.run(cmd, check=True, capture_output=True, text=True)  # nosec B603 B607
+    except FileNotFoundError as err:
+        raise GhCommandError("`gh` command not found") from err
+    except subprocess.CalledProcessError as err:
+        raise GhCommandError(_format_gh_error(cmd, err)) from err
+    raw = proc.stdout.strip()
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as err:
+        raise GhCommandError(f"Failed to parse JSON from gh output for {' '.join(args)}") from err
+
+
+def gh_text(args):
+    cmd = ["gh", *args]
+    try:
+        proc = subprocess.run(cmd, check=True, capture_output=True, text=True)  # nosec B603 B607
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return ""
+    return proc.stdout.strip()
+
+
+def git_head():
+    try:
+        proc = subprocess.run(  # nosec B603 B607
+            ["git", "rev-parse", "--short=12", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+    return proc.stdout.strip() or None
+
+
+def skill_relative_path():
+    try:
+        return str(Path(__file__).resolve().relative_to(Path.cwd().resolve()))
+    except ValueError:
+        return str(Path(__file__).resolve())
+
+
+def gh_api_list_paginated(endpoint, per_page=100, max_pages=None, with_metadata=False):
+    items = []
+    page = 1
+    truncated = False
+    while True:
+        sep = "&" if "?" in endpoint else "?"
+        page_endpoint = f"{endpoint}{sep}per_page={per_page}&page={page}"
+        payload = gh_json(["api", page_endpoint])
+        if payload is None:
+            break
+        if not isinstance(payload, list):
+            raise GhCommandError(f"Unexpected paginated payload from gh api {endpoint}")
+        items.extend(payload)
+        if len(payload) < per_page:
+            break
+        if max_pages is not None and page >= max_pages:
+            truncated = True
+            break
+        page += 1
+    if with_metadata:
+        return {
+            "items": items,
+            "truncated": truncated,
+            "pages": page,
+            "max_pages": max_pages,
+        }
+    return items
+
+
+def search_issue_numbers(queries, limit):
+    numbers = {}
+    for query in queries:
+        page = 1
+        seen_for_query = 0
+        while True:
+            payload = gh_json(
+                [
+                    "api",
+                    "search/issues",
+                    "-X",
+                    "GET",
+                    "-f",
+                    f"q={query}",
+                    "-f",
+                    "sort=updated",
+                    "-f",
+                    "order=desc",
+                    "-f",
+                    "per_page=100",
+                    "-f",
+                    f"page={page}",
+                ]
+            )
+            if not isinstance(payload, dict):
+                raise GhCommandError("Unexpected payload from GitHub issue search")
+            items = payload.get("items") or []
+            if not isinstance(items, list):
+                raise GhCommandError("Expected search `items` to be a list")
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                number = item.get("number")
+                if isinstance(number, int):
+                    numbers[number] = str(item.get("updated_at") or "")
+                    seen_for_query += 1
+            if len(items) < 100 or seen_for_query >= limit:
+                break
+            page += 1
+    ordered = sorted(numbers, key=lambda number: (numbers[number], number), reverse=True)
+    return ordered[:limit]
+
+
+def fetch_issue(repo, number):
+    payload = gh_json(["api", f"repos/{repo}/issues/{number}"])
+    if not isinstance(payload, dict):
+        raise GhCommandError(f"Unexpected issue payload for #{number}")
+    return payload
+
+
+def fetch_comments(repo, number, since=None, max_pages=None):
+    endpoint = f"repos/{repo}/issues/{number}/comments"
+    if since is not None:
+        endpoint = f"{endpoint}?since={quote(format_timestamp(since), safe='')}"
+    return gh_api_list_paginated(
+        endpoint,
+        max_pages=max_pages,
+        with_metadata=True,
+    )
+
+
+def fetch_reactions_for_item(endpoint, item):
+    if reaction_summary(item)["total"] <= 0:
+        return []
+    return gh_api_list_paginated(endpoint)
+
+
+def fetch_comment_reactions(repo, comments):
+    reactions_by_comment_id = {}
+    for comment in comments:
+        comment_id = comment.get("id")
+        if comment_id in (None, ""):
+            continue
+        endpoint = f"repos/{repo}/issues/comments/{comment_id}/reactions"
+        reactions_by_comment_id[comment_id] = fetch_reactions_for_item(endpoint, comment)
+    return reactions_by_comment_id
+
+
+def extract_login(user_obj):
+    if isinstance(user_obj, dict):
+        return str(user_obj.get("login") or "")
+    return ""
+
+
+def is_bot_login(login):
+    return bool(login) and login.lower().endswith("[bot]")
+
+
+def is_human_user(user_obj):
+    login = extract_login(user_obj)
+    return bool(login) and not is_bot_login(login)
+
+
+def label_names(issue):
+    labels = []
+    for label in issue.get("labels") or []:
+        if isinstance(label, dict) and label.get("name"):
+            labels.append(str(label["name"]))
+    return sorted(labels, key=str.casefold)
+
+
+def matching_labels(labels, requested):
+    labels_by_key = {label.casefold(): label for label in labels}
+    return [label for label in requested if label.casefold() in labels_by_key]
+
+
+def area_labels(labels):
+    kind_keys = {label.casefold() for label in QUALIFYING_KIND_LABELS}
+    return [
+        label
+        for label in labels
+        if label.casefold() not in kind_keys
+        and label not in EXCLUDED_ALL_LABELS
+        and (label.startswith(AREA_LABEL_PREFIXES) or label in {"dependencies", "python:uv"})
+    ]
+
+
+def attention_thresholds_for_window(window_hours):
+    if window_hours <= 0:
+        raise ValueError("window_hours must be > 0")
+    window_hours = round(window_hours, 6)
+    scale = math.sqrt(window_hours / BASE_ATTENTION_WINDOW_HOURS)
+    elevated = max(
+        1,
+        min(
+            MAX_ONE_ATTENTION_INTERACTION_THRESHOLD,
+            math.ceil(ONE_ATTENTION_INTERACTION_THRESHOLD * scale),
+        ),
+    )
+    very_high = max(
+        elevated + 1,
+        min(
+            MAX_TWO_ATTENTION_INTERACTION_THRESHOLD,
+            math.ceil(TWO_ATTENTION_INTERACTION_THRESHOLD * scale),
+        ),
+    )
+    return {
+        "base_window_hours": BASE_ATTENTION_WINDOW_HOURS,
+        "window_hours": round(window_hours, 3),
+        "scale": round(scale, 3),
+        "elevated": elevated,
+        "very_high": very_high,
+        "max_elevated": MAX_ONE_ATTENTION_INTERACTION_THRESHOLD,
+        "max_very_high": MAX_TWO_ATTENTION_INTERACTION_THRESHOLD,
+    }
+
+
+def attention_level_for(user_interactions, attention_thresholds=None):
+    thresholds = attention_thresholds or attention_thresholds_for_window(BASE_ATTENTION_WINDOW_HOURS)
+    if user_interactions >= thresholds["very_high"]:
+        return 2
+    if user_interactions >= thresholds["elevated"]:
+        return 1
+    return 0
+
+
+def attention_marker_for(user_interactions, attention_thresholds=None):
+    return "🔥" * attention_level_for(user_interactions, attention_thresholds)
+
+
+def reaction_summary(item):
+    reactions = item.get("reactions")
+    if not isinstance(reactions, dict):
+        return {"total": 0, "counts": {}}
+    counts = {}
+    for key in REACTION_KEYS:
+        value = reactions.get(key, 0)
+        if isinstance(value, int) and value:
+            counts[key] = value
+    total = reactions.get("total_count")
+    if not isinstance(total, int):
+        total = sum(counts.values())
+    return {"total": total, "counts": counts}
+
+
+def reaction_event_summary(reactions, since, until):
+    counts = {}
+    total = 0
+    for reaction in reactions or []:
+        if not isinstance(reaction, dict):
+            continue
+        if not is_in_window(str(reaction.get("created_at") or ""), since, until):
+            continue
+        if not is_human_user(reaction.get("user")):
+            continue
+        content = str(reaction.get("content") or "")
+        if not content:
+            continue
+        counts[content] = counts.get(content, 0) + 1
+        total += 1
+    return {
+        "total": total,
+        "counts": counts,
+        "upvotes": counts.get("+1", 0),
+    }
+
+
+def compact_text(value, limit):
+    text = re.sub(r"\s+", " ", str(value or "")).strip()
+    if limit <= 0:
+        return ""
+    if len(text) <= limit:
+        return text
+    return f"{text[: max(limit - 1, 0)].rstrip()}..."
+
+
+def clean_title_for_description(title):
+    cleaned = re.sub(r"\s+", " ", str(title or "")).strip()
+    cleaned = re.sub(
+        r"^(zammad-mcp|mcp zammad|zammad|dependency dashboard)\s*[:,-]\s*",
+        "",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    cleaned = re.sub(
+        r"^chore\(deps\):\s*bump\s+",
+        "Dependency update: ",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    cleaned = cleaned.strip(" -:;")
+    return compact_text(cleaned, 80) or "Issue needs owner review"
+
+
+def issue_description(issue):
+    return clean_title_for_description(issue.get("title"))
+
+
+def is_in_window(timestamp, since, until):
+    parsed = parse_timestamp(timestamp, "timestamp")
+    if parsed is None:
+        return False
+    return since <= parsed < until
+
+
+def summarize_comment(comment, comment_chars, reaction_events=None, since=None, until=None):
+    reactions = reaction_summary(comment)
+    new_reactions = (
+        reaction_event_summary(reaction_events, since, until)
+        if since is not None and until is not None
+        else {"total": 0, "counts": {}, "upvotes": 0}
+    )
+    human_user_interaction = is_human_user(comment.get("user"))
+    return {
+        "id": comment.get("id"),
+        "author": extract_login(comment.get("user")),
+        "author_association": str(comment.get("author_association") or ""),
+        "created_at": str(comment.get("created_at") or ""),
+        "updated_at": str(comment.get("updated_at") or ""),
+        "url": str(comment.get("html_url") or ""),
+        "human_user_interaction": human_user_interaction,
+        "reactions": reactions["counts"],
+        "reaction_total": reactions["total"],
+        "new_reactions": new_reactions["total"],
+        "new_upvotes": new_reactions["upvotes"],
+        "new_reaction_counts": new_reactions["counts"],
+        "body_excerpt": compact_text(comment.get("body"), comment_chars),
+    }
+
+
+def summarize_issue(
+    issue,
+    comments,
+    requested_labels,
+    since,
+    until,
+    body_chars,
+    comment_chars,
+    issue_reaction_events=None,
+    comment_reactions_by_id=None,
+    all_labels=False,
+    comments_hydration=None,
+    attention_thresholds=None,
+):
+    labels = label_names(issue)
+    labels_by_key = {label.casefold() for label in labels}
+    kind_labels = [label for label in QUALIFYING_KIND_LABELS if label.casefold() in labels_by_key]
+    if all_labels:
+        if not kind_labels:
+            kind_labels = [UNCLASSIFIED_KIND_LABEL]
+        owner_labels = area_labels(labels) or ["unlabeled"]
+    else:
+        owner_labels = matching_labels(labels, requested_labels)
+    if not kind_labels or not owner_labels:
+        return None
+
+    updated_at = str(issue.get("updated_at") or "")
+    if not is_in_window(updated_at, since, until):
+        return None
+
+    new_issue = is_in_window(str(issue.get("created_at") or ""), since, until)
+    comment_reactions_by_id = comment_reactions_by_id or {}
+    new_comments = [
+        summarize_comment(
+            comment,
+            comment_chars,
+            reaction_events=comment_reactions_by_id.get(comment.get("id")),
+            since=since,
+            until=until,
+        )
+        for comment in comments
+        if is_in_window(str(comment.get("created_at") or ""), since, until)
+    ]
+    new_comments.sort(key=lambda item: (item["created_at"], str(item["id"])))
+
+    issue_reactions = reaction_summary(issue)
+    issue_reaction_events_summary = reaction_event_summary(issue_reaction_events, since, until)
+    comment_reaction_events_summary = reaction_event_summary(
+        [reaction for reactions in comment_reactions_by_id.values() for reaction in reactions],
+        since,
+        until,
+    )
+    new_reactions = issue_reaction_events_summary["total"] + comment_reaction_events_summary["total"]
+    new_upvotes = issue_reaction_events_summary["upvotes"] + comment_reaction_events_summary["upvotes"]
+    all_comment_reaction_total = sum(reaction_summary(comment)["total"] for comment in comments)
+    new_comment_reaction_total = sum(comment["reaction_total"] for comment in new_comments)
+    new_issue_user_interaction = new_issue and is_human_user(issue.get("user"))
+    new_comment_user_interactions = sum(1 for comment in new_comments if comment["human_user_interaction"])
+    user_interactions = int(new_issue_user_interaction) + new_comment_user_interactions + new_reactions
+    attention_level = attention_level_for(user_interactions, attention_thresholds)
+    attention_marker = attention_marker_for(user_interactions, attention_thresholds)
+    updated_without_visible_new_post = not new_issue and not new_comments and new_reactions == 0
+
+    engagement_score = (
+        len(new_comments) * 3
+        + new_reactions
+        + issue_reactions["total"]
+        + new_comment_reaction_total
+        + min(int(issue.get("comments") or len(comments) or 0), 10)
+    )
+
+    return {
+        "number": issue.get("number"),
+        "title": str(issue.get("title") or ""),
+        "description": issue_description(issue),
+        "url": str(issue.get("html_url") or ""),
+        "state": str(issue.get("state") or ""),
+        "author": extract_login(issue.get("user")),
+        "author_association": str(issue.get("author_association") or ""),
+        "created_at": str(issue.get("created_at") or ""),
+        "updated_at": updated_at,
+        "labels": labels,
+        "kind_labels": kind_labels,
+        "owner_labels": owner_labels,
+        "comments_total": int(issue.get("comments") or len(comments) or 0),
+        "comments_hydration": comments_hydration
+        or {
+            "fetched": len(comments),
+            "since": None,
+            "truncated": False,
+            "max_pages": None,
+        },
+        "issue_reactions": issue_reactions["counts"],
+        "issue_reaction_total": issue_reactions["total"],
+        "comment_reaction_total": all_comment_reaction_total,
+        "new_comment_reaction_total": new_comment_reaction_total,
+        "new_issue_reactions": issue_reaction_events_summary["total"],
+        "new_issue_upvotes": issue_reaction_events_summary["upvotes"],
+        "new_comment_reactions": comment_reaction_events_summary["total"],
+        "new_comment_upvotes": comment_reaction_events_summary["upvotes"],
+        "new_reactions": new_reactions,
+        "new_upvotes": new_upvotes,
+        "user_interactions": user_interactions,
+        "attention": attention_level > 0,
+        "attention_level": attention_level,
+        "attention_marker": attention_marker,
+        "engagement_score": engagement_score,
+        "activity": {
+            "new_issue": new_issue,
+            "new_comments": len(new_comments),
+            "new_human_comments": new_comment_user_interactions,
+            "new_reactions": new_reactions,
+            "new_upvotes": new_upvotes,
+            "updated_without_visible_new_post": updated_without_visible_new_post,
+        },
+        "body_excerpt": compact_text(issue.get("body"), body_chars),
+        "new_comments": new_comments,
+    }
+
+
+def count_by_label(issues, labels):
+    out = {}
+    for label in labels:
+        matching = [issue for issue in issues if label in issue["owner_labels"]]
+        out[label] = {
+            "issues": len(matching),
+            "new_issues": sum(1 for issue in matching if issue["activity"]["new_issue"]),
+            "new_comments": sum(issue["activity"]["new_comments"] for issue in matching),
+        }
+    return out
+
+
+def count_by_kind(issues):
+    out = {}
+    kinds = [*QUALIFYING_KIND_LABELS, *sorted({kind for issue in issues for kind in issue["kind_labels"]})]
+    for kind in dict.fromkeys(kinds):
+        matching = [issue for issue in issues if kind in issue["kind_labels"]]
+        out[kind] = {
+            "issues": len(matching),
+            "new_issues": sum(1 for issue in matching if issue["activity"]["new_issue"]),
+            "new_comments": sum(issue["activity"]["new_comments"] for issue in matching),
+        }
+    return out
+
+
+def hot_items(issues, limit=8):
+    ranked = sorted(
+        issues,
+        key=lambda issue: (
+            issue["attention"],
+            issue["attention_level"],
+            issue["user_interactions"],
+            issue["engagement_score"],
+            issue["activity"]["new_comments"],
+            issue["issue_reaction_total"] + issue["comment_reaction_total"],
+            issue["updated_at"],
+        ),
+        reverse=True,
+    )
+    return [
+        {
+            "number": issue["number"],
+            "title": issue["title"],
+            "url": issue["url"],
+            "owner_labels": issue["owner_labels"],
+            "kind_labels": issue["kind_labels"],
+            "attention": issue["attention"],
+            "attention_level": issue["attention_level"],
+            "attention_marker": issue["attention_marker"],
+            "user_interactions": issue["user_interactions"],
+            "new_reactions": issue["new_reactions"],
+            "new_upvotes": issue["new_upvotes"],
+            "engagement_score": issue["engagement_score"],
+            "new_comments": issue["activity"]["new_comments"],
+            "reaction_total": issue["issue_reaction_total"] + issue["comment_reaction_total"],
+        }
+        for issue in ranked[:limit]
+        if issue["engagement_score"] > 0
+    ]
+
+
+def ranked_digest_issues(issues):
+    return sorted(
+        issues,
+        key=lambda issue: (
+            issue["attention"],
+            issue["attention_level"],
+            issue["user_interactions"],
+            issue["engagement_score"],
+            issue["activity"]["new_comments"],
+            issue["updated_at"],
+        ),
+        reverse=True,
+    )
+
+
+def digest_rows(issues, limit=10, ref_map=None):
+    ranked = ranked_digest_issues(issues)
+    if ref_map is None:
+        ref_map = {issue["number"]: ref for ref, issue in enumerate(ranked, start=1)}
+    rows = []
+    for issue in ranked[:limit]:
+        ref = ref_map[issue["number"]]
+        reaction_total = issue["issue_reaction_total"] + issue["comment_reaction_total"]
+        rows.append(
+            {
+                "ref": ref,
+                "ref_markdown": f"[{ref}]({issue['url']})",
+                "marker": issue["attention_marker"],
+                "attention_marker": issue["attention_marker"],
+                "number": issue["number"],
+                "description": issue["description"],
+                "title": issue["title"],
+                "url": issue["url"],
+                "area": ", ".join(issue["owner_labels"]),
+                "kind": ", ".join(issue["kind_labels"]),
+                "state": issue["state"],
+                "interactions": issue["user_interactions"],
+                "user_interactions": issue["user_interactions"],
+                "new_reactions": issue["new_reactions"],
+                "new_upvotes": issue["new_upvotes"],
+                "current_reactions": reaction_total,
+            }
+        )
+    return rows
+
+
+def issue_ref_markdown(issue, ref_map):
+    ref = ref_map[issue["number"]]
+    return f"[{ref}]({issue['url']})"
+
+
+def summary_inputs(issues, limit=80, ref_map=None):
+    ranked = ranked_digest_issues(issues)
+    if ref_map is None:
+        ref_map = {issue["number"]: ref for ref, issue in enumerate(ranked, start=1)}
+    rows = []
+    for issue in ranked[:limit]:
+        rows.append(
+            {
+                "ref": ref_map[issue["number"]],
+                "ref_markdown": issue_ref_markdown(issue, ref_map),
+                "number": issue["number"],
+                "title": issue["title"],
+                "description": issue["description"],
+                "url": issue["url"],
+                "labels": issue["labels"],
+                "owner_labels": issue["owner_labels"],
+                "kind_labels": issue["kind_labels"],
+                "state": issue.get("state", ""),
+                "attention_marker": issue.get("attention_marker", ""),
+                "interactions": issue["user_interactions"],
+                "new_comments": issue["activity"].get("new_comments", 0),
+                "new_reactions": issue.get("new_reactions", 0),
+                "new_upvotes": issue.get("new_upvotes", 0),
+                "current_reactions": issue.get("issue_reaction_total", 0) + issue.get("comment_reaction_total", 0),
+            }
+        )
+    return rows
+
+
+def collect_digest(args):
+    since, until = resolve_window(args)
+    window_hours = (until - since).total_seconds() / 3600
+    attention_thresholds = attention_thresholds_for_window(window_hours)
+    requested_labels, all_labels = normalize_requested_labels(args.labels, all_labels=args.all_labels)
+    queries = build_search_queries(args.repo, requested_labels, since, all_labels=all_labels)
+    numbers = search_issue_numbers(queries, args.limit_issues)
+    gh_version_output = gh_text(["--version"])
+
+    issues = []
+    max_comment_pages = None if args.max_comment_pages <= 0 else args.max_comment_pages
+    for number in numbers:
+        issue = fetch_issue(args.repo, number)
+        comments_since = None if args.fetch_all_comments else since
+        comments_payload = fetch_comments(
+            args.repo,
+            number,
+            since=comments_since,
+            max_pages=max_comment_pages,
+        )
+        comments = comments_payload["items"]
+        issue_reaction_events = fetch_reactions_for_item(f"repos/{args.repo}/issues/{number}/reactions", issue)
+        comment_reactions_by_id = fetch_comment_reactions(args.repo, comments)
+        comments_hydration = {
+            "fetched": len(comments),
+            "total": int(issue.get("comments") or len(comments) or 0),
+            "since": format_timestamp(comments_since) if comments_since else None,
+            "truncated": comments_payload["truncated"],
+            "max_pages": comments_payload["max_pages"],
+            "fetch_all_comments": args.fetch_all_comments,
+        }
+        summary = summarize_issue(
+            issue,
+            comments,
+            requested_labels,
+            since,
+            until,
+            args.body_chars,
+            args.comment_chars,
+            issue_reaction_events=issue_reaction_events,
+            comment_reactions_by_id=comment_reactions_by_id,
+            all_labels=all_labels,
+            comments_hydration=comments_hydration,
+            attention_thresholds=attention_thresholds,
+        )
+        if summary is not None:
+            issues.append(summary)
+
+    issues.sort(key=lambda issue: (issue["updated_at"], int(issue["number"] or 0)), reverse=True)
+    totals = {
+        "candidate_issues": len(numbers),
+        "included_issues": len(issues),
+        "new_issues": sum(1 for issue in issues if issue["activity"]["new_issue"]),
+        "issues_with_new_comments": sum(1 for issue in issues if issue["activity"]["new_comments"] > 0),
+        "new_comments": sum(issue["activity"]["new_comments"] for issue in issues),
+        "comments_fetched": sum(issue["comments_hydration"]["fetched"] for issue in issues),
+        "issues_with_truncated_comment_hydration": sum(
+            1 for issue in issues if issue["comments_hydration"]["truncated"]
+        ),
+        "updated_without_visible_new_post": sum(
+            1 for issue in issues if issue["activity"]["updated_without_visible_new_post"]
+        ),
+        "issue_reactions_current_total": sum(issue["issue_reaction_total"] for issue in issues),
+        "comment_reactions_current_total": sum(issue["comment_reaction_total"] for issue in issues),
+        "new_reactions": sum(issue["new_reactions"] for issue in issues),
+        "new_upvotes": sum(issue["new_upvotes"] for issue in issues),
+        "user_interactions": sum(issue["user_interactions"] for issue in issues),
+    }
+    ranked = ranked_digest_issues(issues)
+    ref_map = {issue["number"]: ref for ref, issue in enumerate(ranked, start=1)}
+    filter_label = "all" if all_labels else requested_labels
+
+    return {
+        "generated_at": format_timestamp(datetime.now(timezone.utc)),
+        "source": {
+            "repo": args.repo,
+            "skill": "zammad-mcp-issue-digest",
+            "collector": skill_relative_path(),
+            "script_version": SCRIPT_VERSION,
+            "git_head": git_head(),
+            "gh_version": gh_version_output.splitlines()[0] if gh_version_output else None,
+        },
+        "window": {
+            "since": format_timestamp(since),
+            "until": format_timestamp(until),
+            "hours": round(window_hours, 3),
+        },
+        "attention_thresholds": attention_thresholds,
+        "filters": {
+            "owner_labels": filter_label,
+            "all_labels": all_labels,
+            "kind_labels": list(QUALIFYING_KIND_LABELS),
+        },
+        "collection_notes": [
+            (
+                "Issues are selected when they currently have a qualifying type/dependency label plus at least one "
+                "requested Zammad-MCP area or bot label and were updated during the window."
+            ),
+            (
+                "By default, issue comments are fetched with since=window_start and a max page cap to avoid long "
+                "historical threads; use --fetch-all-comments when exhaustive comment history is needed."
+            ),
+            "New issue comments are filtered by comment creation time within the window from the fetched comment set.",
+            (
+                "Reaction events are counted by GitHub reaction created_at timestamps for hydrated issues and fetched "
+                "comments."
+            ),
+            (
+                "Current reaction totals are standing engagement signals; new_reactions and new_upvotes are windowed "
+                "activity."
+            ),
+            (
+                "The collector does not assign semantic clusters; use summary_inputs as model-ready evidence for "
+                "report-time clustering."
+            ),
+            "Pure reaction-only issues may be missed if GitHub issue search does not surface them via updated_at.",
+            (
+                "Issues updated during the window without a new issue body or new comment are retained because "
+                "label/status edits can still be useful owner signals."
+            ),
+        ],
+        "totals": totals,
+        "by_owner_label": count_by_label(
+            issues,
+            sorted(
+                {area for issue in issues for area in issue["owner_labels"]},
+                key=str.casefold,
+            )
+            if all_labels
+            else requested_labels,
+        ),
+        "by_kind_label": count_by_kind(issues),
+        "hot_items": hot_items(issues),
+        "summary_inputs": summary_inputs(issues, ref_map=ref_map),
+        "digest_rows": digest_rows(issues, ref_map=ref_map),
+        "issues": issues,
+    }
+
+
+def main():
+    args = parse_args()
+    try:
+        digest = collect_digest(args)
+    except (GhCommandError, RuntimeError, ValueError) as err:
+        sys.stderr.write(f"collect_issue_digest.py error: {err}\n")
+        return 1
+    sys.stdout.write(json.dumps(digest, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/zammad-mcp-issue-digest/scripts/collect_issue_digest.py
+++ b/.codex/skills/zammad-mcp-issue-digest/scripts/collect_issue_digest.py
@@ -394,7 +394,10 @@ def extract_login(user_obj):
 
 
 def is_bot_login(login):
-    return bool(login) and login.lower().endswith("[bot]")
+    normalized = str(login or "").casefold()
+    return bool(normalized) and (
+        normalized.endswith("[bot]") or normalized.startswith(("app/", "dependabot", "renovate"))
+    )
 
 
 def is_human_user(user_obj):

--- a/.codex/skills/zammad-mcp-issue-digest/scripts/post_triage_digest.py
+++ b/.codex/skills/zammad-mcp-issue-digest/scripts/post_triage_digest.py
@@ -220,9 +220,10 @@ def main() -> int:
         pr_digest = load_json_file(args.pr_digest)
         body = build_body(issue_digest, pr_digest)
         post = should_post(issue_digest, pr_digest)
-        issue_number = find_tracking_issue(args.repo, args.title)
+        issue_number = None
         created = False
         if args.apply and post:
+            issue_number = find_tracking_issue(args.repo, args.title)
             if issue_number is None:
                 issue_number = create_tracking_issue(args.repo, args.title)
                 created = True

--- a/.codex/skills/zammad-mcp-issue-digest/scripts/post_triage_digest.py
+++ b/.codex/skills/zammad-mcp-issue-digest/scripts/post_triage_digest.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+# mypy: ignore-errors
+# ruff: noqa: PLR2004
+"""Post the combined Zammad-MCP issue and PR digest to a tracking issue."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from triage_common import DEFAULT_REPO, TRACKING_ISSUE_TITLE, GhCommandError, ensure_labels, gh_json, run_gh
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Post a combined Zammad-MCP triage digest.")
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--issue-digest", required=True)
+    parser.add_argument("--pr-digest", required=True)
+    parser.add_argument("--title", default=TRACKING_ISSUE_TITLE)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true")
+    mode.add_argument("--apply", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def load_json_file(path: str) -> dict[str, Any]:
+    payload = json.loads(Path(path).read_text())
+    if not isinstance(payload, dict):
+        raise TypeError(f"{path} must contain a JSON object")
+    return payload
+
+
+def issue_attention_rows(issue_digest: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = issue_digest.get("digest_rows") or []
+    return [
+        row
+        for row in rows
+        if row.get("marker")
+        or str(row.get("state") or "").casefold() == "open"
+        or int(row.get("interactions") or 0) > 0
+    ][:10]
+
+
+def pr_attention_rows(pr_digest: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = pr_digest.get("owner_attention") or []
+    if rows:
+        return rows[:10]
+    return [row for row in pr_digest.get("digest_rows") or [] if row.get("state") == "open"][:10]
+
+
+def should_post(issue_digest: dict[str, Any], pr_digest: dict[str, Any]) -> bool:
+    issue_totals = issue_digest.get("totals") or {}
+    pr_totals = pr_digest.get("totals") or {}
+    return bool(
+        issue_attention_rows(issue_digest)
+        or pr_attention_rows(pr_digest)
+        or int(issue_totals.get("new_issues") or 0) > 0
+        or int(issue_totals.get("new_comments") or 0) > 0
+        or int(pr_totals.get("owner_attention") or 0) > 0
+        or int(pr_totals.get("dependabot_policy_drift") or 0) > 0
+    )
+
+
+def format_issue_line(row: dict[str, Any]) -> str:
+    marker = f"{row.get('marker')} " if row.get("marker") else ""
+    state = str(row.get("state") or "").casefold()
+    interactions = int(row.get("interactions") or 0)
+    ref = row.get("ref_markdown") or f"#{row.get('number')}"
+    return f"- {marker}{ref} `{state}` {row.get('description')} ({interactions} interactions)"
+
+
+def format_pr_line(row: dict[str, Any]) -> str:
+    state = row.get("state") or "unknown"
+    labels = ", ".join(row.get("labels") or [])
+    ref = row.get("ref_markdown") or f"#{row.get('number')}"
+    reason = "; ".join(row.get("reasons") or []) or "PR needs maintainer review"
+    return f"- {ref} `{state}` {row.get('title')} [{labels}] - {reason}"
+
+
+def build_body(issue_digest: dict[str, Any], pr_digest: dict[str, Any]) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    issue_totals = issue_digest.get("totals") or {}
+    pr_totals = pr_digest.get("totals") or {}
+    issue_rows = issue_attention_rows(issue_digest)
+    pr_rows = pr_attention_rows(pr_digest)
+    drift_rows = pr_digest.get("dependency_policy_drift") or []
+
+    lines = [
+        f"## Triage digest - {now}",
+        "",
+        "Maintainer attention summary for Zammad-MCP.",
+        "",
+        "### Issue activity",
+        (
+            f"- {issue_totals.get('included_issues', 0)} recent issues, "
+            f"{issue_totals.get('new_issues', 0)} new, "
+            f"{issue_totals.get('new_comments', 0)} new comments."
+        ),
+    ]
+    if issue_rows:
+        lines.append("")
+        lines.extend(format_issue_line(row) for row in issue_rows)
+    else:
+        lines.append("- No issue-side owner attention surfaced.")
+
+    lines.extend(
+        [
+            "",
+            "### Pull request activity",
+            (
+                f"- {pr_totals.get('candidate_prs', 0)} recent PRs, "
+                f"{pr_totals.get('open', 0)} open, "
+                f"{pr_totals.get('merged', 0)} merged, "
+                f"{pr_totals.get('closed_unmerged', 0)} closed unmerged."
+            ),
+        ]
+    )
+    if pr_rows:
+        lines.append("")
+        lines.extend(format_pr_line(row) for row in pr_rows)
+    else:
+        lines.append("- No PR-side owner attention surfaced.")
+
+    lines.extend(["", "### Dependency automation"])
+    renovate = pr_digest.get("renovate_summary") or {}
+    lines.append(
+        f"- Renovate: {renovate.get('count', 0)} recent PRs "
+        f"({renovate.get('merged', 0)} merged, {renovate.get('open', 0)} open)."
+    )
+    if drift_rows:
+        lines.append(f"- Dependabot policy drift: {len(drift_rows)} PRs need owner reconciliation.")
+    else:
+        lines.append("- No Dependabot policy drift surfaced in this window.")
+
+    issue_source = issue_digest.get("source") or {}
+    pr_source = pr_digest.get("source") or {}
+    lines.extend(
+        [
+            "",
+            "### Source",
+            (
+                f"- Issue collector v{issue_source.get('script_version')} "
+                f"window {issue_digest.get('window', {}).get('since')} to {issue_digest.get('window', {}).get('until')}."
+            ),
+            (
+                f"- PR collector v{pr_source.get('script_version')} "
+                f"window {pr_digest.get('window', {}).get('since')} to {pr_digest.get('window', {}).get('until')}."
+            ),
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def find_tracking_issue(repo: str, title: str) -> int | None:
+    payload = gh_json(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--search",
+            f"{title} in:title",
+            "--limit",
+            "20",
+            "--json",
+            "number,title",
+        ]
+    )
+    if not isinstance(payload, list):
+        return None
+    for issue in payload:
+        if isinstance(issue, dict) and issue.get("title") == title:
+            return int(issue.get("number") or 0)
+    return None
+
+
+def create_tracking_issue(repo: str, title: str) -> int:
+    ensure_labels(repo, ["type:chore", "status:in-progress"])
+    body = "Rolling maintainer digest for Zammad-MCP issue and pull request triage.\n"
+    proc = run_gh(
+        [
+            "issue",
+            "create",
+            "--repo",
+            repo,
+            "--title",
+            title,
+            "--label",
+            "type:chore",
+            "--label",
+            "status:in-progress",
+            "--body-file",
+            "-",
+        ],
+        input_text=body,
+    )
+    url = proc.stdout.strip().splitlines()[-1]
+    match = re.search(r"/issues/(\d+)(?:\b|$)", url)
+    if match is None:
+        raise GhCommandError("Unable to determine created tracking issue number")
+    return int(match.group(1))
+
+
+def post_comment(repo: str, issue_number: int, body: str) -> None:
+    run_gh(["issue", "comment", str(issue_number), "--repo", repo, "--body-file", "-"], input_text=body)
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        issue_digest = load_json_file(args.issue_digest)
+        pr_digest = load_json_file(args.pr_digest)
+        body = build_body(issue_digest, pr_digest)
+        post = should_post(issue_digest, pr_digest)
+        issue_number = find_tracking_issue(args.repo, args.title)
+        created = False
+        if args.apply and post:
+            if issue_number is None:
+                issue_number = create_tracking_issue(args.repo, args.title)
+                created = True
+            post_comment(args.repo, issue_number, body)
+        payload = {
+            "repo": args.repo,
+            "title": args.title,
+            "tracking_issue": issue_number,
+            "created_tracking_issue": created,
+            "should_post": post,
+            "applied": bool(args.apply and post),
+            "body": body,
+        }
+    except (GhCommandError, RuntimeError, TypeError, ValueError, OSError, json.JSONDecodeError) as err:
+        sys.stderr.write(f"post_triage_digest.py error: {err}\n")
+        return 1
+
+    if args.json:
+        sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    else:
+        sys.stdout.write(body)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/zammad-mcp-issue-digest/scripts/post_triage_digest.py
+++ b/.codex/skills/zammad-mcp-issue-digest/scripts/post_triage_digest.py
@@ -63,7 +63,9 @@ def should_post(issue_digest: dict[str, Any], pr_digest: dict[str, Any]) -> bool
         or int(issue_totals.get("new_issues") or 0) > 0
         or int(issue_totals.get("new_comments") or 0) > 0
         or int(pr_totals.get("owner_attention") or 0) > 0
+        or int(pr_totals.get("dependency_policy_drift") or 0) > 0
         or int(pr_totals.get("dependabot_policy_drift") or 0) > 0
+        or bool(pr_digest.get("dependency_policy_drift") or [])
     )
 
 

--- a/.codex/skills/zammad-mcp-issue-digest/scripts/test_collect_issue_digest.py
+++ b/.codex/skills/zammad-mcp-issue-digest/scripts/test_collect_issue_digest.py
@@ -94,6 +94,13 @@ def test_area_labels_keeps_repo_owner_labels_and_excludes_kind_or_legacy_labels(
     check_equal(collector.area_labels(labels), ["area:python", "bot:renovate"])
 
 
+def test_bot_login_detection_includes_github_apps_and_known_automation() -> None:
+    for login in ["app/renovate", "app/dependabot", "dependabot", "renovate[bot]", "coderabbitai[bot]"]:
+        check(collector.is_bot_login(login), f"{login} should be treated as bot-authored")
+
+    check(not collector.is_bot_login("human-maintainer"), "normal users should not be treated as bots")
+
+
 def test_title_cleaning_matches_repo_dependency_and_prefix_conventions() -> None:
     check_equal(
         collector.clean_title_for_description("chore(deps): bump protobuf from 4.25.9 to 5.29.6"),

--- a/.codex/skills/zammad-mcp-issue-digest/scripts/test_collect_issue_digest.py
+++ b/.codex/skills/zammad-mcp-issue-digest/scripts/test_collect_issue_digest.py
@@ -1,0 +1,184 @@
+# mypy: ignore-errors
+# ruff: noqa: PLR2004
+"""Regression tests for the Zammad-MCP issue digest collector."""
+
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).with_name("collect_issue_digest.py")
+SPEC = importlib.util.spec_from_file_location("collect_issue_digest", SCRIPT_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to load collector from {SCRIPT_PATH}")
+collector = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(collector)
+
+
+def utc(year: int, month: int, day: int, hour: int = 0) -> datetime:
+    return datetime(year, month, day, hour, tzinfo=timezone.utc)
+
+
+def check(value: bool, message: str) -> None:
+    if not value:
+        raise AssertionError(message)
+
+
+def check_equal(actual, expected) -> None:
+    if actual != expected:
+        raise AssertionError(f"Expected {expected!r}, got {actual!r}")
+
+
+def check_is(actual, expected) -> None:
+    if actual is not expected:
+        raise AssertionError(f"Expected {expected!r}, got {actual!r}")
+
+
+def test_parse_duration_aliases_and_units() -> None:
+    check_equal(collector.parse_duration_hours("past week"), 168.0)
+    check_equal(collector.parse_duration_hours("48h"), 48.0)
+    check_equal(collector.parse_duration_hours("2d"), 48.0)
+    check_equal(collector.parse_duration_hours("1w"), 168.0)
+
+
+def test_normalize_requested_labels_deduplicates_and_supports_all_labels() -> None:
+    labels, all_labels = collector.normalize_requested_labels(["area:python,area:ci-cd", "AREA:PYTHON"])
+
+    check_equal(labels, ["area:python", "area:ci-cd"])
+    check_is(all_labels, False)
+
+    labels, all_labels = collector.normalize_requested_labels(["all", "labels"])
+
+    check_equal(labels, [])
+    check_is(all_labels, True)
+
+
+def test_build_search_queries_pairs_owner_labels_with_kind_labels() -> None:
+    queries = collector.build_search_queries(
+        "basher83/Zammad-MCP",
+        ["area:python"],
+        utc(2026, 5, 1),
+    )
+
+    check_equal(len(queries), len(collector.QUALIFYING_KIND_LABELS))
+    check_equal(queries[0], "repo:basher83/Zammad-MCP is:issue updated:>=2026-05-01 label:area:python label:type:bug")
+    check_equal(
+        queries[-1],
+        "repo:basher83/Zammad-MCP is:issue updated:>=2026-05-01 label:area:python label:dependencies",
+    )
+
+
+def test_build_search_queries_all_labels_uses_kind_labels_only() -> None:
+    queries = collector.build_search_queries(
+        "basher83/Zammad-MCP",
+        ["area:python"],
+        utc(2026, 5, 1),
+        all_labels=True,
+    )
+
+    check_equal(len(queries), 1)
+    check_equal(queries[0], "repo:basher83/Zammad-MCP is:issue updated:>=2026-05-01")
+    check(all("area:python" not in query for query in queries), "all-labels mode should not add owner labels")
+
+
+def test_area_labels_keeps_repo_owner_labels_and_excludes_kind_or_legacy_labels() -> None:
+    labels = [
+        "type:bug",
+        "area:python",
+        "bot:renovate",
+        "dependencies",
+        "renovate",
+        "python:uv",
+        "🏷️ auto-labeled",
+    ]
+
+    check_equal(collector.area_labels(labels), ["area:python", "bot:renovate"])
+
+
+def test_title_cleaning_matches_repo_dependency_and_prefix_conventions() -> None:
+    check_equal(
+        collector.clean_title_for_description("chore(deps): bump protobuf from 4.25.9 to 5.29.6"),
+        "Dependency update: protobuf from 4.25.9 to 5.29.6",
+    )
+    check_equal(collector.clean_title_for_description("Zammad-MCP: Add webhook support"), "Add webhook support")
+
+
+def test_attention_thresholds_scale_with_digest_window() -> None:
+    thresholds = collector.attention_thresholds_for_window(168)
+
+    check_equal(thresholds["elevated"], 4)
+    check_equal(thresholds["very_high"], 8)
+    check_equal(collector.attention_marker_for(3, thresholds), "")
+    check_equal(collector.attention_marker_for(4, thresholds), "🔥")
+    check_equal(collector.attention_marker_for(8, thresholds), "🔥🔥")
+
+
+def test_all_labels_mode_keeps_unclassified_issues() -> None:
+    issue = {
+        "number": 43,
+        "title": "Zammad-MCP: HTTP transport failure",
+        "state": "open",
+        "html_url": "https://github.com/basher83/Zammad-MCP/issues/43",
+        "created_at": "2026-05-02T10:00:00Z",
+        "updated_at": "2026-05-02T12:00:00Z",
+        "body": "Transport fails in some clients.",
+        "comments": 0,
+        "user": {"login": "zammad-user"},
+        "labels": [],
+        "reactions": {"total_count": 0},
+    }
+
+    summary = collector.summarize_issue(
+        issue,
+        comments=[],
+        requested_labels=[],
+        since=utc(2026, 5, 2),
+        until=utc(2026, 5, 3),
+        body_chars=200,
+        comment_chars=200,
+        all_labels=True,
+    )
+
+    check(summary is not None, "all-labels mode should keep unlabeled repo issues")
+    check_equal(summary["kind_labels"], ["unclassified"])
+    check_equal(summary["owner_labels"], ["unlabeled"])
+
+
+def test_summarize_issue_filters_to_requested_repo_labels() -> None:
+    issue = {
+        "number": 42,
+        "title": "Zammad-MCP: Login failure",
+        "state": "open",
+        "html_url": "https://github.com/basher83/Zammad-MCP/issues/42",
+        "created_at": "2026-05-02T10:00:00Z",
+        "updated_at": "2026-05-02T12:00:00Z",
+        "body": "Users cannot authenticate with token auth.",
+        "comments": 0,
+        "user": {"login": "zammad-user"},
+        "labels": [{"name": "type:bug"}, {"name": "area:python"}],
+        "reactions": {"total_count": 0},
+    }
+
+    summary = collector.summarize_issue(
+        issue,
+        comments=[],
+        requested_labels=["area:python"],
+        since=utc(2026, 5, 2),
+        until=utc(2026, 5, 3),
+        body_chars=200,
+        comment_chars=200,
+        comments_hydration={
+            "fetched": 0,
+            "total": 0,
+            "since": "2026-05-02T00:00:00Z",
+            "truncated": False,
+            "max_pages": 3,
+            "fetch_all_comments": False,
+        },
+    )
+
+    check(summary is not None, "issue should be summarized")
+    check_equal(summary["number"], 42)
+    check_equal(summary["description"], "Login failure")
+    check_equal(summary["owner_labels"], ["area:python"])
+    check_equal(summary["kind_labels"], ["type:bug"])
+    check_equal(summary["user_interactions"], 1)

--- a/.codex/skills/zammad-mcp-issue-digest/scripts/test_triage_issue.py
+++ b/.codex/skills/zammad-mcp-issue-digest/scripts/test_triage_issue.py
@@ -26,6 +26,7 @@ def load_module(name: str, path: Path):
 
 triage_common = load_module("triage_common", SCRIPT_DIR / "triage_common.py")
 triage_issue = load_module("triage_issue", SCRIPT_DIR / "triage_issue.py")
+post_triage_digest = load_module("post_triage_digest", SCRIPT_DIR / "post_triage_digest.py")
 
 
 def check(value: bool, message: str) -> None:
@@ -127,6 +128,32 @@ def test_invalid_llm_json_falls_back_to_deterministic_labels(tmp_path: Path) -> 
     check("type:bug" in decision["labels"], "deterministic fallback should still label")
 
 
+def test_run_gh_timeout_raises_clear_error(monkeypatch) -> None:
+    def fake_run(*args, **kwargs):
+        raise triage_common.subprocess.TimeoutExpired(cmd=kwargs.get("args") or args[0], timeout=kwargs.get("timeout"))
+
+    monkeypatch.setattr(triage_common.subprocess, "run", fake_run)
+
+    try:
+        triage_common.run_gh(["issue", "list"], timeout=0.01)
+    except triage_common.GhCommandError as err:
+        check("timed out" in str(err), "timeout should be surfaced as GhCommandError")
+    else:
+        raise AssertionError("run_gh should raise GhCommandError on timeout")
+
+
+def test_digest_posts_when_dependency_policy_drift_rows_exist() -> None:
+    issue_digest = {"totals": {}, "digest_rows": []}
+    pr_digest = {
+        "totals": {},
+        "owner_attention": [],
+        "digest_rows": [],
+        "dependency_policy_drift": [{"number": 252}],
+    }
+
+    check(post_triage_digest.should_post(issue_digest, pr_digest), "dependency drift rows should trigger digest post")
+
+
 def test_issue_single_dry_run_uses_mocked_gh_payload(monkeypatch, capsys) -> None:
     payloads = {
         "view": issue(212, "Flatten tool `params` into `arguments`", "Pydantic validation fails.", labels=["type:bug"]),
@@ -179,6 +206,9 @@ def test_issue_triage_workflow_uses_labels_only_automation() -> None:
     workflow = (REPO_ROOT / ".github/workflows/issue-triage.yml").read_text()
 
     check("issues:" in workflow, "issue workflow should be issue-event driven")
+    check("workflow_dispatch:" in workflow, "issue workflow should support manual dry-run dispatch")
+    check("default: false" in workflow, "manual issue triage should default to dry-run")
+    check("inputs.apply || true" not in workflow, "explicit manual dry-run should not be coerced to apply")
     check("CODEX_OPENAI_API_KEY" not in workflow, "issue workflow should not expose LLM secrets in label job")
     check("openai/codex-action" not in workflow, "issue workflow should be deterministic-only in v1")
     check("triage_issue.py" in workflow, "issue workflow should call the issue triage CLI")

--- a/.codex/skills/zammad-mcp-issue-digest/scripts/test_triage_issue.py
+++ b/.codex/skills/zammad-mcp-issue-digest/scripts/test_triage_issue.py
@@ -209,6 +209,7 @@ def test_issue_triage_workflow_uses_labels_only_automation() -> None:
     check("workflow_dispatch:" in workflow, "issue workflow should support manual dry-run dispatch")
     check("default: false" in workflow, "manual issue triage should default to dry-run")
     check("inputs.apply || true" not in workflow, "explicit manual dry-run should not be coerced to apply")
+    check("issue-context.json" not in workflow, "issue workflow should not fetch unused context artifacts")
     check("CODEX_OPENAI_API_KEY" not in workflow, "issue workflow should not expose LLM secrets in label job")
     check("openai/codex-action" not in workflow, "issue workflow should be deterministic-only in v1")
     check("triage_issue.py" in workflow, "issue workflow should call the issue triage CLI")

--- a/.codex/skills/zammad-mcp-issue-digest/scripts/test_triage_issue.py
+++ b/.codex/skills/zammad-mcp-issue-digest/scripts/test_triage_issue.py
@@ -1,0 +1,184 @@
+# mypy: ignore-errors
+# ruff: noqa: PLR2004
+"""Tests for Zammad-MCP issue triage automation."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+REPO_ROOT = SCRIPT_DIR.parents[3]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+triage_common = load_module("triage_common", SCRIPT_DIR / "triage_common.py")
+triage_issue = load_module("triage_issue", SCRIPT_DIR / "triage_issue.py")
+
+
+def check(value: bool, message: str) -> None:
+    if not value:
+        raise AssertionError(message)
+
+
+def check_equal(actual, expected) -> None:
+    if actual != expected:
+        raise AssertionError(f"Expected {expected!r}, got {actual!r}")
+
+
+def issue(number: int, title: str, body: str = "", state: str = "OPEN", author: str = "Erudition", labels=None):
+    return {
+        "number": number,
+        "title": title,
+        "body": body,
+        "state": state,
+        "author": {"login": author, "is_bot": author.startswith("app/")},
+        "labels": [{"name": label} for label in (labels or [])],
+        "comments": [],
+        "url": f"https://github.com/basher83/Zammad-MCP/issues/{number}",
+    }
+
+
+def test_issue_212_schema_bug_gets_owner_review_and_duplicate_candidate() -> None:
+    current = issue(
+        212,
+        "Flatten tool `params` into `arguments` to fix arg/param validation failures",
+        "Pydantic params nesting blocks normal agent tool calls.",
+        labels=["type:bug"],
+    )
+    pool = [
+        issue(201, "Make all constants case-insensitive if they can be", "Enum validation makes agents fail."),
+        issue(198, "zammad knowledgebase", "Create and parse knowledgebase articles."),
+    ]
+
+    decision = triage_common.classify_issue_payload(current, duplicate_pool=pool).to_json()
+
+    check("type:bug" in decision["labels"], "schema issue should be a bug")
+    check("area:mcp-tools" in decision["labels"], "schema issue should be mcp-tools")
+    check("needs:owner-review" in decision["labels"], "schema issue needs owner review")
+    check("needs:duplicate-review" in decision["labels"], "schema issue should surface duplicate review")
+    check_equal(decision["duplicate_candidates"][0]["number"], 201)
+
+
+def test_issue_201_case_normalization_gets_tool_bug_labels() -> None:
+    current = issue(
+        201,
+        "Make all constants case-insensitive if they can be",
+        "Enum validation rejects MARKDOWN when agents pass the obvious constant name.",
+    )
+
+    decision = triage_common.classify_issue_payload(current).to_json()
+
+    check("type:bug" in decision["labels"], "case normalization should be a bug")
+    check("area:mcp-tools" in decision["labels"], "case normalization should be mcp-tools")
+
+
+def test_issue_198_knowledgebase_gets_feature_and_zammad_api_labels() -> None:
+    current = issue(
+        198,
+        "zammad knowledgebase",
+        "It would be great to retrieve, search, and create knowledgebase articles via MCP.",
+        author="snizzleorg",
+    )
+
+    decision = triage_common.classify_issue_payload(current).to_json()
+
+    check("type:feature" in decision["labels"], "knowledgebase issue should be a feature")
+    check("area:zammad-api" in decision["labels"], "knowledgebase issue should be zammad API coverage")
+
+
+def test_issue_3_dependency_dashboard_gets_renovate_labels() -> None:
+    current = issue(
+        3,
+        "Dependency Dashboard",
+        "This issue lists Renovate updates and detected dependencies.",
+        author="app/renovate",
+    )
+
+    decision = triage_common.classify_issue_payload(current).to_json()
+
+    check("dependencies" in decision["labels"], "dashboard should be dependency-labeled")
+    check("bot:renovate" in decision["labels"], "dashboard should be Renovate-labeled")
+
+
+def test_invalid_llm_json_falls_back_to_deterministic_labels(tmp_path: Path) -> None:
+    bad_output = tmp_path / "bad.json"
+    bad_output.write_text("{not json")
+
+    payload = triage_common.load_optional_json(str(bad_output))
+    decision = triage_common.classify_issue_payload(
+        issue(201, "Make all constants case-insensitive if they can be", "Enum validation rejects MARKDOWN."),
+        llm_payload=payload,
+    ).to_json()
+
+    check_equal(payload, None)
+    check("type:bug" in decision["labels"], "deterministic fallback should still label")
+
+
+def test_issue_single_dry_run_uses_mocked_gh_payload(monkeypatch, capsys) -> None:
+    payloads = {
+        "view": issue(212, "Flatten tool `params` into `arguments`", "Pydantic validation fails.", labels=["type:bug"]),
+        "list": [issue(201, "Make all constants case-insensitive", "Enum validation fails.")],
+    }
+
+    def fake_gh_json(args):
+        if args[0:2] == ["issue", "view"]:
+            return payloads["view"]
+        if args[0:2] == ["issue", "list"]:
+            return payloads["list"]
+        raise AssertionError(f"Unexpected gh args: {args}")
+
+    monkeypatch.setattr(triage_issue, "gh_json", fake_gh_json)
+    monkeypatch.setattr(sys, "argv", ["triage_issue.py", "--issue", "212", "--dry-run", "--json"])
+
+    code = triage_issue.main()
+    captured = json.loads(capsys.readouterr().out)
+
+    check_equal(code, 0)
+    check_equal(captured["number"], 212)
+    check(captured["applied"] is False, "dry-run should not apply")
+    check("area:mcp-tools" in captured["labels"], "mocked dry-run should classify")
+
+
+def test_issue_backfill_uses_mocked_open_issue_payloads(monkeypatch, capsys) -> None:
+    payloads = [
+        issue(212, "Flatten tool `params` into `arguments`", "Pydantic validation fails.", labels=["type:bug"]),
+        issue(198, "zammad knowledgebase", "Add knowledgebase support."),
+    ]
+
+    def fake_gh_json(args):
+        if args[0:2] == ["issue", "list"]:
+            return payloads
+        raise AssertionError(f"Unexpected gh args: {args}")
+
+    monkeypatch.setattr(triage_issue, "gh_json", fake_gh_json)
+    monkeypatch.setattr(sys, "argv", ["triage_issue.py", "--backfill", "--state", "open", "--dry-run", "--json"])
+
+    code = triage_issue.main()
+    captured = json.loads(capsys.readouterr().out)
+
+    check_equal(code, 0)
+    check_equal(captured["kind"], "issue_backfill")
+    check_equal(len(captured["results"]), 2)
+    check(captured["applied"] is False, "backfill dry-run should not apply")
+
+
+def test_issue_triage_workflow_uses_labels_only_automation() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/issue-triage.yml").read_text()
+
+    check("issues:" in workflow, "issue workflow should be issue-event driven")
+    check("CODEX_OPENAI_API_KEY" in workflow, "issue workflow should gate optional Codex labeling on a secret")
+    check("triage_issue.py" in workflow, "issue workflow should call the issue triage CLI")
+    check("gh issue comment" not in workflow, "issue workflow should not comment on source issues")

--- a/.codex/skills/zammad-mcp-issue-digest/scripts/test_triage_issue.py
+++ b/.codex/skills/zammad-mcp-issue-digest/scripts/test_triage_issue.py
@@ -179,6 +179,8 @@ def test_issue_triage_workflow_uses_labels_only_automation() -> None:
     workflow = (REPO_ROOT / ".github/workflows/issue-triage.yml").read_text()
 
     check("issues:" in workflow, "issue workflow should be issue-event driven")
-    check("CODEX_OPENAI_API_KEY" in workflow, "issue workflow should gate optional Codex labeling on a secret")
+    check("CODEX_OPENAI_API_KEY" not in workflow, "issue workflow should not expose LLM secrets in label job")
+    check("openai/codex-action" not in workflow, "issue workflow should be deterministic-only in v1")
     check("triage_issue.py" in workflow, "issue workflow should call the issue triage CLI")
+    check("--llm-output" not in workflow, "issue workflow should not depend on LLM output artifacts")
     check("gh issue comment" not in workflow, "issue workflow should not comment on source issues")

--- a/.codex/skills/zammad-mcp-issue-digest/scripts/triage_common.py
+++ b/.codex/skills/zammad-mcp-issue-digest/scripts/triage_common.py
@@ -612,7 +612,7 @@ def pr_state_summary(pr: dict[str, Any]) -> dict[str, Any]:
     review = "needed"
     if review_decision == "APPROVED":
         review = "approved"
-    elif review_decision in {"CHANGES_REQUESTED", "REVIEW_REQUIRED"}:
+    elif review_decision == "CHANGES_REQUESTED":
         review = "blocked"
     elif str(pr.get("state") or "").upper() != "OPEN":
         review = "closed"

--- a/.codex/skills/zammad-mcp-issue-digest/scripts/triage_common.py
+++ b/.codex/skills/zammad-mcp-issue-digest/scripts/triage_common.py
@@ -118,7 +118,13 @@ class TriageDecision:
         return out
 
 
-def run_gh(args: list[str], *, input_text: str | None = None, check: bool = True) -> subprocess.CompletedProcess:
+def run_gh(
+    args: list[str],
+    *,
+    input_text: str | None = None,
+    check: bool = True,
+    timeout: float | None = 30.0,
+) -> subprocess.CompletedProcess:
     cmd = ["gh", *args]
     try:
         proc = subprocess.run(  # nosec B603 B607
@@ -127,9 +133,12 @@ def run_gh(args: list[str], *, input_text: str | None = None, check: bool = True
             check=check,
             capture_output=True,
             text=True,
+            timeout=timeout,
         )
     except FileNotFoundError as err:
         raise GhCommandError("`gh` command not found") from err
+    except subprocess.TimeoutExpired as err:
+        raise GhCommandError(f"GitHub CLI command timed out after {timeout}s: {' '.join(cmd)}") from err
     except subprocess.CalledProcessError as err:
         raise GhCommandError(format_gh_error(cmd, err)) from err
     return proc

--- a/.codex/skills/zammad-mcp-issue-digest/scripts/triage_common.py
+++ b/.codex/skills/zammad-mcp-issue-digest/scripts/triage_common.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python3
+# mypy: ignore-errors
+# ruff: noqa: PLR2004,SIM108
+"""Shared deterministic triage helpers for Zammad-MCP issues and pull requests."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import subprocess  # nosec B404
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_REPO = "basher83/Zammad-MCP"
+TRACKING_ISSUE_TITLE = "[triage] Zammad-MCP maintainer digest"
+
+TYPE_LABELS = {
+    "type:bug",
+    "type:feature",
+    "type:docs",
+    "type:security",
+    "type:performance",
+    "type:chore",
+    "dependencies",
+}
+AREA_LABELS = {
+    "area:python",
+    "area:web",
+    "area:docs",
+    "area:ci-cd",
+    "area:security",
+    "area:infra",
+    "area:mcp-tools",
+    "area:zammad-api",
+    "area:transport",
+}
+WORKFLOW_LABELS = {
+    "needs:owner-review",
+    "needs:repro",
+    "needs:info",
+    "needs:duplicate-review",
+    "status:backlog",
+    "status:blocked",
+    "status:done",
+    "status:in-progress",
+    "status:in-review",
+    "status:ready-to-merge",
+}
+BOT_LABELS = {
+    "bot:renovate",
+    "bot:dependabot",
+    "renovate",
+    "docker",
+    "github-actions",
+    "python:uv",
+    "security",
+}
+ALLOWED_LABELS = TYPE_LABELS | AREA_LABELS | WORKFLOW_LABELS | BOT_LABELS
+
+LABEL_DEFINITIONS = {
+    "area:mcp-tools": ("MCP tool schemas, prompts, resources, and agent-facing tool ergonomics", "3776ab"),
+    "area:zammad-api": ("Zammad API coverage, ticket/article/user/knowledgebase behavior", "0e8a16"),
+    "area:transport": ("MCP stdio, HTTP transport, sessions, and client initialization", "0052cc"),
+    "needs:owner-review": ("Requires maintainer review or product decision", "fbca04"),
+    "needs:repro": ("Needs reproduction details before implementation", "fef2c0"),
+    "needs:info": ("Needs more information from the reporter", "fef2c0"),
+    "needs:duplicate-review": ("Potential duplicate; maintainer should review before closing", "cfd3d7"),
+    "bot:renovate": ("Automated dependency updates by Renovate", "0366d6"),
+    "bot:dependabot": ("Automated dependency updates by Dependabot", "0366d6"),
+    "renovate": ("Renovate dependency automation", "ededed"),
+    "docker": ("Docker image, Dockerfile, or container dependency updates", "ededed"),
+    "github-actions": ("GitHub Actions workflow or action dependency updates", "ededed"),
+    "python:uv": ("Python uv, uv.lock, or Python package dependency updates", "2b67c6"),
+    "security": ("Security advisory, vulnerability, or security-sensitive dependency update", "b60205"),
+    "type:bug": ("Something is not working correctly", "d73a4a"),
+    "type:feature": ("New feature or enhancement", "a2eeef"),
+    "type:docs": ("Documentation or content", "0075ca"),
+    "type:security": ("Security-related work", "d73a4a"),
+    "type:performance": ("Performance improvements or optimizations", "fbca04"),
+    "type:chore": ("Maintenance, refactor, or tooling", "5319e7"),
+    "dependencies": ("Dependency updates or dependency issues", "0366d6"),
+}
+
+
+class GhCommandError(RuntimeError):
+    pass
+
+
+@dataclass
+class TriageDecision:
+    number: int
+    kind: str
+    labels: list[str]
+    confidence: str
+    attention: str
+    reasons: list[str] = field(default_factory=list)
+    duplicate_candidates: list[dict[str, Any]] = field(default_factory=list)
+    state_summary: dict[str, Any] | None = None
+
+    def to_json(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "number": self.number,
+            "kind": self.kind,
+            "labels": self.labels,
+            "confidence": self.confidence,
+            "attention": self.attention,
+            "reasons": self.reasons,
+        }
+        if self.duplicate_candidates:
+            out["duplicate_candidates"] = self.duplicate_candidates
+        else:
+            out["duplicate_candidates"] = []
+        if self.state_summary is not None:
+            out["state_summary"] = self.state_summary
+        return out
+
+
+def run_gh(args: list[str], *, input_text: str | None = None, check: bool = True) -> subprocess.CompletedProcess:
+    cmd = ["gh", *args]
+    try:
+        proc = subprocess.run(  # nosec B603 B607
+            cmd,
+            input=input_text,
+            check=check,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as err:
+        raise GhCommandError("`gh` command not found") from err
+    except subprocess.CalledProcessError as err:
+        raise GhCommandError(format_gh_error(cmd, err)) from err
+    return proc
+
+
+def gh_json(args: list[str]) -> Any:
+    proc = run_gh(args)
+    raw = proc.stdout.strip()
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as err:
+        raise GhCommandError(f"Failed to parse JSON from gh output for {' '.join(args)}") from err
+
+
+def format_gh_error(cmd: list[str], err: subprocess.CalledProcessError) -> str:
+    stdout = (err.stdout or "").strip()
+    stderr = (err.stderr or "").strip()
+    parts = [f"GitHub CLI command failed: {' '.join(cmd)}"]
+    if stdout:
+        parts.append(f"stdout: {stdout}")
+    if stderr:
+        parts.append(f"stderr: {stderr}")
+    return "\n".join(parts)
+
+
+def parse_duration_hours(value: str | None) -> float | None:
+    if value is None:
+        return None
+    text = value.strip().casefold().replace("_", " ")
+    if not text:
+        return None
+    text = re.sub(r"^(past|last)\s+", "", text)
+    aliases = {"day": 24.0, "24h": 24.0, "week": 168.0, "7d": 168.0, "30d": 720.0, "year": 8760.0}
+    if text in aliases:
+        return aliases[text]
+    match = re.fullmatch(r"(\d+(?:\.\d+)?)\s*(h|hr|hrs|hour|hours)", text)
+    if match:
+        return float(match.group(1))
+    match = re.fullmatch(r"(\d+(?:\.\d+)?)\s*(d|day|days)", text)
+    if match:
+        return float(match.group(1)) * 24.0
+    match = re.fullmatch(r"(\d+(?:\.\d+)?)\s*(w|week|weeks)", text)
+    if match:
+        return float(match.group(1)) * 168.0
+    raise ValueError(f"Unsupported duration: {value}")
+
+
+def parse_timestamp(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def format_timestamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def resolve_window(
+    window: str | None, window_hours: float | None, since: str | None, until: str | None
+) -> tuple[datetime, datetime]:
+    end = parse_timestamp(until) or datetime.now(timezone.utc)
+    start = parse_timestamp(since)
+    if start is None:
+        hours = parse_duration_hours(window)
+        if hours is None:
+            hours = window_hours or 24.0
+        if hours <= 0:
+            raise ValueError("window duration must be > 0")
+        start = end - timedelta(hours=hours)
+    if start >= end:
+        raise ValueError("--since must be before --until")
+    return start, end
+
+
+def compact_text(value: Any, limit: int = 160) -> str:
+    text = re.sub(r"\s+", " ", str(value or "")).strip()
+    if len(text) <= limit:
+        return text
+    return f"{text[: max(limit - 3, 0)].rstrip()}..."
+
+
+def extract_login(author: Any) -> str:
+    if isinstance(author, dict):
+        return str(author.get("login") or "")
+    return str(author or "")
+
+
+def author_is_bot(author: Any) -> bool:
+    if isinstance(author, dict) and author.get("is_bot") is True:
+        return True
+    login = extract_login(author).casefold()
+    return login.startswith("app/") or login.endswith("[bot]") or login in {"renovate", "dependabot"}
+
+
+def label_names(item: dict[str, Any]) -> list[str]:
+    out = []
+    for label in item.get("labels") or []:
+        if isinstance(label, dict):
+            name = label.get("name")
+        else:
+            name = label
+        if name:
+            out.append(str(name))
+    return sorted(set(out), key=str.casefold)
+
+
+def comments_text(item: dict[str, Any]) -> str:
+    chunks = []
+    for comment in item.get("comments") or []:
+        if isinstance(comment, dict):
+            chunks.append(str(comment.get("body") or ""))
+    return "\n".join(chunks)
+
+
+def text_blob(*values: Any) -> str:
+    return "\n".join(str(value or "") for value in values).casefold()
+
+
+def path_blob(paths: list[str] | None) -> str:
+    return "\n".join(paths or []).casefold()
+
+
+def ordered_labels(labels: set[str]) -> list[str]:
+    type_order = [
+        "type:bug",
+        "type:feature",
+        "type:docs",
+        "type:security",
+        "type:performance",
+        "type:chore",
+        "dependencies",
+    ]
+    area_order = [
+        "area:mcp-tools",
+        "area:zammad-api",
+        "area:transport",
+        "area:security",
+        "area:ci-cd",
+        "area:docs",
+        "area:python",
+        "area:infra",
+        "area:web",
+    ]
+    rest_order = [
+        "bot:renovate",
+        "bot:dependabot",
+        "renovate",
+        "docker",
+        "github-actions",
+        "python:uv",
+        "security",
+        "needs:owner-review",
+        "needs:repro",
+        "needs:info",
+        "needs:duplicate-review",
+    ]
+    order = {label: index for index, label in enumerate([*type_order, *area_order, *rest_order])}
+    return sorted(labels & ALLOWED_LABELS, key=lambda label: (order.get(label, 999), label.casefold()))
+
+
+def merge_llm_labels(labels: set[str], llm_payload: dict[str, Any] | None) -> list[str]:
+    if not isinstance(llm_payload, dict):
+        return []
+    added = []
+    raw_labels = llm_payload.get("labels")
+    if not isinstance(raw_labels, list):
+        return added
+    for raw in raw_labels:
+        label = str(raw)
+        if label in ALLOWED_LABELS and label not in labels:
+            labels.add(label)
+            added.append(label)
+    return added
+
+
+def load_optional_json(path: str | None) -> dict[str, Any] | None:
+    if not path:
+        return None
+    candidate = Path(path)
+    if not candidate.exists():
+        return None
+    raw = candidate.read_text().strip()
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def issue_theme_keys(item: dict[str, Any]) -> set[str]:
+    text = text_blob(item.get("title"), item.get("body"), comments_text(item))
+    keys = set()
+    if re.search(
+        r"params?|arguments?|pydantic|schema|validation|enum|case[- ]?insensitive|tool[- ]?call|tool signatures?",
+        text,
+    ):
+        keys.add("tool-call schema ergonomics")
+    if re.search(r"stdio|http transport|transport corruption|session|initialized|/mcp\b|mcp endpoint", text):
+        keys.add("MCP transport/runtime")
+    if re.search(r"knowledge ?base|webhook|bulk|attachment|customer|tag|time_unit|zammad api|article email", text):
+        keys.add("Zammad API coverage")
+    if re.search(r"renovate|dependabot|dependency|python 3\.14|mcp package|codacy|github actions", text):
+        keys.add("dependency governance")
+    if re.search(r"security|cve|tls|certificate|token|ssrf|xss|audit|rate limiting|vulnerab", text):
+        keys.add("security hardening")
+    return keys
+
+
+def find_duplicate_candidates(
+    item: dict[str, Any],
+    pool: list[dict[str, Any]] | None,
+    *,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    if not pool:
+        return []
+    current_number = int(item.get("number") or 0)
+    current_keys = issue_theme_keys(item)
+    if not current_keys:
+        return []
+    candidates = []
+    for other in pool:
+        number = int(other.get("number") or 0)
+        if not number or number == current_number:
+            continue
+        other_text = text_blob(other.get("title"), other.get("body"), comments_text(other))
+        if author_is_bot(other.get("author") or other.get("user")) or dependency_labels(
+            other_text,
+            extract_login(other.get("author") or other.get("user")),
+        ):
+            continue
+        overlap = current_keys & issue_theme_keys(other)
+        if not overlap:
+            continue
+        state = str(other.get("state") or "").upper()
+        score = len(overlap) + (2 if state == "OPEN" else 0)
+        reason = f"same {sorted(overlap)[0]} theme"
+        candidates.append({"number": number, "reason": reason, "_score": score})
+    candidates.sort(key=lambda row: (row["_score"], row["number"]), reverse=True)
+    return [{key: value for key, value in row.items() if key != "_score"} for row in candidates[:limit]]
+
+
+def classify_type(text: str, existing_labels: set[str]) -> str:  # noqa: PLR0911
+    if "dependencies" in existing_labels:
+        return "dependencies"
+    if re.search(r"security|cve|vulnerab|ssrf|xss|audit logging|rate limiting", text):
+        return "type:security"
+    if re.search(r"performance|optimi[sz]e|memory|slow|timeout", text):
+        return "type:performance"
+    if re.search(
+        r"\b(fails?|failure|error|bug|crash|breaks?|broken|blocks?|cannot|incorrect|rejects?|regression|not initialized)\b",
+        text,
+    ):
+        return "type:bug"
+    if re.search(r"\b(feature|implement|add|support|knowledge ?base|webhook|bulk|enhancement)\b", text):
+        return "type:feature"
+    if re.search(r"docs?|readme|documentation|docstring", text):
+        return "type:docs"
+    if re.search(r"\b(chore|refactor|cleanup|test|workflow|renovate config|dependency dashboard)\b", text):
+        return "type:chore"
+    return "type:chore"
+
+
+def classify_areas(text: str, changed_files: list[str] | None = None) -> set[str]:
+    paths = path_blob(changed_files)
+    labels = set()
+    if re.search(
+        r"params?|arguments?|pydantic|schema|validation|enum|case[- ]?insensitive|tool[- ]?call|tool signatures?",
+        text,
+    ):
+        labels.add("area:mcp-tools")
+    if re.search(r"knowledge ?base|webhook|bulk|attachment|customer|tag|time_unit|zammad api|article email", text):
+        labels.add("area:zammad-api")
+    if re.search(r"stdio|http transport|transport corruption|session|initialized|/mcp\b|mcp endpoint", text):
+        labels.add("area:transport")
+    if re.search(r"security|cve|tls|certificate|token|auth|ssrf|xss|audit|rate limiting|vulnerab", text):
+        labels.add("area:security")
+    if re.search(r"workflow|github actions|codacy|renovate|dependabot|ci|coverage|code scanning", text):
+        labels.add("area:ci-cd")
+    if re.search(r"\b(docs?|readme|documentation|docstring)\b", text) or re.search(r"(^|\n)docs/|readme|\.md$", paths):
+        labels.add("area:docs")
+    if re.search(r"python\s*(?:3|\d|version|runtime)|pyproject|uv|pip|pytest|ruff|mypy|bandit", text) or re.search(
+        r"pyproject\.toml|uv\.lock", paths
+    ):
+        labels.add("area:python")
+    if re.search(r"docker|ghcr|image|container|registry", text) or re.search(r"dockerfile|compose", paths):
+        labels.add("area:infra")
+    if re.search(r"web ui|http endpoint|webhook|browser|cors", text):
+        labels.add("area:web")
+    return labels
+
+
+def dependency_labels(text: str, author_login: str) -> set[str]:
+    labels = set()
+    normalized_author = author_login.casefold()
+    dependency_context = bool(
+        re.search(r"dependency dashboard|chore\(deps\)|\bdeps?\b|bump|update dependency|renovate|dependabot", text)
+        or "renovate" in normalized_author
+        or "dependabot" in normalized_author
+    )
+    if "renovate" in normalized_author or "dependency dashboard" in text:
+        labels.update({"dependencies", "bot:renovate", "renovate"})
+    elif dependency_context and "renovate" in text:
+        labels.update({"dependencies", "renovate"})
+    if "dependabot" in normalized_author:
+        labels.update({"dependencies", "bot:dependabot"})
+    if dependency_context and re.search(r"docker|ghcr|container|image|dockerfile", text):
+        labels.add("docker")
+    if dependency_context and re.search(r"github actions|actions/|codeql|checkout|setup-|upload-artifact", text):
+        labels.add("github-actions")
+    if dependency_context and re.search(r"uv|pip|pyproject|python|pytest|ruff|mypy|bandit|pip-audit", text):
+        labels.add("python:uv")
+    if dependency_context and re.search(r"security|vulnerab|cve|\[security\]", text):
+        labels.add("security")
+    return labels
+
+
+def classify_issue_payload(
+    issue: dict[str, Any],
+    *,
+    llm_payload: dict[str, Any] | None = None,
+    duplicate_pool: list[dict[str, Any]] | None = None,
+) -> TriageDecision:
+    number = int(issue.get("number") or 0)
+    title = str(issue.get("title") or "")
+    body = str(issue.get("body") or "")
+    state = str(issue.get("state") or "").upper()
+    author_login = extract_login(issue.get("author") or issue.get("user"))
+    existing = set(label_names(issue))
+    text = text_blob(title, body, comments_text(issue), " ".join(existing), author_login)
+    labels = set()
+    reasons = []
+
+    labels.update(dependency_labels(text, author_login))
+    if labels & {"bot:renovate", "bot:dependabot"}:
+        reasons.append("dependency automation item")
+    if "bot:dependabot" in labels:
+        labels.add("needs:owner-review")
+        reasons.append("Dependabot routine PRs are policy-drift signals because Renovate owns updates")
+
+    if "dependencies" not in labels:
+        label_type = classify_type(text, existing)
+        labels.add(label_type)
+    labels.update(classify_areas(text))
+
+    if "area:mcp-tools" in labels:
+        reasons.append("agent-facing MCP tool schema or validation behavior")
+    if "area:zammad-api" in labels:
+        reasons.append("Zammad API coverage or ticket/article behavior")
+    if "area:transport" in labels:
+        reasons.append("MCP transport/runtime behavior")
+
+    if (
+        state == "OPEN"
+        and not author_is_bot(issue.get("author") or issue.get("user"))
+        and ("type:bug" in labels or "area:mcp-tools" in labels or "area:zammad-api" in labels)
+    ):
+        labels.add("needs:owner-review")
+
+    if "type:bug" in labels and not re.search(r"repro|steps|traceback|error|```", text):
+        labels.add("needs:repro")
+
+    llm_added = merge_llm_labels(labels, llm_payload)
+    if llm_added:
+        reasons.append(f"LLM suggested labels: {', '.join(llm_added)}")
+
+    duplicate_candidates = find_duplicate_candidates(issue, duplicate_pool)
+    if duplicate_candidates:
+        labels.add("needs:duplicate-review")
+        reasons.append("potential duplicate or repeated theme found")
+
+    type_count = len(labels & TYPE_LABELS)
+    area_count = len(labels & AREA_LABELS)
+    confidence = "high" if type_count and area_count else "medium"
+    if llm_payload and not llm_added:
+        confidence = "medium"
+    attention = "owner" if "needs:owner-review" in labels or "needs:duplicate-review" in labels else "none"
+
+    return TriageDecision(
+        number=number,
+        kind="issue",
+        labels=ordered_labels(labels),
+        confidence=confidence,
+        attention=attention,
+        reasons=reasons or ["deterministic label classification"],
+        duplicate_candidates=duplicate_candidates,
+    )
+
+
+def classify_pr_payload(
+    pr: dict[str, Any],
+    *,
+    changed_files: list[str] | None = None,
+    llm_payload: dict[str, Any] | None = None,
+) -> TriageDecision:
+    number = int(pr.get("number") or 0)
+    title = str(pr.get("title") or "")
+    body = str(pr.get("body") or "")
+    state = str(pr.get("state") or "").upper()
+    author_login = extract_login(pr.get("author") or pr.get("user"))
+    existing = set(label_names(pr))
+    files = changed_files or [str(item.get("path") or item.get("filename") or "") for item in pr.get("files") or []]
+    text = text_blob(title, body, " ".join(existing), author_login, " ".join(files), pr.get("headRefName"))
+    labels = set()
+    reasons = []
+
+    labels.update(dependency_labels(text, author_login))
+    if labels & {"bot:renovate", "bot:dependabot"}:
+        labels.add("type:chore")
+        reasons.append("dependency automation pull request")
+    if "bot:dependabot" in labels:
+        labels.add("needs:owner-review")
+        reasons.append("Dependabot routine PR should be closed or reconciled against Renovate ownership")
+
+    if "dependencies" not in labels:
+        labels.add(classify_type(text, existing))
+    labels.update(classify_areas(text, files))
+
+    if not labels & AREA_LABELS and any(path.endswith(".md") for path in files):
+        labels.add("area:docs")
+    if not labels & AREA_LABELS and any(path.startswith(".github/") for path in files):
+        labels.add("area:ci-cd")
+    if not labels & AREA_LABELS and any(path.startswith("mcp_zammad/") for path in files):
+        labels.add("area:python")
+    if (
+        "area:docs" in labels
+        and "type:docs" not in labels
+        and any(path.startswith(("mcp_zammad/", "tests/")) for path in files)
+    ):
+        labels.discard("area:docs")
+
+    if state == "OPEN" and not author_is_bot(pr.get("author") or pr.get("user")):
+        labels.add("needs:owner-review")
+        reasons.append("open human-authored PR needs maintainer review")
+
+    llm_added = merge_llm_labels(labels, llm_payload)
+    if llm_added:
+        reasons.append(f"LLM suggested labels: {', '.join(llm_added)}")
+
+    state_summary = pr_state_summary(pr)
+    confidence = "high" if labels & AREA_LABELS else "medium"
+    attention = "owner" if "needs:owner-review" in labels or state_summary.get("review") == "needed" else "none"
+
+    return TriageDecision(
+        number=number,
+        kind="pull_request",
+        labels=ordered_labels(labels),
+        confidence=confidence,
+        attention=attention,
+        reasons=reasons or ["deterministic PR classification"],
+        state_summary=state_summary,
+    )
+
+
+def pr_state_summary(pr: dict[str, Any]) -> dict[str, Any]:
+    author = pr.get("author") or pr.get("user")
+    status_rollup = pr.get("statusCheckRollup")
+    ci = "unknown"
+    if isinstance(status_rollup, list) and status_rollup:
+        conclusions = [str(item.get("conclusion") or item.get("state") or "").upper() for item in status_rollup]
+        if any(value in {"FAILURE", "ERROR", "CANCELLED", "TIMED_OUT"} for value in conclusions):
+            ci = "failing"
+        elif all(value in {"SUCCESS", "NEUTRAL", "SKIPPED"} for value in conclusions):
+            ci = "passing"
+        else:
+            ci = "pending"
+    review_decision = str(pr.get("reviewDecision") or "").upper()
+    review = "needed"
+    if review_decision == "APPROVED":
+        review = "approved"
+    elif review_decision in {"CHANGES_REQUESTED", "REVIEW_REQUIRED"}:
+        review = "blocked"
+    elif str(pr.get("state") or "").upper() != "OPEN":
+        review = "closed"
+    return {
+        "author_type": "bot" if author_is_bot(author) else "human",
+        "ci": ci,
+        "review": review,
+        "mergeability": str(pr.get("mergeable") or "unknown").casefold(),
+    }
+
+
+def ensure_labels(repo: str, labels: list[str]) -> None:
+    for label in labels:
+        description, color = LABEL_DEFINITIONS.get(label, ("", "ededed"))
+        create = run_gh(
+            [
+                "label",
+                "create",
+                label,
+                "--repo",
+                repo,
+                "--description",
+                description,
+                "--color",
+                color,
+            ],
+            check=False,
+        )
+        if create.returncode == 0:
+            continue
+        run_gh(
+            [
+                "label",
+                "edit",
+                label,
+                "--repo",
+                repo,
+                "--description",
+                description,
+                "--color",
+                color,
+            ],
+            check=False,
+        )
+
+
+def apply_labels(repo: str, number: int, labels: list[str], *, kind: str) -> None:
+    if not labels:
+        return
+    ensure_labels(repo, labels)
+    target = "pr" if kind == "pull_request" else "issue"
+    cmd = [target, "edit", str(number), "--repo", repo]
+    for label in labels:
+        cmd.extend(["--add-label", label])
+    run_gh(cmd)
+
+
+def days_since(value: str | None, *, now: datetime | None = None) -> int | None:
+    parsed = parse_timestamp(value)
+    if parsed is None:
+        return None
+    current = now or datetime.now(timezone.utc)
+    return max(0, math.floor((current - parsed).total_seconds() / 86400))

--- a/.codex/skills/zammad-mcp-issue-digest/scripts/triage_issue.py
+++ b/.codex/skills/zammad-mcp-issue-digest/scripts/triage_issue.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# mypy: ignore-errors
+# ruff: noqa: PLR2004
+"""Triage Zammad-MCP GitHub issues and apply controlled labels."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+from triage_common import (
+    DEFAULT_REPO,
+    GhCommandError,
+    apply_labels,
+    classify_issue_payload,
+    gh_json,
+    load_optional_json,
+)
+
+ISSUE_FIELDS = "number,title,body,state,author,labels,comments,createdAt,updatedAt,closedAt,url"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Apply Zammad-MCP issue triage labels.")
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--issue", type=int, help="Issue number to triage")
+    target.add_argument("--backfill", action="store_true", help="Triage multiple issues")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="Do not apply labels")
+    mode.add_argument("--apply", action="store_true", help="Apply labels through gh")
+    parser.add_argument("--state", choices=["open", "closed", "all"], default="open", help="Backfill issue state")
+    parser.add_argument("--limit", type=int, default=100, help="Maximum issues to inspect in backfill/pool")
+    parser.add_argument("--llm-output", help="Optional Codex/LLM JSON output with a labels array")
+    parser.add_argument("--json", action="store_true", help="Emit JSON only")
+    return parser.parse_args()
+
+
+def fetch_issue(repo: str, number: int) -> dict[str, Any]:
+    payload = gh_json(["issue", "view", str(number), "--repo", repo, "--json", ISSUE_FIELDS])
+    if not isinstance(payload, dict):
+        raise GhCommandError(f"Unexpected issue payload for #{number}")
+    return payload
+
+
+def fetch_issue_pool(repo: str, state: str, limit: int) -> list[dict[str, Any]]:
+    payload = gh_json(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            state,
+            "--limit",
+            str(limit),
+            "--json",
+            ISSUE_FIELDS,
+        ]
+    )
+    if not isinstance(payload, list):
+        raise GhCommandError("Unexpected issue list payload")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def process_issue(
+    issue: dict[str, Any],
+    *,
+    repo: str,
+    apply: bool,
+    llm_payload: dict[str, Any] | None = None,
+    duplicate_pool: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    decision = classify_issue_payload(issue, llm_payload=llm_payload, duplicate_pool=duplicate_pool)
+    if apply:
+        apply_labels(repo, decision.number, decision.labels, kind="issue")
+    out = decision.to_json()
+    out["applied"] = bool(apply)
+    out["url"] = issue.get("url")
+    return out
+
+
+def output_payload(payload: dict[str, Any], *, json_only: bool) -> None:
+    if json_only:
+        sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        return
+    if payload.get("mode") == "backfill":
+        count = len(payload.get("results") or [])
+        sys.stdout.write(f"Triage decisions for {count} issues:\n")
+        for item in payload.get("results") or []:
+            sys.stdout.write(f"- #{item['number']}: {', '.join(item['labels'])}\n")
+        return
+    sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def main() -> int:
+    args = parse_args()
+    apply = bool(args.apply)
+    llm_payload = load_optional_json(args.llm_output)
+    try:
+        if args.issue:
+            issue = fetch_issue(args.repo, args.issue)
+            duplicate_pool = fetch_issue_pool(args.repo, "all", args.limit)
+            payload = process_issue(
+                issue,
+                repo=args.repo,
+                apply=apply,
+                llm_payload=llm_payload,
+                duplicate_pool=duplicate_pool,
+            )
+        else:
+            issues = fetch_issue_pool(args.repo, args.state, args.limit)
+            duplicate_pool = fetch_issue_pool(args.repo, "all", args.limit)
+            payload = {
+                "repo": args.repo,
+                "kind": "issue_backfill",
+                "mode": "backfill",
+                "state": args.state,
+                "applied": apply,
+                "results": [
+                    process_issue(issue, repo=args.repo, apply=apply, duplicate_pool=duplicate_pool) for issue in issues
+                ],
+            }
+    except (GhCommandError, RuntimeError, ValueError) as err:
+        sys.stderr.write(f"triage_issue.py error: {err}\n")
+        return 1
+
+    output_payload(payload, json_only=args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/zammad-mcp-pr-digest/SKILL.md
+++ b/.codex/skills/zammad-mcp-pr-digest/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: zammad-mcp-pr-digest
+description: Run pull request triage and digest workflows for basher83/Zammad-MCP, including human PR review attention, Renovate/Dependabot dependency noise, CI state, mergeability, and configurable time windows.
+---
+
+# Zammad-MCP PR Digest
+
+## Objective
+
+Produce a maintainer-focused pull request digest for `basher83/Zammad-MCP`. This repository has high PR volume from dependency bots and low but important human contributor volume, so the digest should separate routine Renovate updates from PRs that need owner review.
+
+Default to summary-only output. Include compact details when the user asks for a table, full digest, or specific PR status.
+
+For triage automation, classify PRs from metadata plus changed files. Apply labels only. Do not run PR code, merge PRs, close PRs, or comment on source PRs in v1. `pull_request_target` workflows must fetch the diff safely from the fork or branch and pass only file names and metadata into the classifier.
+
+## Inputs
+
+- Optional PR number for targeted triage.
+- Optional time window, default previous 30 days.
+- Optional repo override, default `basher83/Zammad-MCP`.
+- Optional backfill mode for open or recent PRs.
+
+## Workflow
+
+Run the PR collector for a recent digest:
+
+```bash
+python3 .codex/skills/zammad-mcp-pr-digest/scripts/collect_pr_digest.py --window 30d
+```
+
+Run targeted PR triage:
+
+```bash
+python3 .codex/skills/zammad-mcp-pr-digest/scripts/triage_pr.py --pr 200 --dry-run --json
+```
+
+Run open PR backfill:
+
+```bash
+python3 .codex/skills/zammad-mcp-pr-digest/scripts/triage_pr.py --backfill --state open --dry-run --json
+```
+
+## Interpretation
+
+Treat Renovate as the routine dependency update owner. Renovate PRs should usually be summarized by ecosystem and failure state, not individually unless checks fail, security labels appear, or the PR remains open.
+
+Treat Dependabot routine version PRs as policy drift because this repository keeps Dependabot configured for security posture while Renovate owns routine version updates.
+
+Treat open human-authored PRs as owner-attention items unless they are already merged, closed, or explicitly marked ready-to-merge.
+
+Use the paired issue skill's `post_triage_digest.py` to publish combined issue and PR summaries into the tracking issue titled `[triage] Zammad-MCP maintainer digest`.
+
+## Validation
+
+```bash
+uv run pytest .codex/skills/zammad-mcp-pr-digest/scripts/test_triage_pr.py
+```
+
+```bash
+python3 .codex/skills/zammad-mcp-pr-digest/scripts/collect_pr_digest.py --window 30d --limit-prs 50
+```

--- a/.codex/skills/zammad-mcp-pr-digest/SKILL.md
+++ b/.codex/skills/zammad-mcp-pr-digest/SKILL.md
@@ -11,7 +11,7 @@ Produce a maintainer-focused pull request digest for `basher83/Zammad-MCP`. This
 
 Default to summary-only output. Include compact details when the user asks for a table, full digest, or specific PR status.
 
-For triage automation, classify PRs from metadata plus changed files. Apply labels only. Do not run PR code, merge PRs, close PRs, or comment on source PRs in v1. `pull_request_target` workflows must fetch the diff safely from the fork or branch and pass only file names and metadata into the classifier.
+For triage automation, classify PRs from metadata plus changed files. The CLI accepts optional LLM JSON as an additive signal for local or future isolated generator runs, but the repository Actions run deterministic-only in v1. Apply labels only. Do not run PR code, merge PRs, close PRs, or comment on source PRs in v1. `pull_request_target` workflows must fetch file names safely from the fork or branch and pass only file names and metadata into the classifier.
 
 ## Inputs
 

--- a/.codex/skills/zammad-mcp-pr-digest/agents/openai.yaml
+++ b/.codex/skills/zammad-mcp-pr-digest/agents/openai.yaml
@@ -1,0 +1,7 @@
+---
+name: zammad-mcp-pr-digest
+model: gpt-5.2
+reasoning_effort: medium
+---
+
+Use this agent profile for repository PR digest and triage runs that need concise maintainer-oriented summaries.

--- a/.codex/skills/zammad-mcp-pr-digest/scripts/collect_pr_digest.py
+++ b/.codex/skills/zammad-mcp-pr-digest/scripts/collect_pr_digest.py
@@ -24,6 +24,7 @@ from triage_common import (  # noqa: E402
     days_since,
     format_timestamp,
     gh_json,
+    parse_timestamp,
     resolve_window,
 )
 
@@ -58,8 +59,9 @@ def git_head() -> str | None:
     return git_proc.stdout.strip() or None
 
 
-def fetch_prs(repo: str, since: datetime, limit: int) -> list[dict[str, Any]]:
+def fetch_prs(repo: str, since: datetime, until: datetime, limit: int) -> list[dict[str, Any]]:
     since_date = since.date().isoformat()
+    until_date = until.date().isoformat()
     payload = gh_json(
         [
             "pr",
@@ -71,14 +73,22 @@ def fetch_prs(repo: str, since: datetime, limit: int) -> list[dict[str, Any]]:
             "--limit",
             str(limit),
             "--search",
-            f"updated:>={since_date}",
+            f"updated:{since_date}..{until_date}",
             "--json",
             PR_LIST_FIELDS,
         ]
     )
     if not isinstance(payload, list):
         raise GhCommandError("Unexpected PR list payload")
-    return [item for item in payload if isinstance(item, dict)]
+    filtered = []
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        updated_at = parse_timestamp(str(item.get("updatedAt") or ""))
+        if updated_at is None or updated_at < since or updated_at > until:
+            continue
+        filtered.append(item)
+    return filtered
 
 
 def pr_state(pr: dict[str, Any]) -> str:
@@ -109,7 +119,7 @@ def digest_row(pr: dict[str, Any], decision: dict[str, Any]) -> dict[str, Any]:
 
 def collect_digest(args: argparse.Namespace) -> dict[str, Any]:
     since, until = resolve_window(args.window, args.window_hours, args.since, args.until)
-    prs = fetch_prs(args.repo, since, args.limit_prs)
+    prs = fetch_prs(args.repo, since, until, args.limit_prs)
     decisions = []
     rows = []
     for pr in prs:

--- a/.codex/skills/zammad-mcp-pr-digest/scripts/collect_pr_digest.py
+++ b/.codex/skills/zammad-mcp-pr-digest/scripts/collect_pr_digest.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# mypy: ignore-errors
+# ruff: noqa: PLR2004
+"""Collect recent Zammad-MCP pull request activity for maintainer digests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess  # nosec B404
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SKILLS_DIR = Path(__file__).resolve().parents[2]
+COMMON_DIR = SKILLS_DIR / "zammad-mcp-issue-digest" / "scripts"
+sys.path.insert(0, str(COMMON_DIR))
+
+from triage_common import (  # noqa: E402
+    DEFAULT_REPO,
+    GhCommandError,
+    classify_pr_payload,
+    days_since,
+    format_timestamp,
+    gh_json,
+    resolve_window,
+)
+
+PR_LIST_FIELDS = (
+    "number,title,body,state,author,labels,comments,createdAt,updatedAt,closedAt,mergedAt,"
+    "isDraft,reviewDecision,headRefName,baseRefName,url,mergeable,statusCheckRollup,files"
+)
+SCRIPT_VERSION = 1
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Collect recent Zammad-MCP PR activity.")
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--window", default="30d", help='Lookback duration such as "30d" or "365d"')
+    parser.add_argument("--window-hours", type=float, help="Lookback window in hours")
+    parser.add_argument("--since", help="UTC ISO timestamp override for window start")
+    parser.add_argument("--until", help="UTC ISO timestamp override for window end")
+    parser.add_argument("--limit-prs", type=int, default=250)
+    return parser.parse_args()
+
+
+def git_head() -> str | None:
+    try:
+        git_proc = subprocess.run(  # nosec B603 B607
+            ["git", "rev-parse", "--short=12", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+    return git_proc.stdout.strip() or None
+
+
+def fetch_prs(repo: str, since: datetime, limit: int) -> list[dict[str, Any]]:
+    since_date = since.date().isoformat()
+    payload = gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "all",
+            "--limit",
+            str(limit),
+            "--search",
+            f"updated:>={since_date}",
+            "--json",
+            PR_LIST_FIELDS,
+        ]
+    )
+    if not isinstance(payload, list):
+        raise GhCommandError("Unexpected PR list payload")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def pr_state(pr: dict[str, Any]) -> str:
+    if pr.get("mergedAt"):
+        return "merged"
+    return str(pr.get("state") or "").casefold()
+
+
+def digest_row(pr: dict[str, Any], decision: dict[str, Any]) -> dict[str, Any]:
+    state = pr_state(pr)
+    updated_days = days_since(str(pr.get("updatedAt") or ""))
+    attention = decision.get("attention") == "owner"
+    return {
+        "number": pr.get("number"),
+        "title": pr.get("title"),
+        "url": pr.get("url"),
+        "ref_markdown": f"[#{pr.get('number')}]({pr.get('url')})",
+        "state": state,
+        "author": (pr.get("author") or {}).get("login"),
+        "labels": decision.get("labels", []),
+        "attention": attention,
+        "attention_marker": "owner" if attention else "",
+        "updated_days_ago": updated_days,
+        "state_summary": decision.get("state_summary", {}),
+        "reasons": decision.get("reasons", []),
+    }
+
+
+def collect_digest(args: argparse.Namespace) -> dict[str, Any]:
+    since, until = resolve_window(args.window, args.window_hours, args.since, args.until)
+    prs = fetch_prs(args.repo, since, args.limit_prs)
+    decisions = []
+    rows = []
+    for pr in prs:
+        decision = classify_pr_payload(pr).to_json()
+        decisions.append(decision)
+        rows.append(digest_row(pr, decision))
+
+    rows.sort(
+        key=lambda row: (
+            row["attention"],
+            row["state"] == "open",
+            row["updated_days_ago"] is not None and -row["updated_days_ago"],
+            int(row["number"] or 0),
+        ),
+        reverse=True,
+    )
+    bot_rows = [row for row in rows if row["state_summary"].get("author_type") == "bot"]
+    human_rows = [row for row in rows if row["state_summary"].get("author_type") == "human"]
+    dependabot_policy_drift = [
+        row for row in rows if "bot:dependabot" in row["labels"] and row["state"] in {"open", "closed"}
+    ]
+    renovate_rows = [row for row in rows if "bot:renovate" in row["labels"]]
+
+    return {
+        "generated_at": format_timestamp(datetime.now(timezone.utc)),
+        "source": {
+            "repo": args.repo,
+            "skill": "zammad-mcp-pr-digest",
+            "script_version": SCRIPT_VERSION,
+            "git_head": git_head(),
+        },
+        "window": {
+            "since": format_timestamp(since),
+            "until": format_timestamp(until),
+            "hours": round((until - since).total_seconds() / 3600, 3),
+        },
+        "totals": {
+            "candidate_prs": len(prs),
+            "open": sum(1 for pr in prs if pr_state(pr) == "open"),
+            "merged": sum(1 for pr in prs if pr_state(pr) == "merged"),
+            "closed_unmerged": sum(1 for pr in prs if pr_state(pr) == "closed"),
+            "human_authored": len(human_rows),
+            "bot_authored": len(bot_rows),
+            "renovate_prs": len(renovate_rows),
+            "dependabot_policy_drift": len(dependabot_policy_drift),
+            "owner_attention": sum(1 for row in rows if row["attention"]),
+        },
+        "owner_attention": [row for row in rows if row["attention"]],
+        "dependency_policy_drift": dependabot_policy_drift,
+        "renovate_summary": {
+            "count": len(renovate_rows),
+            "open": sum(1 for row in renovate_rows if row["state"] == "open"),
+            "merged": sum(1 for row in renovate_rows if row["state"] == "merged"),
+            "closed_unmerged": sum(1 for row in renovate_rows if row["state"] == "closed"),
+        },
+        "digest_rows": rows[:20],
+        "pull_requests": rows,
+        "decisions": decisions,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        digest = collect_digest(args)
+    except (GhCommandError, RuntimeError, ValueError) as err:
+        sys.stderr.write(f"collect_pr_digest.py error: {err}\n")
+        return 1
+    sys.stdout.write(json.dumps(digest, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/zammad-mcp-pr-digest/scripts/collect_pr_digest.py
+++ b/.codex/skills/zammad-mcp-pr-digest/scripts/collect_pr_digest.py
@@ -60,8 +60,8 @@ def git_head() -> str | None:
 
 
 def fetch_prs(repo: str, since: datetime, until: datetime, limit: int) -> list[dict[str, Any]]:
-    since_date = since.date().isoformat()
-    until_date = until.date().isoformat()
+    since_timestamp = format_timestamp(since)
+    until_timestamp = format_timestamp(until)
     payload = gh_json(
         [
             "pr",
@@ -73,7 +73,7 @@ def fetch_prs(repo: str, since: datetime, until: datetime, limit: int) -> list[d
             "--limit",
             str(limit),
             "--search",
-            f"updated:{since_date}..{until_date}",
+            f"updated:{since_timestamp}..{until_timestamp}",
             "--json",
             PR_LIST_FIELDS,
         ]
@@ -88,6 +88,10 @@ def fetch_prs(repo: str, since: datetime, until: datetime, limit: int) -> list[d
         if updated_at is None or updated_at < since or updated_at > until:
             continue
         filtered.append(item)
+    if len(payload) >= limit:
+        raise GhCommandError(
+            f"PR digest query reached --limit {limit}; rerun with a higher --limit-prs to avoid truncation"
+        )
     return filtered
 
 

--- a/.codex/skills/zammad-mcp-pr-digest/scripts/test_triage_pr.py
+++ b/.codex/skills/zammad-mcp-pr-digest/scripts/test_triage_pr.py
@@ -206,7 +206,10 @@ def test_collect_pr_digest_filters_exact_updated_window(monkeypatch) -> None:
     ]
 
     def fake_gh_json(args):
-        check("updated:2026-05-01..2026-05-02" in args, "search should bound the broad query by dates")
+        check(
+            "updated:2026-05-01T12:00:00Z..2026-05-02T12:00:00Z" in args,
+            "search should bound the broad query by exact timestamps",
+        )
         return payloads
 
     monkeypatch.setattr(collect_pr_digest, "gh_json", fake_gh_json)
@@ -221,9 +224,28 @@ def test_collect_pr_digest_filters_exact_updated_window(monkeypatch) -> None:
     check_equal([row["number"] for row in rows], [2, 3])
 
 
+def test_collect_pr_digest_fails_when_limit_may_truncate_window(monkeypatch) -> None:
+    payloads = [{"number": 1, "updatedAt": "2026-05-01T12:00:00Z"}]
+
+    monkeypatch.setattr(collect_pr_digest, "gh_json", lambda _args: payloads)
+
+    try:
+        collect_pr_digest.fetch_prs(
+            "basher83/Zammad-MCP",
+            datetime(2026, 5, 1, 12, tzinfo=timezone.utc),
+            datetime(2026, 5, 2, 12, tzinfo=timezone.utc),
+            1,
+        )
+    except collect_pr_digest.GhCommandError as err:
+        check("reached --limit 1" in str(err), "limit truncation should fail clearly")
+    else:
+        raise AssertionError("fetch_prs should fail when gh results reach the requested limit")
+
+
 def test_pr_triage_workflow_collects_fork_diff_without_running_pr_code() -> None:
     workflow = (REPO_ROOT / ".github/workflows/pr-triage.yml").read_text()
 
+    check((REPO_ROOT / ".github/workflows/pr-triage.yml").exists(), "workflow path should resolve from repo root")
     check("pull_request_target:" in workflow, "PR workflow should use pull_request_target for label permissions")
     check("git fetch --no-tags" in workflow, "PR workflow should fetch fork heads for diff metadata")
     check("git diff --name-only" in workflow, "PR workflow should collect changed paths without running PR code")
@@ -232,4 +254,6 @@ def test_pr_triage_workflow_collects_fork_diff_without_running_pr_code() -> None
     check("CODEX_OPENAI_API_KEY" not in workflow, "PR workflow should not expose LLM secrets in label job")
     check("openai/codex-action" not in workflow, "PR workflow should be deterministic-only in v1")
     check("--llm-output" not in workflow, "PR workflow should not depend on LLM output artifacts")
+    check("inputs.apply || true" not in workflow, "explicit manual dry-run should not be coerced to apply")
+    check('INPUT_APPLY="${INPUT_APPLY:-true}"' in workflow, "PR workflow should default missing apply input in shell")
     check("gh pr comment" not in workflow, "PR workflow should not comment on source PRs")

--- a/.codex/skills/zammad-mcp-pr-digest/scripts/test_triage_pr.py
+++ b/.codex/skills/zammad-mcp-pr-digest/scripts/test_triage_pr.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).parent
@@ -29,6 +30,7 @@ def load_module(name: str, path: Path):
 
 triage_common = load_module("triage_common", COMMON_DIR / "triage_common.py")
 triage_pr = load_module("triage_pr", SCRIPT_DIR / "triage_pr.py")
+collect_pr_digest = load_module("collect_pr_digest", SCRIPT_DIR / "collect_pr_digest.py")
 
 
 def check(value: bool, message: str) -> None:
@@ -119,6 +121,16 @@ def test_dependabot_pr_gets_policy_drift_signal() -> None:
     check_equal(decision["attention"], "owner")
 
 
+def test_review_required_pr_state_maps_to_needed_attention() -> None:
+    current = pr(300, "Improve ticket search", "snizzleorg", "Add better ticket search.")
+    current["reviewDecision"] = "REVIEW_REQUIRED"
+
+    decision = triage_common.classify_pr_payload(current).to_json()
+
+    check_equal(decision["state_summary"]["review"], "needed")
+    check_equal(decision["attention"], "owner")
+
+
 def test_pr_single_dry_run_uses_mocked_gh_payload(monkeypatch, capsys, tmp_path: Path) -> None:
     changed_files = tmp_path / "changed-files.txt"
     changed_files.write_text("mcp_zammad/server.py\n")
@@ -167,11 +179,57 @@ def test_pr_backfill_uses_mocked_open_pr_payloads(monkeypatch, capsys) -> None:
     check(captured["applied"] is False, "backfill dry-run should not apply")
 
 
+def test_pr_backfill_rejects_single_pr_context_inputs(monkeypatch, capsys, tmp_path: Path) -> None:
+    changed_files = tmp_path / "changed-files.txt"
+    changed_files.write_text("mcp_zammad/server.py\n")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["triage_pr.py", "--backfill", "--changed-files", str(changed_files), "--dry-run", "--json"],
+    )
+
+    code = triage_pr.main()
+    captured = capsys.readouterr()
+
+    check_equal(code, 1)
+    check("--backfill does not support --llm-output or --changed-files" in captured.err, "should fail clearly")
+
+
+def test_collect_pr_digest_filters_exact_updated_window(monkeypatch) -> None:
+    payloads = [
+        {"number": 1, "updatedAt": "2026-05-01T11:59:59Z"},
+        {"number": 2, "updatedAt": "2026-05-01T12:00:00Z"},
+        {"number": 3, "updatedAt": "2026-05-02T12:00:00Z"},
+        {"number": 4, "updatedAt": "2026-05-02T12:00:01Z"},
+        "not-a-dict",
+    ]
+
+    def fake_gh_json(args):
+        check("updated:2026-05-01..2026-05-02" in args, "search should bound the broad query by dates")
+        return payloads
+
+    monkeypatch.setattr(collect_pr_digest, "gh_json", fake_gh_json)
+
+    rows = collect_pr_digest.fetch_prs(
+        "basher83/Zammad-MCP",
+        datetime(2026, 5, 1, 12, tzinfo=timezone.utc),
+        datetime(2026, 5, 2, 12, tzinfo=timezone.utc),
+        50,
+    )
+
+    check_equal([row["number"] for row in rows], [2, 3])
+
+
 def test_pr_triage_workflow_collects_fork_diff_without_running_pr_code() -> None:
     workflow = (REPO_ROOT / ".github/workflows/pr-triage.yml").read_text()
 
     check("pull_request_target:" in workflow, "PR workflow should use pull_request_target for label permissions")
     check("git fetch --no-tags" in workflow, "PR workflow should fetch fork heads for diff metadata")
     check("git diff --name-only" in workflow, "PR workflow should collect changed paths without running PR code")
-    check("steps.pr.outputs.is_fork != 'true'" in workflow, "Codex Action should not run on fork PRs")
+    check('git diff "$diff_base" "$head_sha"' not in workflow, "PR workflow should not export full patches")
+    check("changes.diff" not in workflow, "PR workflow should not pass full diffs to triage")
+    check("CODEX_OPENAI_API_KEY" not in workflow, "PR workflow should not expose LLM secrets in label job")
+    check("openai/codex-action" not in workflow, "PR workflow should be deterministic-only in v1")
+    check("--llm-output" not in workflow, "PR workflow should not depend on LLM output artifacts")
     check("gh pr comment" not in workflow, "PR workflow should not comment on source PRs")

--- a/.codex/skills/zammad-mcp-pr-digest/scripts/test_triage_pr.py
+++ b/.codex/skills/zammad-mcp-pr-digest/scripts/test_triage_pr.py
@@ -1,0 +1,177 @@
+# mypy: ignore-errors
+# ruff: noqa: PLR2004
+"""Tests for Zammad-MCP PR triage automation."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+SKILLS_DIR = SCRIPT_DIR.parents[1]
+COMMON_DIR = SKILLS_DIR / "zammad-mcp-issue-digest" / "scripts"
+REPO_ROOT = SCRIPT_DIR.parents[3]
+sys.path.insert(0, str(COMMON_DIR))
+sys.path.insert(0, str(SCRIPT_DIR))
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+triage_common = load_module("triage_common", COMMON_DIR / "triage_common.py")
+triage_pr = load_module("triage_pr", SCRIPT_DIR / "triage_pr.py")
+
+
+def check(value: bool, message: str) -> None:
+    if not value:
+        raise AssertionError(message)
+
+
+def check_equal(actual, expected) -> None:
+    if actual != expected:
+        raise AssertionError(f"Expected {expected!r}, got {actual!r}")
+
+
+def pr(number: int, title: str, author: str, body: str = "", state: str = "OPEN", labels=None, files=None):
+    return {
+        "number": number,
+        "title": title,
+        "body": body,
+        "state": state,
+        "author": {"login": author, "is_bot": author.startswith("app/")},
+        "labels": [{"name": label} for label in (labels or [])],
+        "files": [{"path": path} for path in (files or [])],
+        "reviewDecision": "",
+        "mergeable": "UNKNOWN",
+        "url": f"https://github.com/basher83/Zammad-MCP/pull/{number}",
+    }
+
+
+def test_pr_200_open_human_knowledgebase_gets_owner_review() -> None:
+    current = pr(
+        200,
+        "Feature/knowledge base crud",
+        "snizzleorg",
+        "Add knowledge base CRUD support.",
+        files=["mcp_zammad/server.py", "tests/test_server.py"],
+    )
+
+    decision = triage_common.classify_pr_payload(current).to_json()
+
+    check("type:feature" in decision["labels"], "knowledgebase PR should be a feature")
+    check("area:zammad-api" in decision["labels"], "knowledgebase PR should be zammad API")
+    check("needs:owner-review" in decision["labels"], "open human PR should need owner review")
+    check_equal(decision["state_summary"]["author_type"], "human")
+
+
+def test_renovate_docker_pr_gets_dependency_bot_and_docker_labels() -> None:
+    current = pr(
+        249,
+        "chore(deps): Update ghcr.io/astral-sh/uv:latest Docker digest to 3b7b60a",
+        "app/renovate",
+        files=["Dockerfile"],
+    )
+
+    decision = triage_common.classify_pr_payload(current).to_json()
+
+    check("dependencies" in decision["labels"], "Renovate PR should be dependency-labeled")
+    check("bot:renovate" in decision["labels"], "Renovate PR should be bot-labeled")
+    check("docker" in decision["labels"], "Docker digest PR should get docker label")
+
+
+def test_renovate_github_actions_pr_gets_github_actions_label() -> None:
+    current = pr(
+        254,
+        "chore(deps): Update GitHub Actions",
+        "app/renovate",
+        files=[".github/workflows/tests.yml"],
+    )
+
+    decision = triage_common.classify_pr_payload(current).to_json()
+
+    check("dependencies" in decision["labels"], "Renovate Actions PR should be dependency-labeled")
+    check("bot:renovate" in decision["labels"], "Renovate Actions PR should be bot-labeled")
+    check("github-actions" in decision["labels"], "Actions PR should get github-actions label")
+
+
+def test_dependabot_pr_gets_policy_drift_signal() -> None:
+    current = pr(
+        252,
+        "chore(deps): bump protobuf from 4.25.9 to 5.29.6 in the uv group across 1 directory",
+        "app/dependabot",
+        files=["uv.lock"],
+    )
+
+    decision = triage_common.classify_pr_payload(current).to_json()
+
+    check("dependencies" in decision["labels"], "Dependabot PR should be dependency-labeled")
+    check("bot:dependabot" in decision["labels"], "Dependabot PR should be bot-labeled")
+    check("needs:owner-review" in decision["labels"], "Dependabot routine PR should flag policy drift")
+    check_equal(decision["attention"], "owner")
+
+
+def test_pr_single_dry_run_uses_mocked_gh_payload(monkeypatch, capsys, tmp_path: Path) -> None:
+    changed_files = tmp_path / "changed-files.txt"
+    changed_files.write_text("mcp_zammad/server.py\n")
+
+    def fake_gh_json(args):
+        if args[0:2] == ["pr", "view"]:
+            return pr(200, "Feature/knowledge base crud", "snizzleorg", "Add knowledgebase CRUD.")
+        raise AssertionError(f"Unexpected gh args: {args}")
+
+    monkeypatch.setattr(triage_pr, "gh_json", fake_gh_json)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["triage_pr.py", "--pr", "200", "--changed-files", str(changed_files), "--dry-run", "--json"],
+    )
+
+    code = triage_pr.main()
+    captured = json.loads(capsys.readouterr().out)
+
+    check_equal(code, 0)
+    check_equal(captured["number"], 200)
+    check(captured["applied"] is False, "dry-run should not apply")
+    check("area:zammad-api" in captured["labels"], "mocked PR should classify")
+
+
+def test_pr_backfill_uses_mocked_open_pr_payloads(monkeypatch, capsys) -> None:
+    payloads = [
+        pr(200, "Feature/knowledge base crud", "snizzleorg", "Add knowledgebase CRUD."),
+        pr(249, "chore(deps): Update ghcr.io/astral-sh/uv Docker digest", "app/renovate", files=["Dockerfile"]),
+    ]
+
+    def fake_gh_json(args):
+        if args[0:2] == ["pr", "list"]:
+            return payloads
+        raise AssertionError(f"Unexpected gh args: {args}")
+
+    monkeypatch.setattr(triage_pr, "gh_json", fake_gh_json)
+    monkeypatch.setattr(sys, "argv", ["triage_pr.py", "--backfill", "--state", "open", "--dry-run", "--json"])
+
+    code = triage_pr.main()
+    captured = json.loads(capsys.readouterr().out)
+
+    check_equal(code, 0)
+    check_equal(captured["kind"], "pull_request_backfill")
+    check_equal(len(captured["results"]), 2)
+    check(captured["applied"] is False, "backfill dry-run should not apply")
+
+
+def test_pr_triage_workflow_collects_fork_diff_without_running_pr_code() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/pr-triage.yml").read_text()
+
+    check("pull_request_target:" in workflow, "PR workflow should use pull_request_target for label permissions")
+    check("git fetch --no-tags" in workflow, "PR workflow should fetch fork heads for diff metadata")
+    check("git diff --name-only" in workflow, "PR workflow should collect changed paths without running PR code")
+    check("steps.pr.outputs.is_fork != 'true'" in workflow, "Codex Action should not run on fork PRs")
+    check("gh pr comment" not in workflow, "PR workflow should not comment on source PRs")

--- a/.codex/skills/zammad-mcp-pr-digest/scripts/test_triage_pr.py
+++ b/.codex/skills/zammad-mcp-pr-digest/scripts/test_triage_pr.py
@@ -254,6 +254,8 @@ def test_pr_triage_workflow_collects_fork_diff_without_running_pr_code() -> None
     check("CODEX_OPENAI_API_KEY" not in workflow, "PR workflow should not expose LLM secrets in label job")
     check("openai/codex-action" not in workflow, "PR workflow should be deterministic-only in v1")
     check("--llm-output" not in workflow, "PR workflow should not depend on LLM output artifacts")
+    check("default: false" in workflow, "manual PR triage should default to dry-run")
     check("inputs.apply || true" not in workflow, "explicit manual dry-run should not be coerced to apply")
     check('INPUT_APPLY="${INPUT_APPLY:-true}"' in workflow, "PR workflow should default missing apply input in shell")
+    check("pr-context.json" not in workflow, "PR workflow should not fetch unused context artifacts")
     check("gh pr comment" not in workflow, "PR workflow should not comment on source PRs")

--- a/.codex/skills/zammad-mcp-pr-digest/scripts/triage_pr.py
+++ b/.codex/skills/zammad-mcp-pr-digest/scripts/triage_pr.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# mypy: ignore-errors
+# ruff: noqa: PLR2004
+"""Triage Zammad-MCP GitHub pull requests and apply controlled labels."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SKILLS_DIR = Path(__file__).resolve().parents[2]
+COMMON_DIR = SKILLS_DIR / "zammad-mcp-issue-digest" / "scripts"
+sys.path.insert(0, str(COMMON_DIR))
+
+from triage_common import (  # noqa: E402
+    DEFAULT_REPO,
+    GhCommandError,
+    apply_labels,
+    classify_pr_payload,
+    gh_json,
+    load_optional_json,
+)
+
+PR_FIELDS = (
+    "number,title,body,state,author,labels,comments,createdAt,updatedAt,closedAt,mergedAt,"
+    "isDraft,reviewDecision,headRefName,baseRefName,url,mergeable,statusCheckRollup,files"
+)
+PR_LIST_FIELDS = (
+    "number,title,state,author,labels,comments,createdAt,updatedAt,closedAt,mergedAt,"
+    "isDraft,reviewDecision,headRefName,baseRefName,url,mergeable,statusCheckRollup,files"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Apply Zammad-MCP PR triage labels.")
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--pr", type=int, help="Pull request number to triage")
+    target.add_argument("--backfill", action="store_true", help="Triage multiple PRs")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="Do not apply labels")
+    mode.add_argument("--apply", action="store_true", help="Apply labels through gh")
+    parser.add_argument("--state", choices=["open", "closed", "merged", "all"], default="open")
+    parser.add_argument("--limit", type=int, default=100)
+    parser.add_argument("--changed-files", help="Optional newline-delimited changed-files path")
+    parser.add_argument("--llm-output", help="Optional Codex/LLM JSON output with a labels array")
+    parser.add_argument("--json", action="store_true", help="Emit JSON only")
+    return parser.parse_args()
+
+
+def read_changed_files(path: str | None) -> list[str] | None:
+    if not path:
+        return None
+    candidate = Path(path)
+    if not candidate.exists():
+        return None
+    return [line.strip() for line in candidate.read_text().splitlines() if line.strip()]
+
+
+def fetch_pr(repo: str, number: int) -> dict[str, Any]:
+    payload = gh_json(["pr", "view", str(number), "--repo", repo, "--json", PR_FIELDS])
+    if not isinstance(payload, dict):
+        raise GhCommandError(f"Unexpected PR payload for #{number}")
+    return payload
+
+
+def fetch_pr_list(repo: str, state: str, limit: int) -> list[dict[str, Any]]:
+    payload = gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            state,
+            "--limit",
+            str(limit),
+            "--json",
+            PR_LIST_FIELDS,
+        ]
+    )
+    if not isinstance(payload, list):
+        raise GhCommandError("Unexpected PR list payload")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def process_pr(
+    pr: dict[str, Any],
+    *,
+    repo: str,
+    apply: bool,
+    changed_files: list[str] | None = None,
+    llm_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    decision = classify_pr_payload(pr, changed_files=changed_files, llm_payload=llm_payload)
+    if apply:
+        apply_labels(repo, decision.number, decision.labels, kind="pull_request")
+    out = decision.to_json()
+    out["applied"] = bool(apply)
+    out["url"] = pr.get("url")
+    return out
+
+
+def output_payload(payload: dict[str, Any], *, json_only: bool) -> None:
+    if json_only:
+        sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        return
+    if payload.get("mode") == "backfill":
+        count = len(payload.get("results") or [])
+        sys.stdout.write(f"Triage decisions for {count} PRs:\n")
+        for item in payload.get("results") or []:
+            sys.stdout.write(f"- #{item['number']}: {', '.join(item['labels'])}\n")
+        return
+    sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def main() -> int:
+    args = parse_args()
+    apply = bool(args.apply)
+    llm_payload = load_optional_json(args.llm_output)
+    changed_files = read_changed_files(args.changed_files)
+    try:
+        if args.pr:
+            pr = fetch_pr(args.repo, args.pr)
+            payload = process_pr(
+                pr,
+                repo=args.repo,
+                apply=apply,
+                changed_files=changed_files,
+                llm_payload=llm_payload,
+            )
+        else:
+            prs = fetch_pr_list(args.repo, args.state, args.limit)
+            payload = {
+                "repo": args.repo,
+                "kind": "pull_request_backfill",
+                "mode": "backfill",
+                "state": args.state,
+                "applied": apply,
+                "results": [process_pr(pr, repo=args.repo, apply=apply) for pr in prs],
+            }
+    except (GhCommandError, RuntimeError, ValueError) as err:
+        sys.stderr.write(f"triage_pr.py error: {err}\n")
+        return 1
+
+    output_payload(payload, json_only=args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/zammad-mcp-pr-digest/scripts/triage_pr.py
+++ b/.codex/skills/zammad-mcp-pr-digest/scripts/triage_pr.py
@@ -29,7 +29,7 @@ PR_FIELDS = (
     "isDraft,reviewDecision,headRefName,baseRefName,url,mergeable,statusCheckRollup,files"
 )
 PR_LIST_FIELDS = (
-    "number,title,state,author,labels,comments,createdAt,updatedAt,closedAt,mergedAt,"
+    "number,title,body,state,author,labels,comments,createdAt,updatedAt,closedAt,mergedAt,"
     "isDraft,reviewDecision,headRefName,baseRefName,url,mergeable,statusCheckRollup,files"
 )
 
@@ -120,6 +120,9 @@ def output_payload(payload: dict[str, Any], *, json_only: bool) -> None:
 def main() -> int:
     args = parse_args()
     apply = bool(args.apply)
+    if args.backfill and (args.llm_output or args.changed_files):
+        sys.stderr.write("triage_pr.py error: --backfill does not support --llm-output or --changed-files\n")
+        return 1
     llm_payload = load_optional_json(args.llm_output)
     changed_files = read_changed_files(args.changed_files)
     try:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -20,7 +20,7 @@ on:
       apply:
         description: "Apply labels. Disable for dry-run."
         required: false
-        default: true
+        default: false
         type: boolean
 
 permissions:
@@ -70,11 +70,12 @@ jobs:
       - name: Apply issue triage labels
         env:
           EVENT_NAME: ${{ github.event_name }}
-          INPUT_APPLY: ${{ inputs.apply || true }}
+          INPUT_APPLY: ${{ inputs.apply }}
           ISSUE_NUMBER: ${{ steps.target.outputs.issue_number }}
           BACKFILL: ${{ steps.target.outputs.backfill }}
         run: |
           set -euo pipefail
+          INPUT_APPLY="${INPUT_APPLY:-false}"
           mode="--apply"
           if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$INPUT_APPLY" != "true" ]; then
             mode="--dry-run"

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,135 @@
+name: Issue Triage
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to triage. Leave empty when backfill is true."
+        required: false
+        type: string
+      backfill:
+        description: "Backfill labels across open issues."
+        required: false
+        default: false
+        type: boolean
+      apply:
+        description: "Apply labels. Disable for dry-run."
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  issue-triage:
+    if: github.repository == 'basher83/Zammad-MCP'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      CODEX_OPENAI_API_KEY: ${{ secrets.CODEX_OPENAI_API_KEY }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Resolve issue target
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ISSUE_NUMBER: ${{ github.event.issue.number || '' }}
+          INPUT_ISSUE_NUMBER: ${{ inputs.issue_number || '' }}
+          INPUT_BACKFILL: ${{ inputs.backfill || false }}
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp/triage
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$INPUT_BACKFILL" = "true" ]; then
+            echo "backfill=true" >> "$GITHUB_OUTPUT"
+            echo "issue_number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          issue_number="$EVENT_ISSUE_NUMBER"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            issue_number="$INPUT_ISSUE_NUMBER"
+          fi
+          if [ -z "$issue_number" ]; then
+            echo "Issue number is required unless backfill is true."
+            exit 1
+          fi
+          gh issue view "$issue_number" --repo "$GITHUB_REPOSITORY" \
+            --json number,title,body,author,labels,state,comments \
+            > .tmp/triage/issue-context.json
+          echo "backfill=false" >> "$GITHUB_OUTPUT"
+          echo "issue_number=$issue_number" >> "$GITHUB_OUTPUT"
+
+      - name: Codex label suggestion
+        id: codex
+        if: env.CODEX_OPENAI_API_KEY != '' && steps.target.outputs.backfill != 'true'
+        uses: openai/codex-action@5c3f4ccdb2b8790f73d6b21751ac00e602aa0c02 # v1.7
+        with:
+          openai-api-key: ${{ env.CODEX_OPENAI_API_KEY }}
+          allow-users: "*"
+          prompt: |
+            You are triaging one GitHub issue for basher83/Zammad-MCP.
+
+            Read .tmp/triage/issue-context.json and return only labels from this list:
+            type:bug, type:feature, type:docs, type:security, type:performance, type:chore,
+            dependencies, area:python, area:web, area:docs, area:ci-cd, area:security,
+            area:infra, area:mcp-tools, area:zammad-api, area:transport, needs:owner-review,
+            needs:repro, needs:info, needs:duplicate-review, bot:renovate, bot:dependabot,
+            renovate, docker, github-actions, python:uv, security.
+
+            Prefer false negatives over broad labels. Do not suggest closing or commenting.
+          output-schema: |
+            {
+              "type": "object",
+              "properties": {
+                "labels": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              },
+              "required": ["labels"],
+              "additionalProperties": false
+            }
+
+      - name: Save Codex output
+        if: steps.codex.outputs['final-message'] != ''
+        env:
+          CODEX_OUTPUT: ${{ steps.codex.outputs['final-message'] }}
+        run: |
+          printf '%s\n' "$CODEX_OUTPUT" > .tmp/triage/issue-llm.json
+
+      - name: Apply issue triage labels
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_APPLY: ${{ inputs.apply || true }}
+          ISSUE_NUMBER: ${{ steps.target.outputs.issue_number }}
+          BACKFILL: ${{ steps.target.outputs.backfill }}
+        run: |
+          set -euo pipefail
+          mode="--apply"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$INPUT_APPLY" != "true" ]; then
+            mode="--dry-run"
+          fi
+          if [ "$BACKFILL" = "true" ]; then
+            python3 .codex/skills/zammad-mcp-issue-digest/scripts/triage_issue.py \
+              --repo "$GITHUB_REPOSITORY" \
+              --backfill \
+              --state open \
+              "$mode" \
+              --json
+          else
+            python3 .codex/skills/zammad-mcp-issue-digest/scripts/triage_issue.py \
+              --repo "$GITHUB_REPOSITORY" \
+              --issue "$ISSUE_NUMBER" \
+              --llm-output .tmp/triage/issue-llm.json \
+              "$mode" \
+              --json
+          fi

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -47,7 +47,6 @@ jobs:
           INPUT_BACKFILL: ${{ inputs.backfill || false }}
         run: |
           set -euo pipefail
-          mkdir -p .tmp/triage
           if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$INPUT_BACKFILL" = "true" ]; then
             echo "backfill=true" >> "$GITHUB_OUTPUT"
             echo "issue_number=" >> "$GITHUB_OUTPUT"
@@ -61,9 +60,6 @@ jobs:
             echo "Issue number is required unless backfill is true."
             exit 1
           fi
-          gh issue view "$issue_number" --repo "$GITHUB_REPOSITORY" \
-            --json number,title,body,author,labels,state,comments \
-            > .tmp/triage/issue-context.json
           echo "backfill=false" >> "$GITHUB_OUTPUT"
           echo "issue_number=$issue_number" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -33,7 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
-      CODEX_OPENAI_API_KEY: ${{ secrets.CODEX_OPENAI_API_KEY }}
 
     steps:
       - name: Checkout repository
@@ -68,44 +67,6 @@ jobs:
           echo "backfill=false" >> "$GITHUB_OUTPUT"
           echo "issue_number=$issue_number" >> "$GITHUB_OUTPUT"
 
-      - name: Codex label suggestion
-        id: codex
-        if: env.CODEX_OPENAI_API_KEY != '' && steps.target.outputs.backfill != 'true'
-        uses: openai/codex-action@5c3f4ccdb2b8790f73d6b21751ac00e602aa0c02 # v1.7
-        with:
-          openai-api-key: ${{ env.CODEX_OPENAI_API_KEY }}
-          allow-users: "*"
-          prompt: |
-            You are triaging one GitHub issue for basher83/Zammad-MCP.
-
-            Read .tmp/triage/issue-context.json and return only labels from this list:
-            type:bug, type:feature, type:docs, type:security, type:performance, type:chore,
-            dependencies, area:python, area:web, area:docs, area:ci-cd, area:security,
-            area:infra, area:mcp-tools, area:zammad-api, area:transport, needs:owner-review,
-            needs:repro, needs:info, needs:duplicate-review, bot:renovate, bot:dependabot,
-            renovate, docker, github-actions, python:uv, security.
-
-            Prefer false negatives over broad labels. Do not suggest closing or commenting.
-          output-schema: |
-            {
-              "type": "object",
-              "properties": {
-                "labels": {
-                  "type": "array",
-                  "items": { "type": "string" }
-                }
-              },
-              "required": ["labels"],
-              "additionalProperties": false
-            }
-
-      - name: Save Codex output
-        if: steps.codex.outputs['final-message'] != ''
-        env:
-          CODEX_OUTPUT: ${{ steps.codex.outputs['final-message'] }}
-        run: |
-          printf '%s\n' "$CODEX_OUTPUT" > .tmp/triage/issue-llm.json
-
       - name: Apply issue triage labels
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -129,7 +90,6 @@ jobs:
             python3 .codex/skills/zammad-mcp-issue-digest/scripts/triage_issue.py \
               --repo "$GITHUB_REPOSITORY" \
               --issue "$ISSUE_NUMBER" \
-              --llm-output .tmp/triage/issue-llm.json \
               "$mode" \
               --json
           fi

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,0 +1,143 @@
+name: PR Triage
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to triage."
+        required: true
+        type: string
+      apply:
+        description: "Apply labels. Disable for dry-run."
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  pr-triage:
+    if: github.repository == 'basher83/Zammad-MCP'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      CODEX_OPENAI_API_KEY: ${{ secrets.CODEX_OPENAI_API_KEY }}
+
+    steps:
+      - name: Checkout base repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve PR context
+        id: pr
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || '' }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number || '' }}
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp/triage
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            pr_number="$INPUT_PR_NUMBER"
+            gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json title,body \
+              > .tmp/triage/pr-context.json
+            gh pr diff "$pr_number" --repo "$GITHUB_REPOSITORY" --name-only \
+              > .tmp/triage/changed-files.txt
+            gh pr diff "$pr_number" --repo "$GITHUB_REPOSITORY" \
+              > .tmp/triage/changes.diff
+            echo "is_fork=unknown" >> "$GITHUB_OUTPUT"
+          else
+            pr_number="$EVENT_PR_NUMBER"
+            head_repo="$EVENT_HEAD_REPO"
+            head_sha="$EVENT_HEAD_SHA"
+            base_sha="$EVENT_BASE_SHA"
+            gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json title,body \
+              > .tmp/triage/pr-context.json
+            git fetch --no-tags --prune --recurse-submodules=no \
+              "https://github.com/${head_repo}.git" \
+              "$head_sha"
+            diff_base="$(git merge-base "$base_sha" "$head_sha")"
+            git diff --name-only "$diff_base" "$head_sha" > .tmp/triage/changed-files.txt
+            git diff "$diff_base" "$head_sha" > .tmp/triage/changes.diff
+            if [ "$head_repo" = "$GITHUB_REPOSITORY" ]; then
+              echo "is_fork=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "is_fork=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Codex label suggestion
+        id: codex
+        if: env.CODEX_OPENAI_API_KEY != '' && steps.pr.outputs.is_fork != 'true'
+        uses: openai/codex-action@5c3f4ccdb2b8790f73d6b21751ac00e602aa0c02 # v1.7
+        with:
+          openai-api-key: ${{ env.CODEX_OPENAI_API_KEY }}
+          allow-users: "*"
+          prompt: |
+            You are triaging one pull request for basher83/Zammad-MCP.
+
+            Inputs:
+            - .tmp/triage/pr-context.json
+            - .tmp/triage/changed-files.txt
+            - .tmp/triage/changes.diff
+
+            Return only labels from this list:
+            type:bug, type:feature, type:docs, type:security, type:performance, type:chore,
+            dependencies, area:python, area:web, area:docs, area:ci-cd, area:security,
+            area:infra, area:mcp-tools, area:zammad-api, area:transport, needs:owner-review,
+            needs:repro, needs:info, needs:duplicate-review, bot:renovate, bot:dependabot,
+            renovate, docker, github-actions, python:uv, security.
+
+            Prefer the smallest accurate set. Do not suggest closing, merging, or commenting.
+          output-schema: |
+            {
+              "type": "object",
+              "properties": {
+                "labels": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              },
+              "required": ["labels"],
+              "additionalProperties": false
+            }
+
+      - name: Save Codex output
+        if: steps.codex.outputs['final-message'] != ''
+        env:
+          CODEX_OUTPUT: ${{ steps.codex.outputs['final-message'] }}
+        run: |
+          printf '%s\n' "$CODEX_OUTPUT" > .tmp/triage/pr-llm.json
+
+      - name: Apply PR triage labels
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_APPLY: ${{ inputs.apply || true }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          mode="--apply"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$INPUT_APPLY" != "true" ]; then
+            mode="--dry-run"
+          fi
+          python3 .codex/skills/zammad-mcp-pr-digest/scripts/triage_pr.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --pr "$PR_NUMBER" \
+            --changed-files .tmp/triage/changed-files.txt \
+            --llm-output .tmp/triage/pr-llm.json \
+            "$mode" \
+            --json

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -79,10 +79,11 @@ jobs:
       - name: Apply PR triage labels
         env:
           EVENT_NAME: ${{ github.event_name }}
-          INPUT_APPLY: ${{ inputs.apply || true }}
+          INPUT_APPLY: ${{ inputs.apply }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
         run: |
           set -euo pipefail
+          INPUT_APPLY="${INPUT_APPLY:-true}"
           mode="--apply"
           if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$INPUT_APPLY" != "true" ]; then
             mode="--dry-run"

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -16,7 +16,7 @@ on:
       apply:
         description: "Apply labels. Disable for dry-run."
         required: false
-        default: true
+        default: false
         type: boolean
 
 permissions:
@@ -51,8 +51,6 @@ jobs:
           mkdir -p .tmp/triage
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             pr_number="$INPUT_PR_NUMBER"
-            gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json title,body \
-              > .tmp/triage/pr-context.json
             gh pr diff "$pr_number" --repo "$GITHUB_REPOSITORY" --name-only \
               > .tmp/triage/changed-files.txt
             echo "is_fork=unknown" >> "$GITHUB_OUTPUT"
@@ -61,8 +59,6 @@ jobs:
             head_repo="$EVENT_HEAD_REPO"
             head_sha="$EVENT_HEAD_SHA"
             base_sha="$EVENT_BASE_SHA"
-            gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json title,body \
-              > .tmp/triage/pr-context.json
             git fetch --no-tags --prune --recurse-submodules=no \
               "https://github.com/${head_repo}.git" \
               "$head_sha"

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -30,7 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
-      CODEX_OPENAI_API_KEY: ${{ secrets.CODEX_OPENAI_API_KEY }}
 
     steps:
       - name: Checkout base repository
@@ -56,8 +55,6 @@ jobs:
               > .tmp/triage/pr-context.json
             gh pr diff "$pr_number" --repo "$GITHUB_REPOSITORY" --name-only \
               > .tmp/triage/changed-files.txt
-            gh pr diff "$pr_number" --repo "$GITHUB_REPOSITORY" \
-              > .tmp/triage/changes.diff
             echo "is_fork=unknown" >> "$GITHUB_OUTPUT"
           else
             pr_number="$EVENT_PR_NUMBER"
@@ -71,7 +68,6 @@ jobs:
               "$head_sha"
             diff_base="$(git merge-base "$base_sha" "$head_sha")"
             git diff --name-only "$diff_base" "$head_sha" > .tmp/triage/changed-files.txt
-            git diff "$diff_base" "$head_sha" > .tmp/triage/changes.diff
             if [ "$head_repo" = "$GITHUB_REPOSITORY" ]; then
               echo "is_fork=false" >> "$GITHUB_OUTPUT"
             else
@@ -79,49 +75,6 @@ jobs:
             fi
           fi
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
-
-      - name: Codex label suggestion
-        id: codex
-        if: env.CODEX_OPENAI_API_KEY != '' && steps.pr.outputs.is_fork != 'true'
-        uses: openai/codex-action@5c3f4ccdb2b8790f73d6b21751ac00e602aa0c02 # v1.7
-        with:
-          openai-api-key: ${{ env.CODEX_OPENAI_API_KEY }}
-          allow-users: "*"
-          prompt: |
-            You are triaging one pull request for basher83/Zammad-MCP.
-
-            Inputs:
-            - .tmp/triage/pr-context.json
-            - .tmp/triage/changed-files.txt
-            - .tmp/triage/changes.diff
-
-            Return only labels from this list:
-            type:bug, type:feature, type:docs, type:security, type:performance, type:chore,
-            dependencies, area:python, area:web, area:docs, area:ci-cd, area:security,
-            area:infra, area:mcp-tools, area:zammad-api, area:transport, needs:owner-review,
-            needs:repro, needs:info, needs:duplicate-review, bot:renovate, bot:dependabot,
-            renovate, docker, github-actions, python:uv, security.
-
-            Prefer the smallest accurate set. Do not suggest closing, merging, or commenting.
-          output-schema: |
-            {
-              "type": "object",
-              "properties": {
-                "labels": {
-                  "type": "array",
-                  "items": { "type": "string" }
-                }
-              },
-              "required": ["labels"],
-              "additionalProperties": false
-            }
-
-      - name: Save Codex output
-        if: steps.codex.outputs['final-message'] != ''
-        env:
-          CODEX_OUTPUT: ${{ steps.codex.outputs['final-message'] }}
-        run: |
-          printf '%s\n' "$CODEX_OUTPUT" > .tmp/triage/pr-llm.json
 
       - name: Apply PR triage labels
         env:
@@ -138,6 +91,5 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --pr "$PR_NUMBER" \
             --changed-files .tmp/triage/changed-files.txt \
-            --llm-output .tmp/triage/pr-llm.json \
             "$mode" \
             --json

--- a/.github/workflows/triage-digest.yml
+++ b/.github/workflows/triage-digest.yml
@@ -1,0 +1,73 @@
+name: Triage Digest
+
+on:
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+    inputs:
+      window:
+        description: "Digest lookback window."
+        required: false
+        default: "30d"
+        type: string
+      apply:
+        description: "Post to tracking issue. Disable for dry-run."
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  triage-digest:
+    if: github.repository == 'basher83/Zammad-MCP'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Collect issue and PR digests
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_WINDOW: ${{ inputs.window || '30d' }}
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp/triage
+          window="$INPUT_WINDOW"
+          if [ "$EVENT_NAME" != "workflow_dispatch" ]; then
+            window="30d"
+          fi
+          python3 .codex/skills/zammad-mcp-issue-digest/scripts/collect_issue_digest.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --all-labels \
+            --window "$window" \
+            --limit-issues 200 \
+            > .tmp/triage/issues.json
+          python3 .codex/skills/zammad-mcp-pr-digest/scripts/collect_pr_digest.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --window "$window" \
+            --limit-prs 250 \
+            > .tmp/triage/prs.json
+
+      - name: Post tracking digest
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_APPLY: ${{ inputs.apply || true }}
+        run: |
+          set -euo pipefail
+          mode="--apply"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$INPUT_APPLY" != "true" ]; then
+            mode="--dry-run"
+          fi
+          python3 .codex/skills/zammad-mcp-issue-digest/scripts/post_triage_digest.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --issue-digest .tmp/triage/issues.json \
+            --pr-digest .tmp/triage/prs.json \
+            "$mode" \
+            --json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-minimum_prek_version: "0.2.0"
+minimum_pre_commit_version: "4.5.1"
 
 default_install_hook_types:
   - pre-commit
@@ -12,7 +12,7 @@ repos:
     rev: 0.9.2
     hooks:
       - id: uv-sync
-        
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "f8a3f8c471fb698229face5ed7640a64900b781e"  # v0.4.4
     hooks:


### PR DESCRIPTION
## Summary

This PR adds the repository-specific triage automation discussed for Zammad-MCP. It introduces local Codex skills for issue and PR triage, deterministic classifiers with optional LLM label suggestions, dry-run/apply CLIs, duplicate-candidate reporting, and a combined maintainer digest poster.

It also wires those scripts into GitHub Actions for labels-only issue triage, fork-safe PR triage from `pull_request_target` metadata and diffs, and a weekly/manual tracking digest issue titled `[triage] Zammad-MCP maintainer digest`.

The final commit also normalizes the hook config from `minimum_prek_version` to `minimum_pre_commit_version` so both `pre-commit` and `prek` run without the config warning.

## Validation

- `uv run pytest .codex/skills/zammad-mcp-issue-digest/scripts/test_collect_issue_digest.py .codex/skills/zammad-mcp-issue-digest/scripts/test_triage_issue.py .codex/skills/zammad-mcp-pr-digest/scripts/test_triage_pr.py`
- `pre-commit run` during each commit
- `pre-commit run --files .pre-commit-config.yaml`
- `prek run --files .pre-commit-config.yaml`
- Live dry-runs against issue #212 and PR #200 before committing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated issue and PR triage + digest tooling with maintainer-focused summaries, attention scoring, ranked hot items, CLIs to collect/post digests and triage items, and GitHub Actions for event-driven triage and scheduled digests.

* **Documentation**
  * Added maintainer-facing skill docs describing digest/triage behavior, outputs, and validation commands.

* **Tests**
  * Added regression/unit tests covering collectors, triage logic, PR workflows, and safety constraints.

* **Bug Fixes**
  * Fixed pre-commit minimum version declaration.

* **Chores**
  * Extended tool exclusions for generated artifacts and disabled automatic label suggestions/apply in review config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->