### PR TITLE
feat(search): add creation date range filters to ticket search

### DIFF
--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from datetime import date
 from typing import Any
 from urllib.parse import urlparse
 
@@ -160,10 +161,16 @@ class ZammadClient:
         group: str | None = None,
         owner: str | None = None,
         customer: str | None = None,
+        created_after: date | str | None = None,
+        created_before: date | str | None = None,
         page: int = 1,
         per_page: int = 25,
     ) -> list[dict[str, Any]]:
-        """Search tickets with various filters."""
+        """Search tickets with various filters.
+
+        created_after and created_before bound the search by creation date, inclusive
+        on both ends. Dates are passed to Zammad in ISO YYYY-MM-DD form.
+        """
         filters = {"page": page, "per_page": per_page, "expand": "true"}
 
         # Build search query
@@ -180,6 +187,10 @@ class ZammadClient:
             search_parts.append(f"owner.login:{owner}")
         if customer:
             search_parts.append(f"customer.email:{customer}")
+        if created_after:
+            search_parts.append(f"created_at:>={created_after}")
+        if created_before:
+            search_parts.append(f"created_at:<={created_before}")
 
         if search_parts:
             search_query = " AND ".join(search_parts)

--- a/mcp_zammad/models.py
+++ b/mcp_zammad/models.py
@@ -301,9 +301,18 @@ class TicketSearchParams(StrictBaseModel):
     group: str | None = Field(None, description="Filter by group name")
     owner: str | None = Field(None, description="Filter by owner login/email")
     customer: str | None = Field(None, description="Filter by customer email")
+    created_after: date | None = Field(None, description="Only tickets created on or after this date (YYYY-MM-DD)")
+    created_before: date | None = Field(None, description="Only tickets created on or before this date (YYYY-MM-DD)")
     page: int = Field(default=1, ge=1, description="Page number (must be >= 1)")
     per_page: int = Field(default=25, ge=1, le=100, description="Results per page (1-100)")
     response_format: ResponseFormat = Field(default=ResponseFormat.MARKDOWN, description="Output format")
+
+    @model_validator(mode="after")
+    def validate_date_range(self) -> "TicketSearchParams":
+        """Reject an inverted date range rather than silently returning nothing."""
+        if self.created_after and self.created_before and self.created_after > self.created_before:
+            raise ValueError("created_after must not be later than created_before")
+        return self
 
 
 class Attachment(BaseModel):

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -884,6 +884,8 @@ class ZammadMCPServer:
                     - group (str | None): Filter by group name
                     - owner (str | None): Filter by owner email/login
                     - customer (str | None): Filter by customer email/login
+                    - created_after (date | None): Only tickets created on/after YYYY-MM-DD
+                    - created_before (date | None): Only tickets created on/before YYYY-MM-DD
                     - page (int): Page number (default: 1)
                     - per_page (int): Results per page, 1-100 (default: 25)
                     - response_format (ResponseFormat): Output format (default: MARKDOWN)

--- a/tests/test_client_methods.py
+++ b/tests/test_client_methods.py
@@ -3,12 +3,15 @@
 import os
 import pathlib
 from collections.abc import Generator
+from datetime import date
 from unittest.mock import Mock, patch
 
 import pytest
 import requests
+from pydantic import ValidationError
 
 from mcp_zammad.client import ZammadClient
+from mcp_zammad.models import TicketSearchParams
 
 # Test constants to avoid magic numbers
 EXPECTED_TWO_RESULTS = 2
@@ -652,3 +655,70 @@ class TestZammadClientMethods:
 
         with pytest.raises(requests.HTTPError, match="403"):
             client.list_tags()
+
+
+class TestSearchTicketsDateFilters:
+    """Creation-date bounds must reach the Zammad search query."""
+
+    @pytest.fixture
+    def mock_zammad_api(self):
+        with patch("mcp_zammad.client.ZammadAPI") as mock_api:
+            yield mock_api
+
+    def _client(self, mock_zammad_api: Mock) -> tuple[ZammadClient, Mock]:
+        mock_instance = Mock()
+        mock_instance.ticket.search.return_value = []
+        mock_instance.ticket.all.return_value = []
+        mock_zammad_api.return_value = mock_instance
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+        return client, mock_instance
+
+    def test_created_after_in_query(self, mock_zammad_api: Mock) -> None:
+        """created_after becomes a >= bound."""
+        client, mock_instance = self._client(mock_zammad_api)
+        client.search_tickets(created_after=date(2024, 1, 1))
+        assert mock_instance.ticket.search.call_args[0][0] == "created_at:>=2024-01-01"
+
+    def test_created_before_in_query(self, mock_zammad_api: Mock) -> None:
+        """created_before becomes a <= bound."""
+        client, mock_instance = self._client(mock_zammad_api)
+        client.search_tickets(created_before=date(2024, 12, 31))
+        assert mock_instance.ticket.search.call_args[0][0] == "created_at:<=2024-12-31"
+
+    def test_both_bounds_combine(self, mock_zammad_api: Mock) -> None:
+        """Both bounds AND together."""
+        client, mock_instance = self._client(mock_zammad_api)
+        client.search_tickets(created_after=date(2024, 1, 1), created_before=date(2024, 12, 31))
+        assert mock_instance.ticket.search.call_args[0][0] == "created_at:>=2024-01-01 AND created_at:<=2024-12-31"
+
+    def test_combines_with_other_filters(self, mock_zammad_api: Mock) -> None:
+        """Date bounds compose with existing filters."""
+        client, mock_instance = self._client(mock_zammad_api)
+        client.search_tickets(group="Support", created_after=date(2024, 1, 1))
+        assert mock_instance.ticket.search.call_args[0][0] == "group.name:Support AND created_at:>=2024-01-01"
+
+    def test_no_dates_leaves_query_untouched(self, mock_zammad_api: Mock) -> None:
+        """Without dates the unfiltered path still uses the list endpoint."""
+        client, mock_instance = self._client(mock_zammad_api)
+        client.search_tickets()
+        mock_instance.ticket.search.assert_not_called()
+        mock_instance.ticket.all.assert_called_once()
+
+
+class TestTicketSearchParamsDateValidation:
+    """The search params model validates the date range."""
+
+    def test_inverted_range_rejected(self) -> None:
+        """created_after later than created_before is a validation error."""
+        with pytest.raises(ValidationError, match="created_after must not be later"):
+            TicketSearchParams(created_after=date(2024, 12, 31), created_before=date(2024, 1, 1))
+
+    def test_equal_dates_allowed(self) -> None:
+        """A single-day window is valid."""
+        params = TicketSearchParams(created_after=date(2024, 6, 1), created_before=date(2024, 6, 1))
+        assert params.created_after == params.created_before
+
+    def test_string_dates_parsed(self) -> None:
+        """ISO strings coerce to dates."""
+        params = TicketSearchParams(created_after="2024-01-01")
+        assert params.created_after == date(2024, 1, 1)


### PR DESCRIPTION
## Motivation

`zammad_search_tickets` filters by state, priority, group, owner and customer, but not by when a ticket was created. Common asks like *"tickets opened last quarter"* or *"everything from 2024"* aren't expressible, so callers page through results and filter client-side — which is both slow and, past the search endpoint's result cap, incomplete.

## Change

`created_after` and `created_before` on `TicketSearchParams` and `ZammadClient.search_tickets()`. Both bounds are inclusive and translate to Zammad `created_at` range terms:

```
group.name:Support AND created_at:>=2024-01-01 AND created_at:<=2024-12-31
```

They compose with the existing filters through the same `AND` join, so nothing about current behaviour changes when they're omitted.

Typed as `date` rather than `str`, so Pydantic validates the format and rejects malformed input before a request goes out; ISO strings still coerce. A model validator rejects an inverted range (`created_after > created_before`) rather than issuing a query that can only ever return nothing.

The search tool passes params through `model_dump()`, so no tool-level plumbing was needed beyond the docstring.

## Verification

Against a live instance, a 2024 window returns 2024 tickets only, and a 2025 window 2025 tickets only — confirming Zammad applies the bounds server-side rather than the filter being a no-op.

## Tests

Eight tests: five on the client covering query construction for each bound, both together, composition with `group`, and the unfiltered path still using the list endpoint; three on the model covering the inverted range, a single-day window, and string coercion.

`ruff check`, `ruff format --check`, `mypy` and the full suite (230 tests) all pass.