### PR TITLE
fix(stats): flag group-filtered counts truncated at the search cap

### DIFF
--- a/mcp_zammad/models.py
+++ b/mcp_zammad/models.py
@@ -662,6 +662,13 @@ class TicketStats(BaseModel):
     escalated_count: int = Field(description="Number of escalated tickets")
     avg_first_response_time: float | None = Field(None, description="Average first response time in minutes")
     avg_resolution_time: float | None = Field(None, description="Average resolution time in minutes")
+    counts_truncated: bool = Field(
+        default=False,
+        description=(
+            "True when the scan hit the search backend's result cap, so the counts are "
+            "lower bounds rather than exact totals."
+        ),
+    )
 
 
 class TagOperationResult(BaseModel):

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -99,6 +99,10 @@ logger = logging.getLogger(__name__)
 MAX_PAGES_FOR_TICKET_SCAN = 1000
 MAX_TICKETS_PER_STATE_IN_QUEUE = 10
 MAX_PER_PAGE = 100  # Maximum results per page for pagination
+# Zammad's search endpoint is backed by Elasticsearch, whose index.max_result_window
+# defaults to 10,000. Past that the endpoint returns empty pages rather than an error,
+# so an unguarded scan silently stops and under-reports.
+SEARCH_RESULT_CAP = 10000
 CHARACTER_LIMIT = 25000  # Maximum response size per MCP best practices
 ARTICLE_BODY_TRUNCATE_LENGTH = 500  # Maximum length for article body in markdown formatting
 
@@ -1952,7 +1956,7 @@ class ZammadMCPServer:
 
     def _collect_ticket_stats_paginated(
         self, client: ZammadClient, group: str | None
-    ) -> tuple[int, int, int, int, int, int]:
+    ) -> tuple[int, int, int, int, int, int, bool]:
         """Collect ticket statistics using pagination.
 
         Args:
@@ -1960,7 +1964,9 @@ class ZammadMCPServer:
             group: Optional group filter
 
         Returns:
-            Tuple of (total, open, closed, pending, escalated, pages) counts
+            Tuple of (total, open, closed, pending, escalated, pages, truncated) counts.
+            truncated is True when the scan stopped at a backend limit, making the
+            counts lower bounds rather than exact totals.
         """
         total_count = 0
         open_count = 0
@@ -1969,6 +1975,7 @@ class ZammadMCPServer:
         escalated_count = 0
         page = 1
         per_page = MAX_PER_PAGE
+        truncated = False
 
         while True:
             tickets = client.search_tickets(group=group, page=page, per_page=per_page)
@@ -1985,7 +1992,20 @@ class ZammadMCPServer:
 
             page += 1
 
+            # A group filter routes through the search endpoint, which stops returning
+            # results at SEARCH_RESULT_CAP. Record that the totals are lower bounds
+            # instead of reporting the capped number as exact.
+            if group and total_count >= SEARCH_RESULT_CAP:
+                truncated = True
+                logger.warning(
+                    "Group '%s' reached the search result cap (%s); counts are lower bounds, not exact totals",
+                    group,
+                    SEARCH_RESULT_CAP,
+                )
+                break
+
             if page > MAX_PAGES_FOR_TICKET_SCAN:
+                truncated = True
                 logger.warning(
                     "Reached maximum page limit (%s pages), processed %s tickets - some tickets may not be counted",
                     MAX_PAGES_FOR_TICKET_SCAN,
@@ -1993,7 +2013,7 @@ class ZammadMCPServer:
                 )
                 break
 
-        return total_count, open_count, closed_count, pending_count, escalated_count, page - 1
+        return total_count, open_count, closed_count, pending_count, escalated_count, page - 1, truncated
 
     def _build_stats_result(
         self,
@@ -2004,6 +2024,7 @@ class ZammadMCPServer:
         escalated: int,
         pages: int,
         elapsed: float,
+        truncated: bool = False,
     ) -> TicketStats:
         """Build and log ticket statistics result.
 
@@ -2015,6 +2036,7 @@ class ZammadMCPServer:
             escalated: Escalated ticket count
             pages: Number of pages processed
             elapsed: Elapsed time in seconds
+            truncated: Whether the scan stopped at a backend limit
 
         Returns:
             TicketStats object
@@ -2039,6 +2061,7 @@ class ZammadMCPServer:
             escalated_count=escalated,
             avg_first_response_time=None,
             avg_resolution_time=None,
+            counts_truncated=truncated,
         )
 
     def _setup_system_tools(self) -> None:  # noqa: PLR0915
@@ -2097,12 +2120,12 @@ class ZammadMCPServer:
             group_filter_msg = f" for group '{params.group}'" if params.group else ""
             logger.info("Starting ticket statistics calculation%s", group_filter_msg)
 
-            total, open_count, closed, pending, escalated, pages = self._collect_ticket_stats_paginated(
+            total, open_count, closed, pending, escalated, pages, truncated = self._collect_ticket_stats_paginated(
                 client, params.group
             )
 
             return self._build_stats_result(
-                total, open_count, closed, pending, escalated, pages, time.time() - start_time
+                total, open_count, closed, pending, escalated, pages, time.time() - start_time, truncated
             )
 
         @self.mcp.tool(annotations=_read_only_annotations("List Groups"))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 import tempfile
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -3230,7 +3230,7 @@ def test_get_organization_supports_json_format(decorator_capturer):
 class TestTicketStatsSearchCap:
     """Group-filtered stats must not report the search cap as an exact total."""
 
-    _STATES = [
+    _STATES: ClassVar[list[dict[str, Any]]] = [
         {"id": 1, "name": "new", "state_type_id": 1, "created_at": "2024-01-01", "updated_at": "2024-01-01"},
         {"id": 2, "name": "open", "state_type_id": 2, "created_at": "2024-01-01", "updated_at": "2024-01-01"},
         {"id": 3, "name": "closed", "state_type_id": 3, "created_at": "2024-01-01", "updated_at": "2024-01-01"},

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -45,6 +45,8 @@ from mcp_zammad.models import (
 )
 from mcp_zammad.server import (
     CHARACTER_LIMIT,
+    MAX_PER_PAGE,
+    SEARCH_RESULT_CAP,
     AttachmentDeletionError,
     ZammadMCPServer,
     _format_ticket_detail_markdown,
@@ -3223,3 +3225,68 @@ def test_get_organization_supports_json_format(decorator_capturer):
     assert parsed["id"] == 2
     assert parsed["name"] == "ACME Corp"
     assert parsed["domain"] == "acme.com"
+
+
+class TestTicketStatsSearchCap:
+    """Group-filtered stats must not report the search cap as an exact total."""
+
+    _STATES = [
+        {"id": 1, "name": "new", "state_type_id": 1, "created_at": "2024-01-01", "updated_at": "2024-01-01"},
+        {"id": 2, "name": "open", "state_type_id": 2, "created_at": "2024-01-01", "updated_at": "2024-01-01"},
+        {"id": 3, "name": "closed", "state_type_id": 3, "created_at": "2024-01-01", "updated_at": "2024-01-01"},
+    ]
+
+    def _server(self, mock_instance):
+        mock_instance.get_ticket_states.return_value = self._STATES
+        server_inst = ZammadMCPServer()
+        server_inst.client = mock_instance
+        server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
+        return server_inst
+
+    def test_group_scan_flags_truncation_at_cap(self, mock_zammad_client):
+        """Hitting the cap marks the counts as lower bounds."""
+        mock_instance, _ = mock_zammad_client
+        full_page = [{"id": i, "state": "open"} for i in range(MAX_PER_PAGE)]
+        # Enough full pages to reach the cap, then the empty page the backend returns.
+        pages = [full_page] * (SEARCH_RESULT_CAP // MAX_PER_PAGE) + [[]]
+        mock_instance.search_tickets.side_effect = pages
+
+        server_inst = self._server(mock_instance)
+        *_, truncated = server_inst._collect_ticket_stats_paginated(mock_instance, "Support")
+
+        assert truncated is True
+
+    def test_small_group_scan_is_not_truncated(self, mock_zammad_client):
+        """A scan that ends before the cap reports exact counts."""
+        mock_instance, _ = mock_zammad_client
+        mock_instance.search_tickets.side_effect = [[{"id": 1, "state": "open"}], []]
+
+        server_inst = self._server(mock_instance)
+        total, *_, truncated = server_inst._collect_ticket_stats_paginated(mock_instance, "Support")
+
+        assert total == 1
+        assert truncated is False
+
+    def test_unfiltered_scan_is_not_capped(self, mock_zammad_client):
+        """Without a group filter the client uses the uncapped list endpoint."""
+        mock_instance, _ = mock_zammad_client
+        full_page = [{"id": i, "state": "open"} for i in range(MAX_PER_PAGE)]
+        pages = [full_page] * (SEARCH_RESULT_CAP // MAX_PER_PAGE) + [[]]
+        mock_instance.search_tickets.side_effect = pages
+
+        server_inst = self._server(mock_instance)
+        *_, truncated = server_inst._collect_ticket_stats_paginated(mock_instance, None)
+
+        assert truncated is False
+
+    def test_truncation_surfaces_on_the_model(self):
+        """The flag reaches TicketStats so callers can see it."""
+        server_inst = ZammadMCPServer()
+        stats = server_inst._build_stats_result(10000, 1, 2, 3, 4, 100, 1.0, True)
+        assert stats.counts_truncated is True
+
+    def test_default_stats_are_not_truncated(self):
+        """The flag defaults to False for exact scans."""
+        server_inst = ZammadMCPServer()
+        stats = server_inst._build_stats_result(5, 1, 2, 1, 1, 1, 1.0)
+        assert stats.counts_truncated is False


### PR DESCRIPTION
## Problem

`zammad_get_ticket_stats` can silently under-report for large groups, returning a wrong number with no indication anything was missed.

## Cause

`_collect_ticket_stats_paginated` pages through `client.search_tickets()`. Which endpoint that reaches depends on whether a group filter is set:

- **No group filter** — `search_parts` is empty, so `search_tickets` falls through to `ticket.all()`, the list endpoint. Uncapped, counts are correct.
- **With a group filter** — it builds `group.name:<x>` and calls `ticket.search()`, which is backed by Elasticsearch and bounded by `index.max_result_window`, 10,000 by default.

Past that bound the search endpoint [returns empty pages rather than an error](https://community.zammad.org/t/api-tickets-search-endpoint-limited-to-10-000-results/10644), so the loop exits through its `if not tickets: break` path exactly as if it had reached the end of the data.

The existing `MAX_PAGES_FOR_TICKET_SCAN` guard can't catch this. At `MAX_PER_PAGE = 100` the cap is hit on page 100, well short of the 1000-page limit, so that warning never fires. A group with more than 10,000 tickets reports exactly `10000` as an exact total, with nothing in the response or the logs saying otherwise.

## Change

Detect the cap during group-filtered scans and surface it, rather than guessing at a correction:

- `counts_truncated` added to `TicketStats`, defaulting to `False`, so callers can distinguish a lower bound from an exact total
- A warning naming the group is logged when the cap is reached
- `SEARCH_RESULT_CAP` documents where the 10,000 comes from

The new field is optional with a default, so existing consumers are unaffected.

## What this deliberately does not do

It doesn't raise the ceiling. Counting past it means enumerating via the list endpoint and filtering client-side, which is a substantially larger change and a real cost on big instances. Reporting the limit honestly seemed like the right first step — happy to follow up with the fuller approach if you'd prefer it, or to drop this in favour of that.

## Tests

Five tests: truncation flagged at the cap, exact counts below it, unfiltered scans never flagged, and the flag surfacing on `TicketStats` in both states.

`ruff check`, `ruff format --check`, `mypy` and the full suite (227 tests) all pass.