### PR TITLE
feat(export): add bulk ticket export to JSONL

### DIFF
--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -160,6 +160,8 @@ class ZammadClient:
         group: str | None = None,
         owner: str | None = None,
         customer: str | None = None,
+        created_after: str | None = None,
+        created_before: str | None = None,
         page: int = 1,
         per_page: int = 25,
     ) -> list[dict[str, Any]]:
@@ -180,6 +182,10 @@ class ZammadClient:
             search_parts.append(f"owner.login:{owner}")
         if customer:
             search_parts.append(f"customer.email:{customer}")
+        if created_after:
+            search_parts.append(f"created_at:>={created_after}")
+        if created_before:
+            search_parts.append(f"created_at:<={created_before}")
 
         if search_parts:
             search_query = " AND ".join(search_parts)
@@ -187,6 +193,16 @@ class ZammadClient:
         else:
             result = self.api.ticket.all(filters=filters)
 
+        return list(result)
+
+    def list_tickets(self, page: int = 1, per_page: int = 50) -> list[dict[str, Any]]:
+        """List tickets with pagination (no 10K search limit).
+
+        Uses the list endpoint which has no result cap, unlike the search endpoint
+        which is limited to 10,000 results.
+        """
+        filters = {"page": page, "per_page": per_page, "expand": True}
+        result = self.api.ticket.all(filters=filters)
         return list(result)
 
     def get_ticket(

--- a/mcp_zammad/models.py
+++ b/mcp_zammad/models.py
@@ -664,6 +664,35 @@ class TicketStats(BaseModel):
     avg_resolution_time: float | None = Field(None, description="Average resolution time in minutes")
 
 
+class TicketExportParams(StrictBaseModel):
+    """Parameters for bulk ticket export to JSONL."""
+
+    output_path: str = Field(description="Path to output JSONL file (must end in .jsonl)")
+    query: str | None = Field(None, description="Free text search filter")
+    group: str | None = Field(None, description="Filter by group name")
+    state: str | None = Field(None, description="Filter by state name")
+    created_after: str | None = Field(None, description="Filter tickets created on or after this date (YYYY-MM-DD)")
+    created_before: str | None = Field(None, description="Filter tickets created on or before this date (YYYY-MM-DD)")
+    delay_seconds: float = Field(default=0.5, ge=0.0, le=10.0, description="Delay between API calls in seconds")
+    per_page: int = Field(default=50, ge=1, le=100, description="Number of tickets per page/batch")
+    include_internal_articles: bool = Field(default=False, description="Include internal notes in export")
+    resume_from_page: int = Field(default=1, ge=1, description="Page to resume export from (for interrupted exports)")
+    max_tickets: int | None = Field(default=None, ge=1, description="Maximum number of tickets to export")
+    include_tags: bool = Field(
+        default=False,
+        description="Fetch tags for each ticket. Tags are not part of the ticket payload, "
+        "so this costs one extra API call per ticket.",
+    )
+
+    @field_validator("output_path")
+    @classmethod
+    def validate_output_path(cls, v: str) -> str:
+        """Validate that output path ends with .jsonl."""
+        if not v.endswith(".jsonl"):
+            raise ValueError("output_path must end with .jsonl")
+        return v
+
+
 class TagOperationResult(BaseModel):
     """Result of a tag operation (add/remove)."""
 

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -5,6 +5,7 @@ import html
 import json
 import logging
 import os
+import re
 import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -47,6 +48,7 @@ from .models import (
     TagOperationResult,
     Ticket,
     TicketCreate,
+    TicketExportParams,
     TicketIdGuidanceError,
     TicketPriority,
     TicketSearchParams,
@@ -101,6 +103,7 @@ MAX_TICKETS_PER_STATE_IN_QUEUE = 10
 MAX_PER_PAGE = 100  # Maximum results per page for pagination
 CHARACTER_LIMIT = 25000  # Maximum response size per MCP best practices
 ARTICLE_BODY_TRUNCATE_LENGTH = 500  # Maximum length for article body in markdown formatting
+MAX_EXPORT_ERRORS_LOGGED = 100  # Maximum number of per-ticket errors to log during export
 
 # Zammad state type IDs (from Zammad API)
 STATE_TYPE_NEW = 1
@@ -190,6 +193,19 @@ def _brief_field(value: object, attr: str) -> str:
     if isinstance(value, str):
         return value
     return "Unknown"
+
+
+def _strip_html_tags(text: str) -> str:
+    """Strip HTML tags and unescape HTML entities from text.
+
+    Args:
+        text: HTML or plain text string
+
+    Returns:
+        Plain text with HTML tags removed and entities decoded
+    """
+    clean = re.sub(r"<[^>]+>", "", text)
+    return html.unescape(clean).strip()
 
 
 def _escape_article_body(article: Article) -> str:
@@ -753,6 +769,180 @@ def _format_organization_detail_markdown(org: Organization) -> str:
     return "\n".join(lines)
 
 
+def _extract_expanded_field_name(value: object) -> str:
+    """Extract name from an expanded field (dict or string)."""
+    if isinstance(value, dict):
+        return str(value.get("name", ""))
+    return str(value) if value else ""
+
+
+def _build_export_article(article: dict[str, Any]) -> dict[str, Any]:
+    """Build a single export article record with HTML stripped."""
+    body = article.get("body", "")
+    content_type = (article.get("content_type") or "").lower()
+    if "html" in content_type:
+        body = _strip_html_tags(body)
+
+    return {
+        "sender": article.get("sender", "Unknown"),
+        "type": article.get("type", "note"),
+        "from": article.get("from", ""),
+        "subject": article.get("subject", ""),
+        "body": body,
+        "internal": article.get("internal", False),
+        "created_at": article.get("created_at", ""),
+    }
+
+
+def _resolve_export_path(output_path: str) -> Path:
+    """Resolve and validate an export output path against the configured export directory.
+
+    Export writes to the host filesystem, so the destination is confined to the directory
+    named by ZAMMAD_EXPORT_DIR. The variable is required: without it the export tool is
+    unavailable rather than defaulting to a writable location.
+
+    Symlinks are resolved before the containment check, so a symlink inside the export
+    directory cannot be used to escape it.
+
+    Args:
+        output_path: Requested output path, absolute or relative to the export directory.
+
+    Returns:
+        Path: The resolved, validated absolute path.
+
+    Raises:
+        ValueError: If ZAMMAD_EXPORT_DIR is unset, is not a directory, or the resolved
+            path would fall outside it.
+    """
+    export_dir_raw = os.environ.get("ZAMMAD_EXPORT_DIR")
+    if not export_dir_raw:
+        raise ValueError(
+            "Ticket export is disabled: ZAMMAD_EXPORT_DIR is not set. "
+            "Set it to a directory the server may write exports into."
+        )
+
+    export_dir = Path(export_dir_raw).expanduser().resolve()
+    if not export_dir.is_dir():
+        raise ValueError(f"ZAMMAD_EXPORT_DIR does not exist or is not a directory: {export_dir}")
+
+    candidate = Path(output_path).expanduser()
+    resolved = (export_dir / candidate).resolve() if not candidate.is_absolute() else candidate.resolve()
+
+    if resolved != export_dir and export_dir not in resolved.parents:
+        raise ValueError(
+            f"Refusing to write outside the export directory. "
+            f"Resolved path {resolved} is not contained in ZAMMAD_EXPORT_DIR {export_dir}."
+        )
+
+    return resolved
+
+
+def _build_export_record(
+    ticket_data: dict[str, Any],
+    include_internal: bool,
+    summary: dict[str, Any] | None = None,
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a JSONL export record from ticket data.
+
+    The per-ticket detail fetch uses the Zammad ticket find endpoint, which does not
+    support expansion, so group/state/priority arrive as numeric *_id fields only. The
+    list and search endpoints do expand those names, so the batch summary the ticket
+    came from is used as a fallback for the human-readable values.
+
+    Args:
+        ticket_data: Full ticket detail, including articles.
+        include_internal: Whether internal articles are included in the conversation.
+        summary: The batch entry this ticket came from, used to recover expanded names.
+        tags: Tags fetched separately; the ticket payload never carries them.
+    """
+    conversation = []
+    for article in ticket_data.get("articles", []):
+        if not include_internal and article.get("internal", False):
+            continue
+        conversation.append(_build_export_article(article))
+
+    summary = summary or {}
+
+    def expanded(field: str) -> str:
+        """Prefer the detail payload, falling back to the expanded batch summary."""
+        value = _extract_expanded_field_name(ticket_data.get(field, ""))
+        if value:
+            return value
+        return _extract_expanded_field_name(summary.get(field, ""))
+
+    raw_tags = tags if tags is not None else ticket_data.get("tags")
+    resolved_tags = raw_tags if isinstance(raw_tags, list) else []
+
+    return {
+        "ticket_id": ticket_data.get("id"),
+        "ticket_number": str(ticket_data.get("number", "")),
+        "title": ticket_data.get("title", ""),
+        "group": expanded("group"),
+        "state": expanded("state"),
+        "priority": expanded("priority"),
+        "tags": resolved_tags,
+        "created_at": str(ticket_data.get("created_at", "")),
+        "updated_at": str(ticket_data.get("updated_at", "")),
+        "conversation": conversation,
+    }
+
+
+def _format_export_summary(
+    params: "TicketExportParams",
+    exported_count: int,
+    error_count: int,
+    errors: list[str],
+    elapsed: float,
+    use_search: bool,
+    export_path: Path | None = None,
+) -> str:
+    """Format export summary as markdown."""
+    lines = ["# Ticket Export Complete", ""]
+    lines.append(f"- **File**: `{export_path if export_path is not None else params.output_path}`")
+    lines.append(f"- **Tickets exported**: {exported_count}")
+    lines.append(f"- **Errors**: {error_count}")
+    lines.append(f"- **Elapsed time**: {elapsed:.1f}s")
+    lines.append(f"- **Mode**: {'search (10K limit)' if use_search else 'list (no limit)'}")
+    if params.resume_from_page > 1:
+        lines.append(f"- **Resumed from page**: {params.resume_from_page}")
+    lines.append("")
+
+    if use_search:
+        lines.append(
+            "> **Note**: Filtered export uses the search endpoint, which is capped at 10,000 results by Zammad."
+        )
+        lines.append("")
+
+    if errors:
+        lines.append("## Errors (first 100)")
+        lines.append("")
+        for err in errors:
+            lines.append(f"- {err}")
+
+    return "\n".join(lines)
+
+
+def _fetch_export_batch(
+    client: "ZammadClient",
+    params: "TicketExportParams",
+    use_search: bool,
+    page: int,
+) -> list[dict[str, Any]]:
+    """Fetch a batch of tickets for export using search or list endpoint."""
+    if use_search:
+        return client.search_tickets(
+            query=params.query,
+            group=params.group,
+            state=params.state,
+            created_after=params.created_after,
+            created_before=params.created_before,
+            page=page,
+            per_page=params.per_page,
+        )
+    return client.list_tickets(page=page, per_page=params.per_page)
+
+
 def _handle_api_error(e: Exception, context: str = "operation") -> str:
     """Format errors with actionable guidance for LLM agents.
 
@@ -866,6 +1056,7 @@ class ZammadMCPServer:
     def _setup_tools(self) -> None:
         """Register all tools with the MCP server."""
         self._setup_ticket_tools()
+        self._setup_export_tools()
         self._setup_user_org_tools()
         self._setup_system_tools()
 
@@ -1482,6 +1673,127 @@ class ZammadMCPServer:
             client = self.get_client()
             result = client.remove_ticket_tag(params.ticket_id, params.tag)
             return TagOperationResult(**result)
+
+    def _setup_export_tools(self) -> None:
+        """Register export-related tools."""
+
+        @self.mcp.tool(annotations=_read_only_annotations("Export Tickets to JSONL"))
+        def zammad_export_tickets(params: TicketExportParams) -> str:
+            """Export tickets with conversation articles to a JSONL file for AI training.
+
+            Fetches tickets in batches, retrieves all articles for each ticket,
+            strips HTML to plain text, and writes one JSON line per ticket.
+
+            By default (no filters), uses the list endpoint which has no result cap.
+            When filters are specified, uses the search endpoint (capped at 10,000 results).
+
+            Args:
+                params (TicketExportParams): Export parameters containing:
+                    - output_path (str): Path to output JSONL file (must end in .jsonl).
+                      Relative to ZAMMAD_EXPORT_DIR; absolute paths must resolve inside it.
+                    - query (str | None): Free text search filter
+                    - group (str | None): Filter by group name
+                    - state (str | None): Filter by state name
+                    - created_after (str | None): Filter tickets created on/after date (YYYY-MM-DD)
+                    - created_before (str | None): Filter tickets created on/before date (YYYY-MM-DD)
+                    - delay_seconds (float): Delay between API calls (default: 0.5)
+                    - per_page (int): Batch size per page (default: 50)
+                    - include_internal_articles (bool): Include internal notes (default: False)
+                    - resume_from_page (int): Page to resume from (default: 1)
+                    - max_tickets (int | None): Maximum tickets to export (default: None)
+                    - include_tags (bool): Fetch per-ticket tags via an extra API call (default: False)
+
+            Returns:
+                str: Markdown summary with file path, counts, elapsed time, and errors
+
+            JSONL record format (one per line):
+                ```json
+                {
+                    "ticket_id": 123,
+                    "ticket_number": "65003",
+                    "title": "Subject line",
+                    "group": "Support",
+                    "state": "closed",
+                    "priority": "2 normal",
+                    "tags": ["network"],
+                    "created_at": "2024-01-15T10:30:00Z",
+                    "updated_at": "2024-02-01T14:22:00Z",
+                    "conversation": [
+                        {
+                            "sender": "Customer",
+                            "type": "email",
+                            "from": "user@example.com",
+                            "subject": "Subject line",
+                            "body": "Plain text body...",
+                            "internal": false,
+                            "created_at": "2024-01-15T10:30:00Z"
+                        }
+                    ]
+                }
+                ```
+
+            Note:
+                - The file is opened in append mode to support resume from interruption.
+                - Each line is flushed immediately so progress survives crashes.
+                - Errors on individual tickets are logged but do not stop the export.
+                - The search endpoint is capped at 10,000 results by Zammad.
+            """
+            client = self.get_client()
+            start_time = time.monotonic()
+
+            use_search = any([params.query, params.group, params.state, params.created_after, params.created_before])
+
+            export_path = _resolve_export_path(params.output_path)
+
+            exported_count = 0
+            error_count = 0
+            errors: list[str] = []
+            page = params.resume_from_page
+
+            with open(export_path, "a") as f:
+                while page <= MAX_PAGES_FOR_TICKET_SCAN:
+                    batch = _fetch_export_batch(client, params, use_search, page)
+                    if not batch:
+                        break
+
+                    for ticket_summary in batch:
+                        ticket_id = ticket_summary.get("id")
+                        if not ticket_id:
+                            continue
+
+                        try:
+                            time.sleep(params.delay_seconds)
+                            ticket_data = client.get_ticket(
+                                ticket_id=ticket_id, include_articles=True, article_limit=-1
+                            )
+                            ticket_tags: list[str] | None = None
+                            if params.include_tags:
+                                ticket_tags = client.get_ticket_tags(ticket_id)
+                            record = _build_export_record(
+                                ticket_data,
+                                params.include_internal_articles,
+                                summary=ticket_summary,
+                                tags=ticket_tags,
+                            )
+                            f.write(json.dumps(record, default=str) + "\n")
+                            f.flush()
+                            exported_count += 1
+
+                            if params.max_tickets and exported_count >= params.max_tickets:
+                                break
+
+                        except Exception as e:
+                            error_count += 1
+                            if len(errors) < MAX_EXPORT_ERRORS_LOGGED:
+                                errors.append(f"Ticket {ticket_id}: {type(e).__name__} - {e}")
+
+                    if params.max_tickets and exported_count >= params.max_tickets:
+                        break
+
+                    page += 1
+
+            elapsed = time.monotonic() - start_time
+            return _format_export_summary(params, exported_count, error_count, errors, elapsed, use_search, export_path)
 
     def _setup_user_org_tools(self) -> None:
         """Register user and organization tools."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -35,6 +35,7 @@ from mcp_zammad.models import (
     StateBrief,
     Ticket,
     TicketCreate,
+    TicketExportParams,
     TicketPriority,
     TicketSearchParams,
     TicketState,
@@ -47,7 +48,10 @@ from mcp_zammad.server import (
     CHARACTER_LIMIT,
     AttachmentDeletionError,
     ZammadMCPServer,
+    _build_export_record,
     _format_ticket_detail_markdown,
+    _resolve_export_path,
+    _strip_html_tags,
     main,
     mcp,
     truncate_response,
@@ -3223,3 +3227,537 @@ def test_get_organization_supports_json_format(decorator_capturer):
     assert parsed["id"] == 2
     assert parsed["name"] == "ACME Corp"
     assert parsed["domain"] == "acme.com"
+
+
+# ==================== EXPORT TOOL TESTS ====================
+
+
+def _make_ticket_data(ticket_id: int, title: str = "Test Ticket") -> dict:
+    """Helper to create ticket data for export tests."""
+    return {
+        "id": ticket_id,
+        "number": str(60000 + ticket_id),
+        "title": title,
+        "group_id": 1,
+        "group": {"id": 1, "name": "Support"},
+        "state_id": 1,
+        "state": {"id": 1, "name": "open"},
+        "priority_id": 2,
+        "priority": {"id": 2, "name": "2 normal"},
+        "customer_id": 1,
+        "owner_id": 1,
+        "created_by_id": 1,
+        "updated_by_id": 1,
+        "created_at": "2024-01-15T10:30:00Z",
+        "updated_at": "2024-02-01T14:22:00Z",
+        "tags": ["network"],
+        "articles": [
+            {
+                "id": ticket_id * 10,
+                "ticket_id": ticket_id,
+                "type": "email",
+                "sender": "Customer",
+                "from": "user@example.com",
+                "subject": title,
+                "body": "<p>Hello, I need help with <b>this</b> issue.</p>",
+                "content_type": "text/html",
+                "internal": False,
+                "created_by_id": 1,
+                "updated_by_id": 1,
+                "created_at": "2024-01-15T10:30:00Z",
+                "updated_at": "2024-01-15T10:30:00Z",
+            },
+            {
+                "id": ticket_id * 10 + 1,
+                "ticket_id": ticket_id,
+                "type": "note",
+                "sender": "Agent",
+                "from": "agent@example.com",
+                "subject": "Internal note",
+                "body": "This is an internal note",
+                "content_type": "text/plain",
+                "internal": True,
+                "created_by_id": 2,
+                "updated_by_id": 2,
+                "created_at": "2024-01-15T11:00:00Z",
+                "updated_at": "2024-01-15T11:00:00Z",
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def export_dir(tmp_path, monkeypatch):
+    """Confine ticket exports to a per-test directory via ZAMMAD_EXPORT_DIR."""
+    monkeypatch.setenv("ZAMMAD_EXPORT_DIR", str(tmp_path))
+    return tmp_path
+
+
+def test_export_tickets_basic(mock_zammad_client, decorator_capturer, export_dir):
+    """Test basic export with 2 pages of tickets via list endpoint."""
+    mock_instance, _ = mock_zammad_client
+
+    # Page 1: 2 tickets, Page 2: empty (end)
+    mock_instance.list_tickets.side_effect = [
+        [{"id": 1}, {"id": 2}],
+        [],
+    ]
+    mock_instance.get_ticket.side_effect = [
+        _make_ticket_data(1, "First ticket"),
+        _make_ticket_data(2, "Second ticket"),
+    ]
+
+    server_inst = ZammadMCPServer()
+    server_inst.client = mock_instance
+    test_tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
+    server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
+    server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
+    server_inst._setup_tools()
+
+    output_file = str(export_dir / "export.jsonl")
+    params = TicketExportParams(output_path=output_file, delay_seconds=0.0, per_page=50)
+    result = test_tools["zammad_export_tickets"](params)
+
+    assert "Tickets exported**: 2" in result
+    assert "list (no limit)" in result
+
+    # Verify JSONL content
+    with open(output_file) as f:
+        lines = f.readlines()
+    assert len(lines) == 2
+
+    record = json.loads(lines[0])
+    assert record["ticket_id"] == 1
+    assert record["title"] == "First ticket"
+    assert record["group"] == "Support"
+    assert record["state"] == "open"
+    assert record["tags"] == ["network"]
+    assert len(record["conversation"]) == 1  # internal filtered out by default
+    assert "Hello, I need help with this issue." in record["conversation"][0]["body"]
+
+    # Verify list_tickets was used (not search_tickets)
+    mock_instance.list_tickets.assert_called()
+    mock_instance.search_tickets.assert_not_called()
+
+
+def test_export_tickets_filtered_uses_search(mock_zammad_client, decorator_capturer, export_dir):
+    """Test that filtered export uses search endpoint with 10K limit warning."""
+    mock_instance, _ = mock_zammad_client
+
+    mock_instance.search_tickets.side_effect = [
+        [{"id": 5}],
+        [],
+    ]
+    mock_instance.get_ticket.return_value = _make_ticket_data(5)
+
+    server_inst = ZammadMCPServer()
+    server_inst.client = mock_instance
+    test_tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
+    server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
+    server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
+    server_inst._setup_tools()
+
+    output_file = str(export_dir / "filtered.jsonl")
+    params = TicketExportParams(output_path=output_file, group="Support", delay_seconds=0.0)
+    result = test_tools["zammad_export_tickets"](params)
+
+    assert "search (10K limit)" in result
+    assert "10,000 results" in result
+    mock_instance.search_tickets.assert_called()
+    mock_instance.list_tickets.assert_not_called()
+
+
+def test_export_tickets_internal_articles_filtered(mock_zammad_client, decorator_capturer, export_dir):
+    """Test that internal articles are filtered when include_internal_articles=False."""
+    mock_instance, _ = mock_zammad_client
+
+    mock_instance.list_tickets.side_effect = [[{"id": 1}], []]
+    mock_instance.get_ticket.return_value = _make_ticket_data(1)
+
+    server_inst = ZammadMCPServer()
+    server_inst.client = mock_instance
+    test_tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
+    server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
+    server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
+    server_inst._setup_tools()
+
+    output_file = str(export_dir / "no_internal.jsonl")
+    params = TicketExportParams(output_path=output_file, delay_seconds=0.0, include_internal_articles=False)
+    test_tools["zammad_export_tickets"](params)
+
+    with open(output_file) as f:
+        record = json.loads(f.readline())
+    # Only the non-internal article should be included
+    assert len(record["conversation"]) == 1
+    assert record["conversation"][0]["internal"] is False
+
+
+def test_export_tickets_include_internal_articles(mock_zammad_client, decorator_capturer, export_dir):
+    """Test that internal articles are included when include_internal_articles=True."""
+    mock_instance, _ = mock_zammad_client
+
+    mock_instance.list_tickets.side_effect = [[{"id": 1}], []]
+    mock_instance.get_ticket.return_value = _make_ticket_data(1)
+
+    server_inst = ZammadMCPServer()
+    server_inst.client = mock_instance
+    test_tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
+    server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
+    server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
+    server_inst._setup_tools()
+
+    output_file = str(export_dir / "with_internal.jsonl")
+    params = TicketExportParams(output_path=output_file, delay_seconds=0.0, include_internal_articles=True)
+    test_tools["zammad_export_tickets"](params)
+
+    with open(output_file) as f:
+        record = json.loads(f.readline())
+    assert len(record["conversation"]) == 2
+
+
+def test_export_tickets_throttle_delay(mock_zammad_client, decorator_capturer, export_dir):
+    """Test that time.sleep is called with configured delay between ticket fetches."""
+    mock_instance, _ = mock_zammad_client
+
+    mock_instance.list_tickets.side_effect = [[{"id": 1}, {"id": 2}], []]
+    mock_instance.get_ticket.side_effect = [_make_ticket_data(1), _make_ticket_data(2)]
+
+    server_inst = ZammadMCPServer()
+    server_inst.client = mock_instance
+    test_tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
+    server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
+    server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
+    server_inst._setup_tools()
+
+    output_file = str(export_dir / "throttle.jsonl")
+    with patch("mcp_zammad.server.time.sleep") as mock_sleep:
+        params = TicketExportParams(output_path=output_file, delay_seconds=1.5)
+        test_tools["zammad_export_tickets"](params)
+
+    assert mock_sleep.call_count == 2
+    mock_sleep.assert_called_with(1.5)
+
+
+def test_export_tickets_per_ticket_error_handling(mock_zammad_client, decorator_capturer, export_dir):
+    """Test that errors on individual tickets don't stop the export."""
+    mock_instance, _ = mock_zammad_client
+
+    mock_instance.list_tickets.side_effect = [[{"id": 1}, {"id": 2}, {"id": 3}], []]
+    mock_instance.get_ticket.side_effect = [
+        _make_ticket_data(1),
+        Exception("Connection timeout"),
+        _make_ticket_data(3),
+    ]
+
+    server_inst = ZammadMCPServer()
+    server_inst.client = mock_instance
+    test_tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
+    server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
+    server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
+    server_inst._setup_tools()
+
+    output_file = str(export_dir / "errors.jsonl")
+    params = TicketExportParams(output_path=output_file, delay_seconds=0.0)
+    result = test_tools["zammad_export_tickets"](params)
+
+    assert "Tickets exported**: 2" in result
+    assert "Errors**: 1" in result
+    assert "Connection timeout" in result
+
+    with open(output_file) as f:
+        lines = f.readlines()
+    assert len(lines) == 2
+
+
+def test_export_tickets_resume_from_page(mock_zammad_client, decorator_capturer, export_dir):
+    """Test that resume_from_page starts pagination at the correct page."""
+    mock_instance, _ = mock_zammad_client
+
+    mock_instance.list_tickets.side_effect = [[{"id": 10}], []]
+    mock_instance.get_ticket.return_value = _make_ticket_data(10)
+
+    server_inst = ZammadMCPServer()
+    server_inst.client = mock_instance
+    test_tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
+    server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
+    server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
+    server_inst._setup_tools()
+
+    output_file = str(export_dir / "resume.jsonl")
+    params = TicketExportParams(output_path=output_file, delay_seconds=0.0, resume_from_page=3)
+    result = test_tools["zammad_export_tickets"](params)
+
+    assert "Resumed from page**: 3" in result
+    # Verify list_tickets was called with page=3 first
+    first_call = mock_instance.list_tickets.call_args_list[0]
+    assert first_call.kwargs["page"] == 3 or first_call[1].get("page") == 3
+
+
+def test_export_tickets_max_tickets_cap(mock_zammad_client, decorator_capturer, export_dir):
+    """Test that max_tickets stops export after N tickets."""
+    mock_instance, _ = mock_zammad_client
+
+    mock_instance.list_tickets.side_effect = [[{"id": 1}, {"id": 2}, {"id": 3}], []]
+    mock_instance.get_ticket.side_effect = [
+        _make_ticket_data(1),
+        _make_ticket_data(2),
+        _make_ticket_data(3),
+    ]
+
+    server_inst = ZammadMCPServer()
+    server_inst.client = mock_instance
+    test_tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
+    server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
+    server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
+    server_inst._setup_tools()
+
+    output_file = str(export_dir / "max.jsonl")
+    params = TicketExportParams(output_path=output_file, delay_seconds=0.0, max_tickets=2)
+    result = test_tools["zammad_export_tickets"](params)
+
+    assert "Tickets exported**: 2" in result
+    with open(output_file) as f:
+        lines = f.readlines()
+    assert len(lines) == 2
+
+
+def test_export_tickets_empty_results(mock_zammad_client, decorator_capturer, export_dir):
+    """Test export with no tickets returns clean result."""
+    mock_instance, _ = mock_zammad_client
+
+    mock_instance.list_tickets.return_value = []
+
+    server_inst = ZammadMCPServer()
+    server_inst.client = mock_instance
+    test_tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
+    server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
+    server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
+    server_inst._setup_tools()
+
+    output_file = str(export_dir / "empty.jsonl")
+    params = TicketExportParams(output_path=output_file, delay_seconds=0.0)
+    result = test_tools["zammad_export_tickets"](params)
+
+    assert "Tickets exported**: 0" in result
+    assert "Errors**: 0" in result
+
+
+@pytest.mark.parametrize(
+    "html_input,expected",
+    [
+        ("<p>Hello</p>", "Hello"),
+        ("<b>bold</b> and <i>italic</i>", "bold and italic"),
+        ("plain text", "plain text"),
+        ("&amp; &lt; &gt;", "& < >"),
+        ("<div><p>Nested</p></div>", "Nested"),
+        ("", ""),
+        ("  <p>  spaced  </p>  ", "spaced"),
+    ],
+)
+def test_strip_html_tags(html_input, expected):
+    """Test HTML tag stripping helper."""
+    assert _strip_html_tags(html_input) == expected
+
+
+def test_export_params_validation():
+    """Test TicketExportParams validation."""
+    # Valid
+    params = TicketExportParams(output_path="/tmp/test.jsonl")
+    assert params.output_path == "/tmp/test.jsonl"
+
+    # Invalid: not .jsonl
+    with pytest.raises(ValidationError, match=r"must end with \.jsonl"):
+        TicketExportParams(output_path="/tmp/test.json")
+
+    # Invalid: delay too high
+    with pytest.raises(ValidationError):
+        TicketExportParams(output_path="/tmp/test.jsonl", delay_seconds=20.0)
+
+    # Invalid: per_page too high
+    with pytest.raises(ValidationError):
+        TicketExportParams(output_path="/tmp/test.jsonl", per_page=200)
+
+    # resume_from_page must be >= 1
+    with pytest.raises(ValidationError):
+        TicketExportParams(output_path="/tmp/test.jsonl", resume_from_page=0)
+
+    # max_tickets must be >= 1
+    with pytest.raises(ValidationError):
+        TicketExportParams(output_path="/tmp/test.jsonl", max_tickets=0)
+
+
+def test_export_tickets_date_filters_use_search(mock_zammad_client, decorator_capturer, export_dir):
+    """Test that date filters trigger search endpoint."""
+    mock_instance, _ = mock_zammad_client
+
+    mock_instance.search_tickets.side_effect = [[{"id": 1}], []]
+    mock_instance.get_ticket.return_value = _make_ticket_data(1)
+
+    server_inst = ZammadMCPServer()
+    server_inst.client = mock_instance
+    test_tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
+    server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
+    server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
+    server_inst._setup_tools()
+
+    output_file = str(export_dir / "dates.jsonl")
+    params = TicketExportParams(
+        output_path=output_file,
+        created_after="2024-01-01",
+        created_before="2024-12-31",
+        delay_seconds=0.0,
+    )
+    result = test_tools["zammad_export_tickets"](params)
+
+    assert "search (10K limit)" in result
+    mock_instance.search_tickets.assert_called()
+    # Verify date params were passed
+    call_kwargs = mock_instance.search_tickets.call_args_list[0].kwargs
+    assert call_kwargs["created_after"] == "2024-01-01"
+    assert call_kwargs["created_before"] == "2024-12-31"
+
+
+class TestResolveExportPath:
+    """Tests for export path confinement (_resolve_export_path)."""
+
+    def test_requires_export_dir_env(self, monkeypatch):
+        """Export is disabled when ZAMMAD_EXPORT_DIR is unset."""
+        monkeypatch.delenv("ZAMMAD_EXPORT_DIR", raising=False)
+        with pytest.raises(ValueError, match="ZAMMAD_EXPORT_DIR is not set"):
+            _resolve_export_path("export.jsonl")
+
+    def test_rejects_missing_export_dir(self, tmp_path, monkeypatch):
+        """A configured directory that does not exist is rejected."""
+        monkeypatch.setenv("ZAMMAD_EXPORT_DIR", str(tmp_path / "nope"))
+        with pytest.raises(ValueError, match="not a directory"):
+            _resolve_export_path("export.jsonl")
+
+    def test_relative_path_resolves_inside_export_dir(self, tmp_path, monkeypatch):
+        """Relative paths are joined to the export directory."""
+        monkeypatch.setenv("ZAMMAD_EXPORT_DIR", str(tmp_path))
+        assert _resolve_export_path("export.jsonl") == (tmp_path / "export.jsonl").resolve()
+
+    def test_nested_relative_path_allowed(self, tmp_path, monkeypatch):
+        """Subdirectories of the export directory are permitted."""
+        monkeypatch.setenv("ZAMMAD_EXPORT_DIR", str(tmp_path))
+        (tmp_path / "sub").mkdir()
+        assert _resolve_export_path("sub/export.jsonl") == (tmp_path / "sub" / "export.jsonl").resolve()
+
+    def test_rejects_parent_traversal(self, tmp_path, monkeypatch):
+        """../ escapes are rejected."""
+        export_root = tmp_path / "exports"
+        export_root.mkdir()
+        monkeypatch.setenv("ZAMMAD_EXPORT_DIR", str(export_root))
+        with pytest.raises(ValueError, match="outside the export directory"):
+            _resolve_export_path("../escaped.jsonl")
+
+    def test_rejects_absolute_path_outside(self, tmp_path, monkeypatch):
+        """Absolute paths outside the export directory are rejected."""
+        export_root = tmp_path / "exports"
+        export_root.mkdir()
+        monkeypatch.setenv("ZAMMAD_EXPORT_DIR", str(export_root))
+        with pytest.raises(ValueError, match="outside the export directory"):
+            _resolve_export_path(str(tmp_path / "elsewhere.jsonl"))
+
+    def test_accepts_absolute_path_inside(self, tmp_path, monkeypatch):
+        """Absolute paths inside the export directory are accepted."""
+        monkeypatch.setenv("ZAMMAD_EXPORT_DIR", str(tmp_path))
+        target = tmp_path / "export.jsonl"
+        assert _resolve_export_path(str(target)) == target.resolve()
+
+    def test_rejects_symlink_escape(self, tmp_path, monkeypatch):
+        """A symlink inside the export directory cannot redirect writes outside it."""
+        export_root = tmp_path / "exports"
+        export_root.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (export_root / "link").symlink_to(outside)
+        monkeypatch.setenv("ZAMMAD_EXPORT_DIR", str(export_root))
+        with pytest.raises(ValueError, match="outside the export directory"):
+            _resolve_export_path("link/escaped.jsonl")
+
+    def test_export_tool_surfaces_disabled_error(self, mock_zammad_client, decorator_capturer, monkeypatch):
+        """The export tool fails clearly when the export directory is not configured."""
+        monkeypatch.delenv("ZAMMAD_EXPORT_DIR", raising=False)
+        mock_instance, _ = mock_zammad_client
+        server_inst = ZammadMCPServer()
+        server_inst.client = mock_instance
+        test_tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
+        server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
+        server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
+        server_inst._setup_tools()
+
+        params = TicketExportParams(output_path="export.jsonl", delay_seconds=0.0)
+        with pytest.raises(ValueError, match="ZAMMAD_EXPORT_DIR is not set"):
+            test_tools["zammad_export_tickets"](params)
+
+
+class TestExportExpandedFields:
+    """Export records must recover expanded names the detail endpoint cannot return."""
+
+    def test_summary_supplies_expanded_names(self):
+        """find() returns *_id only, so names come from the expanded batch summary."""
+        detail = {"id": 1, "number": "1001", "title": "T", "group_id": 2, "state_id": 3, "priority_id": 4}
+        summary = {"id": 1, "group": "GSI Tech Team", "state": "closed", "priority": "2 normal"}
+        record = _build_export_record(detail, include_internal=False, summary=summary)
+        assert record["group"] == "GSI Tech Team"
+        assert record["state"] == "closed"
+        assert record["priority"] == "2 normal"
+
+    def test_detail_takes_precedence_over_summary(self):
+        """When the detail payload does carry names, they win."""
+        detail = {"id": 1, "group": "Detail Group", "state": "open", "priority": "1 low"}
+        summary = {"id": 1, "group": "Stale Group", "state": "closed", "priority": "3 high"}
+        record = _build_export_record(detail, include_internal=False, summary=summary)
+        assert record["group"] == "Detail Group"
+        assert record["state"] == "open"
+
+    def test_missing_summary_is_safe(self):
+        """No summary yields empty strings rather than an error."""
+        record = _build_export_record({"id": 1}, include_internal=False)
+        assert record["group"] == ""
+        assert record["tags"] == []
+
+    def test_explicit_tags_used(self):
+        """Tags fetched separately land in the record."""
+        record = _build_export_record({"id": 1}, include_internal=False, tags=["network", "vpn"])
+        assert record["tags"] == ["network", "vpn"]
+
+    def test_export_fetches_tags_when_requested(self, mock_zammad_client, decorator_capturer, export_dir):
+        """include_tags triggers one get_ticket_tags call per exported ticket."""
+        mock_instance, _ = mock_zammad_client
+        mock_instance.list_tickets.side_effect = [[{"id": 1, "group": "Support"}], []]
+        mock_instance.get_ticket.side_effect = [_make_ticket_data(1, "First ticket")]
+        mock_instance.get_ticket_tags.return_value = ["network"]
+
+        server_inst = ZammadMCPServer()
+        server_inst.client = mock_instance
+        test_tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
+        server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
+        server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
+        server_inst._setup_tools()
+
+        output_file = str(export_dir / "tags.jsonl")
+        params = TicketExportParams(output_path=output_file, delay_seconds=0.0, include_tags=True)
+        test_tools["zammad_export_tickets"](params)
+
+        mock_instance.get_ticket_tags.assert_called_once_with(1)
+        with open(output_file) as f:
+            assert json.loads(f.readline())["tags"] == ["network"]
+
+    def test_export_skips_tag_fetch_by_default(self, mock_zammad_client, decorator_capturer, export_dir):
+        """Without include_tags no extra tag calls are made."""
+        mock_instance, _ = mock_zammad_client
+        mock_instance.list_tickets.side_effect = [[{"id": 1}], []]
+        mock_instance.get_ticket.side_effect = [_make_ticket_data(1, "First ticket")]
+
+        server_inst = ZammadMCPServer()
+        server_inst.client = mock_instance
+        test_tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
+        server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
+        server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
+        server_inst._setup_tools()
+
+        params = TicketExportParams(output_path=str(export_dir / "notags.jsonl"), delay_seconds=0.0)
+        test_tools["zammad_export_tickets"](params)
+        mock_instance.get_ticket_tags.assert_not_called()


### PR DESCRIPTION
## Upfront

This one proposes a capability the server doesn't currently have — writing to the host filesystem — so it's a bigger ask than a bug fix, and **a "no" is a completely fine outcome.** We built it for our own use and figured it might be useful to others, so we're offering it rather than lobbying for it. If the direction isn't right for the project, close it without ceremony; no hard feelings and nothing is blocked on it. Equally happy to rework the shape if you like the idea but not the implementation.

## What it does

`zammad_export_tickets` walks a ticket set and writes one JSON object per ticket to a JSONL file, with the full conversation inlined:

```json
{"ticket_id": 17, "ticket_number": "190017", "title": "...", "group": "GSI Tech Team",
 "state": "closed", "priority": "2 normal", "tags": ["Access Request"],
 "created_at": "...", "updated_at": "...",
 "conversation": [{"sender": "Customer", "type": "email", "body": "...", "internal": false}]}
```

The motivation is corpora too large to pass through tool responses. A few thousand tickets with articles is far past any response limit, so for analysis or training data the result has to land on disk to be usable at all.

## Design notes

**Endpoint selection.** Filtered exports go through the search endpoint, which Zammad caps at 10,000 results. Unfiltered exports use the list endpoint, which has no cap, so a full history can be walked — `list_tickets()` is added for that path. The chosen mode is reported in the summary so the cap is never silently in play.

**Filesystem boundary.** This is the only tool that writes to the host filesystem, and `zammad_download_attachment` returning base64 rather than writing suggests that's deliberate. So the write is fenced: output is confined to `ZAMMAD_EXPORT_DIR`, relative paths resolve against it, absolute paths must resolve inside it, and resolution happens *before* the containment check so a symlink planted in the directory can't redirect writes out. The variable is required rather than defaulted — with it unset the tool refuses to run, so the capability is opt-in and a default install gains no filesystem access.

**Expanded fields.** Records build from the per-ticket detail fetch, which uses the find endpoint and can't expand, so `group`/`state`/`priority` would come back empty. The batch summary each ticket came from does carry expanded names, so it's threaded through as a fallback. (#313 fixes the underlying `get_ticket` gap; this branch doesn't depend on it and the fallback stays correct either way.)

**Tags** aren't in the ticket payload at all and need a separate call, so `include_tags` is offered and defaulted off — it costs one extra request per ticket.

**Long runs.** `resume_from_page` continues an interrupted export, `delay_seconds` throttles, `max_tickets` bounds a run, and per-ticket errors are collected and reported rather than aborting.

## Overlap with the other PRs

`created_after` / `created_before` on `search_tickets` also appear in #315. These branches are independent and either can land first; whichever is second will need a trivial rebase.

## Tests

26 tests: export mechanics (batching, resume, caps, internal-article filtering, throttling, per-ticket error handling), path confinement (traversal, absolute escape, symlink escape, missing directory, disabled-by-default), and expanded-field recovery.

`ruff check`, `ruff format --check`, `mypy`, `bandit` and the full suite (255 tests) all pass.