### PR TITLE
fix: add customer field to zammad_update_ticket

### DIFF
--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -247,8 +247,8 @@ class ZammadClient:
         priority: str | None = None,
         owner: str | None = None,
         group: str | None = None,
-        customer: str | None = None,
         time_unit: float | None = None,
+        customer: str | None = None,
     ) -> dict[str, Any]:
         """Update an existing ticket."""
         if time_unit is not None and time_unit <= 0:

--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -247,6 +247,7 @@ class ZammadClient:
         priority: str | None = None,
         owner: str | None = None,
         group: str | None = None,
+        customer: str | None = None,
         time_unit: float | None = None,
     ) -> dict[str, Any]:
         """Update an existing ticket."""
@@ -264,6 +265,8 @@ class ZammadClient:
             update_data["owner"] = owner
         if group is not None:
             update_data["group"] = group
+        if customer is not None:
+            update_data["customer"] = customer
         if time_unit is not None:
             update_data["time_unit"] = time_unit
 

--- a/mcp_zammad/models.py
+++ b/mcp_zammad/models.py
@@ -373,6 +373,7 @@ class TicketUpdateParams(StrictBaseModel):
     priority: str | None = Field(None, description="New priority name", max_length=100)
     owner: str | None = Field(None, description="New owner login/email", max_length=255)
     group: str | None = Field(None, description="New group name", max_length=100)
+    customer: str | None = Field(None, description="New customer email/login (must exist in Zammad)", max_length=255)
     time_unit: float | None = Field(
         None, description="Time spent for time accounting (unit defined in Zammad admin settings)", gt=0
     )

--- a/tests/test_client_methods.py
+++ b/tests/test_client_methods.py
@@ -72,6 +72,23 @@ class TestZammadClientMethods:
         assert result["title"] == "Updated Title"
         mock_instance.ticket.update.assert_called_once_with(1, {"title": "Updated Title", "state": "open"})
 
+    def test_update_ticket_with_customer(self, mock_zammad_api: Mock) -> None:
+        """Test update_ticket method with customer reassignment."""
+        mock_instance = Mock()
+        mock_instance.ticket.update.return_value = {
+            "id": 1,
+            "title": "Updated Title",
+            "customer": {"email": "new@example.com"},
+        }
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+
+        result = client.update_ticket(1, customer="new@example.com")
+
+        assert "customer" in result
+        mock_instance.ticket.update.assert_called_once_with(1, {"customer": "new@example.com"})
+
     def test_update_ticket_with_time_unit(self, mock_zammad_api: Mock) -> None:
         """Test update_ticket method with time_unit for time accounting."""
         mock_instance = Mock()

--- a/tests/test_client_methods.py
+++ b/tests/test_client_methods.py
@@ -86,7 +86,7 @@ class TestZammadClientMethods:
 
         result = client.update_ticket(1, customer="new@example.com")
 
-        assert "customer" in result
+        assert result["customer"]["email"] == "new@example.com"
         mock_instance.ticket.update.assert_called_once_with(1, {"customer": "new@example.com"})
 
     def test_update_ticket_with_time_unit(self, mock_zammad_api: Mock) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,6 +12,7 @@ from mcp_zammad.models import (
     ResponseFormat,
     TicketCreate,
     TicketUpdate,
+    TicketUpdateParams,
 )
 
 
@@ -68,6 +69,21 @@ class TestTicketUpdate:
         with pytest.raises(ValidationError) as exc_info:
             TicketUpdate(title="x" * 201)  # type: ignore[call-arg]  # Exceeds 200 char limit
         assert "String should have at most 200 characters" in str(exc_info.value)
+
+
+class TestTicketUpdateParams:
+    """Test TicketUpdateParams model validation."""
+
+    def test_customer_at_max_length_accepted(self):
+        """A 255-character customer value is accepted (max_length boundary)."""
+        params = TicketUpdateParams(ticket_id=1, customer="x" * 255)  # type: ignore[call-arg]
+        assert params.customer == "x" * 255
+
+    def test_customer_over_max_length_rejected(self):
+        """A 256-character customer value is rejected (exceeds max_length)."""
+        with pytest.raises(ValidationError) as exc_info:
+            TicketUpdateParams(ticket_id=1, customer="x" * 256)  # type: ignore[call-arg]
+        assert "String should have at most 255 characters" in str(exc_info.value)
 
 
 class TestArticleCreate:


### PR DESCRIPTION
## Problem

The `zammad_update_ticket` tool's docstring documents a `customer` parameter,
but passing one is rejected:

## Root Cause

`customer` was never implemented at either layer:

- `TicketUpdateParams` (models.py) has no `customer` field, and
  `StrictBaseModel` forbids extra inputs, so the parameter is rejected at
  validation time.
- `ZammadClient.update_ticket` (client.py) also has no `customer` argument.
  Even if accepted, it would be silently dropped.

The docstring is ahead of the code; the feature simply wasn't built.

## Fix

- **models.py**: add `customer: str | None` (email/login, `max_length=255`)
  to `TicketUpdateParams`, mirroring the existing `owner` field.
- **client.py**: add `customer` to `ZammadClient.update_ticket` and include it
  in the update payload when set. Zammad's API accepts a customer
  email/login directly on ticket update (the same form `create_ticket`
  already sends), so no ID lookup is required.
- **tests**: add `test_update_ticket_with_customer` covering customer
  forwarding in the update payload.

## Verification

- [x] All 223 tests pass (222 existing + 1 new)
- [x] Ruff lint: no new findings (5 pre-existing `PLR0917` on `main` unchanged)
- [x] Ruff format: clean
- [x] MyPy: clean
- [x] E2E against a live Zammad instance over MCP stdio:
  `zammad_update_ticket(ticket_id=N, customer="user@example.com")`
  reassigns the ticket's customer, verified with `zammad_get_ticket`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ticket updates can now optionally reassign the customer using their email address or login.
  * Customer changes are included in the ticket update request when provided.
  * Customer information is validated before submission, with names limited to 255 characters.
  * Updated ticket details reflect the newly assigned customer after a successful update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->