### PR TITLE
test: cover double quotes in plain-text sanitization (follow-up to #307)

### DIFF
--- a/mcp_zammad/models.py
+++ b/mcp_zammad/models.py
@@ -269,8 +269,12 @@ class TicketCreate(StrictBaseModel):
     @field_validator("title", "article_body")
     @classmethod
     def sanitize_html(cls, v: str) -> str:
-        """Escape HTML to prevent XSS attacks."""
-        return html.escape(v)
+        """Escape HTML to prevent XSS attacks.
+
+        quote=False: title and the initial article are plain text (no content_type choice here),
+        sent/stored verbatim, so quotes and apostrophes must not become &#x27;/&quot; entities.
+        """
+        return html.escape(v, quote=False)
 
 
 class TicketUpdate(StrictBaseModel):
@@ -341,7 +345,10 @@ class ArticleCreate(StrictBaseModel):
     def sanitize_body(self) -> "ArticleCreate":
         """Sanitize body content according to content type."""
         if self.content_type == "text/plain":
-            self.body = html.escape(self.body)
+            # quote=False: plain text is sent/stored verbatim (e.g. in outbound emails), so quotes
+            # and apostrophes must not be turned into &#x27;/&quot; entities. Still neutralize
+            # <, >, & in case a downstream renderer treats the body as HTML despite the content type.
+            self.body = html.escape(self.body, quote=False)
         else:
             self.body = self._sanitize_html_body(self.body)
         return self

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,7 +26,7 @@ class TestTicketCreate:
             customer="test@example.com",
             article_body="Test body",
         )
-        assert ticket.title == "&lt;script&gt;alert(&#x27;XSS&#x27;)&lt;/script&gt;"
+        assert ticket.title == "&lt;script&gt;alert('XSS')&lt;/script&gt;"
 
     def test_html_sanitization_in_body(self):
         """Test that HTML is escaped in article body."""
@@ -36,7 +36,7 @@ class TestTicketCreate:
             customer="test@example.com",
             article_body="<b>Bold</b> and <script>alert('XSS')</script>",
         )
-        assert ticket.article_body == "&lt;b&gt;Bold&lt;/b&gt; and &lt;script&gt;alert(&#x27;XSS&#x27;)&lt;/script&gt;"
+        assert ticket.article_body == "&lt;b&gt;Bold&lt;/b&gt; and &lt;script&gt;alert('XSS')&lt;/script&gt;"
 
     def test_field_length_limits(self):
         """Test that field length limits are enforced."""
@@ -74,12 +74,17 @@ class TestArticleCreate:
     """Test ArticleCreate model validation."""
 
     def test_html_sanitization_in_body(self):
-        """Test that HTML is escaped in article body."""
+        """Test that HTML is escaped in article body, but quotes/apostrophes are left intact.
+
+        text/plain bodies are sent verbatim (e.g. in outbound emails), so quotes must not
+        become &#x27;/&quot; entities. <, >, & are still escaped, which already neutralizes
+        the tag regardless of the quote style used inside it.
+        """
         article = ArticleCreate(
             ticket_id=123,
             body="<div onclick='alert()'>Click me</div>",
         )
-        assert article.body == "&lt;div onclick=&#x27;alert()&#x27;&gt;Click me&lt;/div&gt;"
+        assert article.body == "&lt;div onclick='alert()'&gt;Click me&lt;/div&gt;"
 
     def test_ticket_id_validation(self):
         """Test that ticket_id must be positive."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,6 +38,17 @@ class TestTicketCreate:
         )
         assert ticket.article_body == "&lt;b&gt;Bold&lt;/b&gt; and &lt;script&gt;alert('XSS')&lt;/script&gt;"
 
+    def test_quotes_preserved_in_plain_text(self):
+        """Test that double quotes and apostrophes survive sanitization while & is still escaped."""
+        ticket = TicketCreate(
+            title='He said "we\'ve got it"',
+            group="Support",
+            customer="test@example.com",
+            article_body='Quote: "you\'d agree" & more',
+        )
+        assert ticket.title == 'He said "we\'ve got it"'
+        assert ticket.article_body == 'Quote: "you\'d agree" &amp; more'
+
     def test_field_length_limits(self):
         """Test that field length limits are enforced."""
         with pytest.raises(ValidationError) as exc_info:
@@ -85,6 +96,11 @@ class TestArticleCreate:
             body="<div onclick='alert()'>Click me</div>",
         )
         assert article.body == "&lt;div onclick='alert()'&gt;Click me&lt;/div&gt;"
+
+    def test_double_quotes_preserved_in_plain_text_body(self):
+        """Test that double quotes are not turned into &quot; for text/plain bodies."""
+        article = ArticleCreate(ticket_id=123, body='She said "hello" & left')
+        assert article.body == 'She said "hello" &amp; left'
 
     def test_ticket_id_validation(self):
         """Test that ticket_id must be positive."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -627,6 +627,9 @@ def test_add_article_content_type_validation() -> None:
     plain_article = ArticleCreate(ticket_id=1, body="<p>plain</p>", content_type="text/plain")
     assert plain_article.body == "&lt;p&gt;plain&lt;/p&gt;"
 
+    apostrophe_article = ArticleCreate(ticket_id=1, body="we've got it, you'd agree", content_type="text/plain")
+    assert apostrophe_article.body == "we've got it, you'd agree"
+
     with pytest.raises(ValidationError, match="content_type"):
         ArticleCreate(ticket_id=1, body="test", content_type="application/json")  # type: ignore[arg-type]
 


### PR DESCRIPTION
## Summary

Supplemental test coverage for #307 (fix: don't HTML-escape quotes/apostrophes in plain-text article/ticket content). Lands **after** #307 — this branch is based on its head commit and contains only test additions on top of it.

#307's updated assertions only exercise apostrophes; the bug it fixes also covered `"` → `&quot;`. This adds explicit cases so a regression to `quote=True` fails on both halves:

- `TestTicketCreate::test_quotes_preserved_in_plain_text` — `"` and `'` preserved in title and article_body, `&` still escaped
- `TestArticleCreate::test_double_quotes_preserved_in_plain_text_body` — same for `text/plain` article bodies

## Addresses

- Review finding (non-blocking) on #307: no assertion covers the double-quote half of the described bug.

## Test plan

- [x] `uv run --frozen pytest -q tests/test_models.py` — 24 passed
- [x] `ruff check` / `ruff format --check` clean on the changed file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plain-text ticket titles and article content now preserve quotation marks and apostrophes while continuing to escape HTML-sensitive characters.
  * HTML content continues to use the existing sanitization behavior.

* **Tests**
  * Added coverage for quote and apostrophe preservation across ticket titles and article bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->