### PR TITLE
fix(client): request expand=true when fetching a single ticket

### DIFF
--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -5,6 +5,7 @@ import os
 from typing import Any
 from urllib.parse import urlparse
 
+import requests  # type: ignore[import-untyped]
 from zammad_py import ZammadAPI
 from zammad_py.exceptions import ConfigException
 
@@ -189,11 +190,34 @@ class ZammadClient:
 
         return list(result)
 
+    def _find_ticket_expanded(self, ticket_id: int) -> dict[str, Any]:
+        """Fetch a single ticket with ``expand=true``.
+
+        The expand value must be the lowercase string ``"true"`` — Zammad is
+        case-sensitive here and ``requests`` serializes the bool ``True`` as
+        ``"True"``, which Zammad ignores.
+
+        Raises:
+            requests.HTTPError: If the API request fails, carrying Zammad's
+                response body so callers can detect "Couldn't find Ticket ..."
+        """
+        response = self.api.session.get(f"{self.url}/tickets/{ticket_id}", params={"expand": "true"})
+        if not response.ok:
+            raise requests.HTTPError(response.text)
+        return dict(response.json())
+
     def get_ticket(
         self, ticket_id: int, include_articles: bool = True, article_limit: int = 10, article_offset: int = 0
     ) -> dict[str, Any]:
-        """Get a single ticket by ID with optional article pagination."""
-        ticket = self.api.ticket.find(ticket_id)
+        """Get a single ticket by ID with optional article pagination.
+
+        Uses a direct HTTP call via zammad_py's internal session because
+        ``Resource.find()`` accepts no filters, so there is no way to pass
+        ``expand=true`` through it. Without expansion Zammad only returns the
+        ``*_id`` fields and the state/priority/group/owner/customer names all
+        render as "Unknown".
+        """
+        ticket = self._find_ticket_expanded(ticket_id)
 
         if include_articles:
             articles = self.api.ticket.articles(ticket_id)

--- a/tests/test_client_methods.py
+++ b/tests/test_client_methods.py
@@ -320,10 +320,20 @@ class TestZammadClientMethods:
         assert len(result) == 1
         mock_instance.ticket.all.assert_called_once_with(filters={"page": 1, "per_page": 25, "expand": "true"})
 
+    @staticmethod
+    def _mock_ticket_response(mock_instance: Mock, payload: dict, *, ok: bool = True, text: str = "") -> Mock:
+        """Point the client's session at a canned GET /tickets/{id} response."""
+        response = Mock()
+        response.ok = ok
+        response.text = text
+        response.json.return_value = payload
+        mock_instance.session.get.return_value = response
+        return response
+
     def test_get_ticket_with_articles(self, mock_zammad_api: Mock) -> None:
         """Test get_ticket with article pagination."""
         mock_instance = Mock()
-        mock_instance.ticket.find.return_value = {"id": 1, "title": "Test Ticket"}
+        self._mock_ticket_response(mock_instance, {"id": 1, "title": "Test Ticket"})
         mock_instance.ticket.articles.return_value = [
             {"id": 1, "body": "Article 1"},
             {"id": 2, "body": "Article 2"},
@@ -346,7 +356,7 @@ class TestZammadClientMethods:
     def test_get_ticket_all_articles(self, mock_zammad_api: Mock) -> None:
         """Test get_ticket with all articles."""
         mock_instance = Mock()
-        mock_instance.ticket.find.return_value = {"id": 1, "title": "Test Ticket"}
+        self._mock_ticket_response(mock_instance, {"id": 1, "title": "Test Ticket"})
         mock_instance.ticket.articles.return_value = [{"id": 1, "body": "Article 1"}, {"id": 2, "body": "Article 2"}]
         mock_zammad_api.return_value = mock_instance
 
@@ -356,6 +366,62 @@ class TestZammadClientMethods:
         result = client.get_ticket(1, include_articles=True, article_limit=-1)
 
         assert len(result["articles"]) == 2
+
+    def test_get_ticket_requests_expanded_fields(self, mock_zammad_api: Mock) -> None:
+        """get_ticket must ask for expand=true, otherwise names come back as None.
+
+        Regression test: without the flag Zammad only returns ``*_id`` fields and
+        the server renders State/Priority/Group/Owner/Customer as "Unknown".
+        """
+        mock_instance = Mock()
+        self._mock_ticket_response(
+            mock_instance,
+            {
+                "id": 1,
+                "title": "Test Ticket",
+                "state_id": 2,
+                "state": "open",
+                "priority_id": 3,
+                "priority": "3 high",
+                "group": "Support",
+            },
+        )
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+
+        result = client.get_ticket(1, include_articles=False)
+
+        mock_instance.session.get.assert_called_once_with(
+            "https://test.zammad.com/api/v1/tickets/1", params={"expand": "true"}
+        )
+        # The literal string "true" matters: requests serializes bool True as
+        # "True", which Zammad ignores because the parameter is case-sensitive.
+        _, kwargs = mock_instance.session.get.call_args
+        assert kwargs["params"]["expand"] == "true"
+        assert result["state"] == "open"
+        assert result["priority"] == "3 high"
+        assert result["group"] == "Support"
+
+    def test_get_ticket_not_found_raises_with_zammad_message(self, mock_zammad_api: Mock) -> None:
+        """A failed lookup must surface Zammad's body so the server can map it.
+
+        The server turns "Couldn't find Ticket ..." into TicketIdGuidanceError,
+        so the response text has to survive.
+        """
+        mock_instance = Mock()
+        self._mock_ticket_response(
+            mock_instance,
+            {},
+            ok=False,
+            text='{"error":"Couldn\'t find Ticket with \'id\'=999"}',
+        )
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+
+        with pytest.raises(requests.HTTPError, match="Couldn't find Ticket"):
+            client.get_ticket(999)
 
     def test_create_ticket(self, mock_zammad_api: Mock) -> None:
         """Test create_ticket method."""


### PR DESCRIPTION
Fixes #319

## Problem

`zammad_get_ticket` — and the `zammad://ticket/{id}` resource, which shares the same client method — renders State, Priority, Group, Owner and Customer as `Unknown` for every ticket.

`get_ticket` fetched the ticket with `api.ticket.find(ticket_id)`, and `zammad_py`'s `Resource.find()` accepts no filters, so `expand=true` never reached Zammad. Without it the API returns only `*_id` fields, the optional `Ticket` fields stay `None`, and `_brief_field` falls back to `"Unknown"`.

`search_tickets` was unaffected because it passes `filters={..., "expand": "true"}` — this is the one call site the earlier expand work (`tests/test_expand_param_fix.py`) could not cover, since `find()` has no filters parameter at all.

## Change

Fetch the ticket through `zammad_py`'s session with `params={"expand": "true"}`, in a small `_find_ticket_expanded` helper. This follows the pattern `list_tags` already uses for the `tag_list` endpoint, and keeps the lowercase `"true"` that the existing tests care about (Zammad is case-sensitive here and `requests` serializes bool `True` as `"True"`).

On failure it raises `requests.HTTPError(response.text)` — same shape `zammad_py` produces — so the server's `TicketIdGuidanceError` mapping, which looks for `"couldn't find"` in the message, still fires for a bad ticket id.

No model changes were needed: `Ticket` already declares `group: GroupBrief | str | None` and friends, with a comment noting the string form arrives when `expand=true`.

## Tests

- Updated the two existing `get_ticket` tests to mock the session response instead of `ticket.find`.
- `test_get_ticket_requests_expanded_fields` — asserts the exact URL and that `expand` is the literal `"true"`, and that the expanded names survive.
- `test_get_ticket_not_found_raises_with_zammad_message` — asserts Zammad's error body survives, so the ticket-id guidance keeps working.

224 passed, coverage 88.47% (gate 86%). `ruff check`, `ruff format --check` and `mypy mcp_zammad` all clean on the touched files.

## Verification against a real instance

Zammad 6.5, ticket #27003, before and after:

```
**State**: Unknown        ->  **State**: open
**Priority**: Unknown     ->  **Priority**: 2 normal
**Group**: Unknown        ->  **Group**: CGT
**Owner**: Unknown        ->  **Owner**: -
**Customer**: Unknown     ->  **Customer**: jovanir
```

## Note

Out of scope here, but flagged in the issue: `_brief_field` only checks `isinstance(value, StateBrief | PriorityBrief | UserBrief)`, so a `GroupBrief` or `OrganizationBrief` object would still yield `"Unknown"`. It does not bite with `expand=true` (Zammad sends plain strings), so I left it alone — happy to fold in a one-liner if you want it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ticket details now include expanded fields when retrieved.
  * Ticket lookup errors provide the service’s response message for clearer troubleshooting.
  * Existing article pagination behavior is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->