### PR TITLE
fix(prompts): accept string arguments for ticket_id

### DIFF
--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -2623,7 +2623,7 @@ class ZammadMCPServer:
         """Register all prompts with the MCP server."""
 
         @self.mcp.prompt()
-        def analyze_ticket(ticket_id: int) -> str:
+        def analyze_ticket(ticket_id: str) -> str:
             """Generate a prompt to analyze a ticket.
 
             Note: ticket_id must be the internal database ID (NOT the display number).
@@ -2642,7 +2642,7 @@ After retrieving the ticket, provide:
 Use appropriate tools to gather any additional context about the customer or organization if needed."""
 
         @self.mcp.prompt()
-        def draft_response(ticket_id: int, tone: str = "professional") -> str:
+        def draft_response(ticket_id: str, tone: str = "professional") -> str:
             """Generate a prompt to draft a response to a ticket.
 
             Note: ticket_id must be the internal database ID (NOT the display number).

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -233,6 +233,28 @@ async def test_prompts():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name,arguments",
+    [
+        ("analyze_ticket", {"ticket_id": "$1"}),
+        ("draft_response", {"ticket_id": "$1", "tone": "$2"}),
+        ("escalation_summary", {"group": "$1"}),
+    ],
+)
+async def test_prompts_render_with_non_numeric_arguments(name: str, arguments: dict[str, str]) -> None:
+    """Prompt arguments arrive as strings, so they must not be coerced to int.
+
+    Clients that turn MCP prompts into slash commands render them with placeholder
+    values such as "$1" to discover their arguments. Annotating ticket_id as int made
+    FastMCP raise PromptError on those placeholders, so the prompts were unusable.
+    """
+    result = await mcp.render_prompt(name, arguments)
+
+    rendered = result.messages[0].content.text  # type: ignore[union-attr]
+    assert "$1" in rendered
+
+
+@pytest.mark.asyncio
 async def test_initialization_failure():
     """Test that initialization handles failures gracefully."""
     with patch("mcp_zammad.server.ZammadClient") as mock_client_class:
@@ -1579,13 +1601,13 @@ def test_prompt_handlers(decorator_capturer):
 
     # Test analyze_ticket prompt
     assert "analyze_ticket" in test_prompts
-    result = test_prompts["analyze_ticket"](ticket_id=123)
+    result = test_prompts["analyze_ticket"](ticket_id="123")
     assert "analyze ticket with ID 123" in result
     assert "get_ticket tool" in result
 
     # Test draft_response prompt
     assert "draft_response" in test_prompts
-    result = test_prompts["draft_response"](ticket_id=123, tone="friendly")
+    result = test_prompts["draft_response"](ticket_id="123", tone="friendly")
     assert "draft a friendly response to ticket with ID 123" in result
     assert "add_article" in result
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -234,7 +234,7 @@ async def test_prompts():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "name,arguments",
+    ("name", "arguments"),
     [
         ("analyze_ticket", {"ticket_id": "$1"}),
         ("draft_response", {"ticket_id": "$1", "tone": "$2"}),


### PR DESCRIPTION
## Problem

`analyze_ticket` and `draft_response` annotate `ticket_id` as `int`:

```python
def analyze_ticket(ticket_id: int) -> str:
def draft_response(ticket_id: int, tone: str = "professional") -> str:
```

MCP prompt arguments are always transmitted as **strings** — `PromptArgument` has no type field. FastMCP's `_convert_string_arguments` (`fastmcp/prompts/function_prompt.py`) therefore coerces the incoming value to the annotation via pydantic, and any non-numeric string raises `PromptError` instead of rendering.

Clients that materialize MCP prompts into slash commands discover their arguments by rendering them with placeholder values. opencode issues `prompts/get` with `"$1"` / `"$2"`, which fails:

```
PromptError: Could not convert argument 'ticket_id' with value '$1' to expected
type <class 'int'>. Error: 1 validation error for int
  Input should be a valid integer, unable to parse string as an integer
  [type=int_parsing, input_value='$1', input_type=str]
```

The result is that both prompts are unusable in such clients. `escalation_summary` is unaffected because `group` is annotated `str | None`, which is a useful control: it renders the same `"$1"` fine.

For context on how noisy this is in practice — my local logs carry 896 occurrences of this error, two per session across 448 sessions.

## Fix

Annotate `ticket_id` as `str`. Both functions only interpolate it into the returned f-string — no arithmetic, no comparison — so this is behaviour-preserving. The docstrings already document that callers must pass the internal database ID rather than the display number, and that guidance is unchanged.

## Tests

Added a parametrized regression test rendering all three prompts through the public `mcp.render_prompt` API with non-numeric arguments.

Verified it genuinely covers the bug — with the `server.py` change reverted:

```
FAILED tests/test_server.py::test_prompts_render_with_non_numeric_arguments[analyze_ticket-arguments0]
FAILED tests/test_server.py::test_prompts_render_with_non_numeric_arguments[draft_response-arguments1]
2 failed, 1 passed
```

`escalation_summary` passes both before and after, confirming the test is not trivially green.

Also updated `test_prompt_handlers` to pass `ticket_id` as a string, matching the new signature.

Full suite on this branch:

```
225 passed
Required test coverage of 86.0% reached. Total coverage: 88.42%
```

`uv run ruff format`, `uv run ruff check`, and `uv run mypy mcp_zammad` are all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ticket analysis and response drafting now accept ticket IDs provided as strings, including non-numeric values.
  * Prompt placeholders are preserved correctly when clients provide string arguments.

* **Tests**
  * Added coverage for string-based ticket IDs and placeholder handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->