### PR TITLE
fix(client): request expanded fields in get_ticket

### DIFF
--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -10,6 +10,11 @@ from zammad_py.exceptions import ConfigException
 
 logger = logging.getLogger(__name__)
 
+# Requests defaults to no timeout, which lets a stalled connection hang a tool call
+# indefinitely. Every direct session call passes an explicit bound instead.
+DEFAULT_REQUEST_TIMEOUT = 30.0
+MAX_REQUEST_TIMEOUT = 600.0
+
 
 class ZammadClient:
     """Wrapper around zammad_py ZammadAPI with additional functionality."""
@@ -23,6 +28,7 @@ class ZammadClient:
         oauth2_token: str | None = None,
         *,
         insecure: bool | None = None,
+        timeout: float | None = None,
     ) -> None:
         """Initialize Zammad client with environment variables or provided credentials.
 
@@ -34,6 +40,11 @@ class ZammadClient:
         Set insecure=True, or set ZAMMAD_INSECURE to 1/true/yes/on, only for
         trusted self-signed/internal certificate chains. Defaults to secure TLS
         verification.
+
+        timeout bounds every direct HTTP call in seconds, and can also be set with
+        ZAMMAD_REQUEST_TIMEOUT. Defaults to DEFAULT_REQUEST_TIMEOUT; values that are
+        not positive numbers at or below MAX_REQUEST_TIMEOUT are rejected in favour
+        of the default.
         """
         self.url = url or os.getenv("ZAMMAD_URL")
         self.username = username or os.getenv("ZAMMAD_USERNAME")
@@ -47,6 +58,7 @@ class ZammadClient:
             oauth2_token or self._read_secret_file("ZAMMAD_OAUTH2_TOKEN_FILE") or os.getenv("ZAMMAD_OAUTH2_TOKEN")
         )
         self.insecure = insecure if insecure is not None else ZammadClient._parse_bool_env("ZAMMAD_INSECURE")
+        self.timeout = timeout if timeout is not None else ZammadClient._parse_timeout_env("ZAMMAD_REQUEST_TIMEOUT")
 
         if not self.url:
             raise ConfigException("Zammad URL is required. Set ZAMMAD_URL environment variable.")
@@ -152,6 +164,42 @@ class ZammadClient:
         value = os.getenv(env_var, "").strip().lower()
         return value in {"1", "true", "yes", "on"}
 
+    @staticmethod
+    def _parse_timeout_env(env_var: str) -> float:
+        """Parse a request timeout in seconds, falling back to the default.
+
+        The value is bounded: it must be positive and no greater than
+        MAX_REQUEST_TIMEOUT, so a misconfiguration cannot restore the
+        unbounded-wait behaviour this replaces. Unparseable or out-of-range
+        values log a warning and fall back rather than failing startup.
+        """
+        raw = os.getenv(env_var, "").strip()
+        if not raw:
+            return DEFAULT_REQUEST_TIMEOUT
+
+        try:
+            value = float(raw)
+        except ValueError:
+            logger.warning(
+                "Ignoring invalid %s=%r; using default of %ss.",
+                env_var,
+                raw,
+                DEFAULT_REQUEST_TIMEOUT,
+            )
+            return DEFAULT_REQUEST_TIMEOUT
+
+        if not 0 < value <= MAX_REQUEST_TIMEOUT:
+            logger.warning(
+                "Ignoring out-of-range %s=%r; expected 0 < seconds <= %s. Using default of %ss.",
+                env_var,
+                raw,
+                MAX_REQUEST_TIMEOUT,
+                DEFAULT_REQUEST_TIMEOUT,
+            )
+            return DEFAULT_REQUEST_TIMEOUT
+
+        return value
+
     def search_tickets(
         self,
         query: str | None = None,
@@ -197,9 +245,12 @@ class ZammadClient:
         Requests expanded fields so that group, state, priority, owner and customer
         come back as names. zammad_py's ticket.find() accepts no query parameters, so
         the request is issued through the library's session directly, matching the
-        approach already used by list_tags().
+        approach already used by list_tags(). Both pass the client's configured
+        timeout, since requests would otherwise wait indefinitely.
         """
-        response = self.api.session.get(f"{self.url}/tickets/{ticket_id}", params={"expand": "true"})
+        response = self.api.session.get(
+            f"{self.url}/tickets/{ticket_id}", params={"expand": "true"}, timeout=self.timeout
+        )
         response.raise_for_status()
         ticket = response.json()
 
@@ -486,6 +537,6 @@ class ZammadClient:
             requests.HTTPError: If the API request fails (e.g., 403 Forbidden)
         """
         # Use zammad_py's internal session for authentication
-        response = self.api.session.get(f"{self.url}/tag_list")
+        response = self.api.session.get(f"{self.url}/tag_list", timeout=self.timeout)
         response.raise_for_status()
         return list(response.json())

--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -192,8 +192,16 @@ class ZammadClient:
     def get_ticket(
         self, ticket_id: int, include_articles: bool = True, article_limit: int = 10, article_offset: int = 0
     ) -> dict[str, Any]:
-        """Get a single ticket by ID with optional article pagination."""
-        ticket = self.api.ticket.find(ticket_id)
+        """Get a single ticket by ID with optional article pagination.
+
+        Requests expanded fields so that group, state, priority, owner and customer
+        come back as names. zammad_py's ticket.find() accepts no query parameters, so
+        the request is issued through the library's session directly, matching the
+        approach already used by list_tags().
+        """
+        response = self.api.session.get(f"{self.url}/tickets/{ticket_id}", params={"expand": "true"})
+        response.raise_for_status()
+        ticket = response.json()
 
         if include_articles:
             articles = self.api.ticket.articles(ticket_id)

--- a/tests/test_client_methods.py
+++ b/tests/test_client_methods.py
@@ -15,6 +15,14 @@ EXPECTED_TWO_RESULTS = 2
 EXPECTED_THREE_RESULTS = 3
 
 
+def _mock_ticket_response(payload: dict) -> Mock:
+    """Build a mock requests.Response for the expanded single-ticket endpoint."""
+    response = Mock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
+
+
 class TestZammadClientMethods:
     """Test ZammadClient methods."""
 
@@ -323,7 +331,7 @@ class TestZammadClientMethods:
     def test_get_ticket_with_articles(self, mock_zammad_api: Mock) -> None:
         """Test get_ticket with article pagination."""
         mock_instance = Mock()
-        mock_instance.ticket.find.return_value = {"id": 1, "title": "Test Ticket"}
+        mock_instance.session.get.return_value = _mock_ticket_response({"id": 1, "title": "Test Ticket"})
         mock_instance.ticket.articles.return_value = [
             {"id": 1, "body": "Article 1"},
             {"id": 2, "body": "Article 2"},
@@ -346,7 +354,7 @@ class TestZammadClientMethods:
     def test_get_ticket_all_articles(self, mock_zammad_api: Mock) -> None:
         """Test get_ticket with all articles."""
         mock_instance = Mock()
-        mock_instance.ticket.find.return_value = {"id": 1, "title": "Test Ticket"}
+        mock_instance.session.get.return_value = _mock_ticket_response({"id": 1, "title": "Test Ticket"})
         mock_instance.ticket.articles.return_value = [{"id": 1, "body": "Article 1"}, {"id": 2, "body": "Article 2"}]
         mock_zammad_api.return_value = mock_instance
 
@@ -652,3 +660,75 @@ class TestZammadClientMethods:
 
         with pytest.raises(requests.HTTPError, match="403"):
             client.list_tags()
+
+
+class TestGetTicketExpandsReferenceFields:
+    """get_ticket must request expanded fields.
+
+    The single-ticket endpoint returns only group_id/state_id/priority_id unless
+    expand is requested, which previously left Ticket.group, .state, .priority,
+    .owner and .customer as None so tools rendered them as "Unknown".
+    """
+
+    @pytest.fixture
+    def mock_zammad_api(self):
+        with patch("mcp_zammad.client.ZammadAPI") as mock_api:
+            yield mock_api
+
+    def test_requests_expand(self, mock_zammad_api: Mock) -> None:
+        """The request carries expand=true."""
+        mock_instance = Mock()
+        mock_instance.session.get.return_value = _mock_ticket_response({"id": 1})
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+        client.get_ticket(1, include_articles=False)
+
+        _, kwargs = mock_instance.session.get.call_args
+        assert kwargs["params"] == {"expand": "true"}
+
+    def test_targets_the_ticket_endpoint(self, mock_zammad_api: Mock) -> None:
+        """The request hits /tickets/<id>."""
+        mock_instance = Mock()
+        mock_instance.session.get.return_value = _mock_ticket_response({"id": 42})
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+        client.get_ticket(42, include_articles=False)
+
+        args, _ = mock_instance.session.get.call_args
+        assert args[0] == "https://test.zammad.com/api/v1/tickets/42"
+
+    def test_expanded_names_survive(self, mock_zammad_api: Mock) -> None:
+        """Expanded names are returned rather than dropped."""
+        mock_instance = Mock()
+        mock_instance.session.get.return_value = _mock_ticket_response(
+            {
+                "id": 1,
+                "group": "GSI Tech Team",
+                "state": "closed",
+                "priority": "2 normal",
+                "customer": "user@example.com",
+            }
+        )
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+        result = client.get_ticket(1, include_articles=False)
+
+        assert result["group"] == "GSI Tech Team"
+        assert result["state"] == "closed"
+        assert result["priority"] == "2 normal"
+        assert result["customer"] == "user@example.com"
+
+    def test_http_error_propagates(self, mock_zammad_api: Mock) -> None:
+        """A failed request raises rather than returning a partial ticket."""
+        mock_instance = Mock()
+        response = Mock()
+        response.raise_for_status.side_effect = requests.HTTPError("404 Not Found")
+        mock_instance.session.get.return_value = response
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+        with pytest.raises(requests.HTTPError):
+            client.get_ticket(999, include_articles=False)

--- a/tests/test_client_methods.py
+++ b/tests/test_client_methods.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
-from mcp_zammad.client import ZammadClient
+from mcp_zammad.client import DEFAULT_REQUEST_TIMEOUT, MAX_REQUEST_TIMEOUT, ZammadClient
 
 # Test constants to avoid magic numbers
 EXPECTED_TWO_RESULTS = 2
@@ -630,7 +630,9 @@ class TestZammadClientMethods:
         assert result[0]["count"] == 15
         assert result[1]["name"] == "billing"
         assert result[2]["name"] == "feature-request"
-        mock_instance.session.get.assert_called_once_with("https://test.zammad.com/api/v1/tag_list")
+        mock_instance.session.get.assert_called_once_with(
+            "https://test.zammad.com/api/v1/tag_list", timeout=DEFAULT_REQUEST_TIMEOUT
+        )
 
     def test_list_tags_empty(self, mock_zammad_api: Mock) -> None:
         """Test list_tags returns empty list when no tags defined."""
@@ -708,6 +710,7 @@ class TestGetTicketExpandsReferenceFields:
                 "group": "GSI Tech Team",
                 "state": "closed",
                 "priority": "2 normal",
+                "owner": "agent@example.com",
                 "customer": "user@example.com",
             }
         )
@@ -719,6 +722,7 @@ class TestGetTicketExpandsReferenceFields:
         assert result["group"] == "GSI Tech Team"
         assert result["state"] == "closed"
         assert result["priority"] == "2 normal"
+        assert result["owner"] == "agent@example.com"
         assert result["customer"] == "user@example.com"
 
     def test_http_error_propagates(self, mock_zammad_api: Mock) -> None:
@@ -732,3 +736,68 @@ class TestGetTicketExpandsReferenceFields:
         client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
         with pytest.raises(requests.HTTPError):
             client.get_ticket(999, include_articles=False)
+
+
+class TestRequestTimeout:
+    """Direct HTTP calls must carry a bounded timeout.
+
+    requests defaults to waiting forever, so a stalled Zammad connection would
+    hang the tool call with no way to recover.
+    """
+
+    @pytest.fixture
+    def mock_zammad_api(self):
+        with patch("mcp_zammad.client.ZammadAPI") as mock_api:
+            yield mock_api
+
+    def _client(self, mock_zammad_api: Mock, **kwargs) -> tuple[ZammadClient, Mock]:
+        mock_instance = Mock()
+        mock_instance.session.get.return_value = _mock_ticket_response({"id": 1})
+        mock_zammad_api.return_value = mock_instance
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token", **kwargs)
+        return client, mock_instance
+
+    def test_default_timeout_applied(self, mock_zammad_api: Mock) -> None:
+        """get_ticket passes the default timeout."""
+        client, mock_instance = self._client(mock_zammad_api)
+        client.get_ticket(1, include_articles=False)
+        assert mock_instance.session.get.call_args.kwargs["timeout"] == DEFAULT_REQUEST_TIMEOUT
+
+    def test_explicit_timeout_used(self, mock_zammad_api: Mock) -> None:
+        """A constructor timeout overrides the default."""
+        client, mock_instance = self._client(mock_zammad_api, timeout=5.0)
+        client.get_ticket(1, include_articles=False)
+        assert mock_instance.session.get.call_args.kwargs["timeout"] == 5.0
+
+    def test_list_tags_uses_same_timeout(self, mock_zammad_api: Mock) -> None:
+        """The other direct session call is bounded consistently."""
+        client, mock_instance = self._client(mock_zammad_api, timeout=7.5)
+        mock_instance.session.get.return_value = _mock_ticket_response([])
+        client.list_tags()
+        assert mock_instance.session.get.call_args.kwargs["timeout"] == 7.5
+
+    def test_env_var_configures_timeout(self, mock_zammad_api: Mock, monkeypatch) -> None:
+        """ZAMMAD_REQUEST_TIMEOUT sets the bound."""
+        monkeypatch.setenv("ZAMMAD_REQUEST_TIMEOUT", "12.5")
+        client, mock_instance = self._client(mock_zammad_api)
+        client.get_ticket(1, include_articles=False)
+        assert mock_instance.session.get.call_args.kwargs["timeout"] == 12.5
+
+    @pytest.mark.parametrize("value", ["0", "-1", "abc", "", "601"])
+    def test_invalid_env_falls_back_to_default(self, mock_zammad_api: Mock, monkeypatch, value: str) -> None:
+        """Unusable values fall back rather than disabling the bound."""
+        monkeypatch.setenv("ZAMMAD_REQUEST_TIMEOUT", value)
+        client, _ = self._client(mock_zammad_api)
+        assert client.timeout == DEFAULT_REQUEST_TIMEOUT
+
+    def test_max_timeout_accepted(self, mock_zammad_api: Mock, monkeypatch) -> None:
+        """The upper bound itself is valid."""
+        monkeypatch.setenv("ZAMMAD_REQUEST_TIMEOUT", str(MAX_REQUEST_TIMEOUT))
+        client, _ = self._client(mock_zammad_api)
+        assert client.timeout == MAX_REQUEST_TIMEOUT
+
+    def test_timeout_is_never_none(self, mock_zammad_api: Mock) -> None:
+        """No configuration path yields an unbounded wait."""
+        client, _ = self._client(mock_zammad_api)
+        assert client.timeout is not None
+        assert client.timeout > 0


### PR DESCRIPTION
## Problem

`zammad_get_ticket` reports `Unknown` for **State, Priority, Group, Owner and Customer** on every ticket:

```
# Ticket #190017 - Office Location Adjustment for New Hire
**ID**: 17
**State**: Unknown
**Priority**: Unknown
**Group**: Unknown
**Owner**: Unknown
**Customer**: Unknown
```

## Cause

`ZammadClient.get_ticket()` fetches through `zammad_py`'s `ticket.find()`, which issues a plain `GET` with no query parameters:

```python
def find(self, id: int) -> Any:
    response = self._connection.session.get(self.url + "/%s" % id)
    return self._raise_or_return_json(response)
```

Without `expand`, the single-ticket endpoint returns `group_id` / `state_id` / `priority_id` / `owner_id` / `customer_id` and omits the name fields. `Ticket.group`, `.state`, `.priority`, `.owner` and `.customer` therefore deserialize to `None`, and `_brief_field` renders each as `Unknown`.

Confirmed against a live instance — `find()` returns `group=None, state=None, priority=None` with only `group_id=2, state_id=4, priority_id=2` present.

The `Ticket` model already anticipates the expanded form:

```python
# Expanded fields - can be either objects or strings when expand=true
group: GroupBrief | str | None = None
state: StateBrief | str | None = None
priority: PriorityBrief | str | None = None
```

So only the request was missing. `search_tickets()` and the other list methods already pass `expand="true"`, which is why search results render correctly and single-ticket lookups do not.

## Fix

`ticket.find()` accepts no query parameters, so the request goes through the library session directly — the same approach `list_tags()` already uses for an endpoint `zammad_py` doesn't expose.

## Verification

Same ticket, same instance, after the change:

```
**State**: closed
**Priority**: 2 normal
**Group**: GSI Tech Team
**Owner**: -
**Customer**: user@example.com
```

## Tests

The two existing `get_ticket` tests mocked `ticket.find` and are updated to mock the session response. Four regression tests added covering the `expand` parameter, the request URL, expanded names surviving deserialization, and HTTP errors propagating.

`ruff check`, `ruff format --check`, `mypy` and the full suite (226 tests) all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ticket retrieval through the authenticated connection.
  * Ticket details now include expanded reference information.
  * HTTP errors are detected and reported consistently.

* **Tests**
  * Added coverage for ticket endpoints, expanded-field requests, reference names, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->