### PR TITLE
fix: don't HTML-escape quotes/apostrophes in plain-text article/ticket content

### DIFF
--- a/mcp_zammad/models.py
+++ b/mcp_zammad/models.py
@@ -269,8 +269,12 @@ class TicketCreate(StrictBaseModel):
     @field_validator("title", "article_body")
     @classmethod
     def sanitize_html(cls, v: str) -> str:
-        """Escape HTML to prevent XSS attacks."""
-        return html.escape(v)
+        """Escape HTML to prevent XSS attacks.
+
+        quote=False: title and the initial article are plain text (no content_type choice here),
+        sent/stored verbatim, so quotes and apostrophes must not become &#x27;/&quot; entities.
+        """
+        return html.escape(v, quote=False)
 
 
 class TicketUpdate(StrictBaseModel):
@@ -341,7 +345,10 @@ class ArticleCreate(StrictBaseModel):
     def sanitize_body(self) -> "ArticleCreate":
         """Sanitize body content according to content type."""
         if self.content_type == "text/plain":
-            self.body = html.escape(self.body)
+            # quote=False: plain text is sent/stored verbatim (e.g. in outbound emails), so quotes
+            # and apostrophes must not be turned into &#x27;/&quot; entities. Still neutralize
+            # <, >, & in case a downstream renderer treats the body as HTML despite the content type.
+            self.body = html.escape(self.body, quote=False)
         else:
             self.body = self._sanitize_html_body(self.body)
         return self

--- a/mcp_zammad/models.py
+++ b/mcp_zammad/models.py
@@ -293,7 +293,7 @@ class TicketUpdate(StrictBaseModel):
     @classmethod
     def sanitize_title(cls, v: str | None) -> str | None:
         """Escape HTML to prevent XSS attacks."""
-        return html.escape(v) if v else v
+        return html.escape(v, quote=False) if v else v
 
 
 class TicketSearchParams(StrictBaseModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,7 +26,7 @@ class TestTicketCreate:
             customer="test@example.com",
             article_body="Test body",
         )
-        assert ticket.title == "&lt;script&gt;alert(&#x27;XSS&#x27;)&lt;/script&gt;"
+        assert ticket.title == "&lt;script&gt;alert('XSS')&lt;/script&gt;"
 
     def test_html_sanitization_in_body(self):
         """Test that HTML is escaped in article body."""
@@ -36,7 +36,7 @@ class TestTicketCreate:
             customer="test@example.com",
             article_body="<b>Bold</b> and <script>alert('XSS')</script>",
         )
-        assert ticket.article_body == "&lt;b&gt;Bold&lt;/b&gt; and &lt;script&gt;alert(&#x27;XSS&#x27;)&lt;/script&gt;"
+        assert ticket.article_body == "&lt;b&gt;Bold&lt;/b&gt; and &lt;script&gt;alert('XSS')&lt;/script&gt;"
 
     def test_field_length_limits(self):
         """Test that field length limits are enforced."""
@@ -74,12 +74,17 @@ class TestArticleCreate:
     """Test ArticleCreate model validation."""
 
     def test_html_sanitization_in_body(self):
-        """Test that HTML is escaped in article body."""
+        """Test that HTML is escaped in article body, but quotes/apostrophes are left intact.
+
+        text/plain bodies are sent verbatim (e.g. in outbound emails), so quotes must not
+        become &#x27;/&quot; entities. <, >, & are still escaped, which already neutralizes
+        the tag regardless of the quote style used inside it.
+        """
         article = ArticleCreate(
             ticket_id=123,
             body="<div onclick='alert()'>Click me</div>",
         )
-        assert article.body == "&lt;div onclick=&#x27;alert()&#x27;&gt;Click me&lt;/div&gt;"
+        assert article.body == "&lt;div onclick='alert()'&gt;Click me&lt;/div&gt;"
 
     def test_ticket_id_validation(self):
         """Test that ticket_id must be positive."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -58,6 +58,11 @@ class TestTicketUpdate:
         update = TicketUpdate(title="<i>Important</i> Update")  # type: ignore[call-arg]
         assert update.title == "&lt;i&gt;Important&lt;/i&gt; Update"
 
+    def test_quotes_preserved_in_plain_text_title(self):
+        """Test that quotes remain literal while HTML-sensitive characters are escaped."""
+        update = TicketUpdate(title='<i>Say "hi", it\'s AT&T</i>')  # type: ignore[call-arg]
+        assert update.title == '&lt;i&gt;Say "hi", it\'s AT&amp;T&lt;/i&gt;'
+
     def test_none_title_not_sanitized(self):
         """Test that None title is not processed."""
         update = TicketUpdate(state="closed")  # type: ignore[call-arg]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -627,6 +627,9 @@ def test_add_article_content_type_validation() -> None:
     plain_article = ArticleCreate(ticket_id=1, body="<p>plain</p>", content_type="text/plain")
     assert plain_article.body == "&lt;p&gt;plain&lt;/p&gt;"
 
+    apostrophe_article = ArticleCreate(ticket_id=1, body="we've got it, you'd agree", content_type="text/plain")
+    assert apostrophe_article.body == "we've got it, you'd agree"
+
     with pytest.raises(ValidationError, match="content_type"):
         ArticleCreate(ticket_id=1, body="test", content_type="application/json")  # type: ignore[arg-type]
 


### PR DESCRIPTION
## Summary

- `ArticleCreate.sanitize_body` (for `text/plain` articles added via `zammad_add_article`) and `TicketCreate.sanitize_html` (title + initial article body via `zammad_create_ticket`) both called `html.escape()` with its default `quote=True`, which turns `'` into `&#x27;` and `"` into `&quot;`.
- That's intended as defense-in-depth against HTML injection, but plain-text content is sent/stored verbatim by Zammad (e.g. in outbound emails) — there's no HTML decoding step downstream. The result: ordinary apostrophes like "we've"/"you'd" show up literally as `&#x27;` in the actual sent email, even though `content_type` is `text/plain` (the default).
- Fix: keep escaping `<`, `>`, `&` for defense-in-depth, but stop escaping quotes (`html.escape(v, quote=False)`) for plain-text content.

## Test plan

- [x] `uv run pytest` — full suite passes (222 passed)
- [x] `uv run ruff check` / `uv run mypy` — clean
- [x] Updated existing tests (`test_html_sanitization_in_title`, `test_html_sanitization_in_body` in both `tests/test_models.py` and the `ArticleCreate` equivalent in `tests/test_server.py`) to assert quotes are preserved while `<`/`>` remain escaped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sanitization for ticket creation, ticket updates, and article creation.
  * Quotation marks and apostrophes are now preserved as entered instead of being converted into HTML entities.
  * HTML-sensitive characters such as `<`, `>`, and `&` continue to be escaped for safer content handling.
  * Plain-text article content now preserves apostrophes consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->