### PR TITLE
test: cover customer forwarding through zammad_update_ticket tool (follow-up to #318)

### DIFF
--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -247,8 +247,8 @@ class ZammadClient:
         priority: str | None = None,
         owner: str | None = None,
         group: str | None = None,
-        customer: str | None = None,
         time_unit: float | None = None,
+        customer: str | None = None,
     ) -> dict[str, Any]:
         """Update an existing ticket."""
         if time_unit is not None and time_unit <= 0:

--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -247,6 +247,7 @@ class ZammadClient:
         priority: str | None = None,
         owner: str | None = None,
         group: str | None = None,
+        customer: str | None = None,
         time_unit: float | None = None,
     ) -> dict[str, Any]:
         """Update an existing ticket."""
@@ -264,6 +265,8 @@ class ZammadClient:
             update_data["owner"] = owner
         if group is not None:
             update_data["group"] = group
+        if customer is not None:
+            update_data["customer"] = customer
         if time_unit is not None:
             update_data["time_unit"] = time_unit
 

--- a/mcp_zammad/models.py
+++ b/mcp_zammad/models.py
@@ -373,6 +373,7 @@ class TicketUpdateParams(StrictBaseModel):
     priority: str | None = Field(None, description="New priority name", max_length=100)
     owner: str | None = Field(None, description="New owner login/email", max_length=255)
     group: str | None = Field(None, description="New group name", max_length=100)
+    customer: str | None = Field(None, description="New customer email/login (must exist in Zammad)", max_length=255)
     time_unit: float | None = Field(
         None, description="Time spent for time accounting (unit defined in Zammad admin settings)", gt=0
     )

--- a/tests/test_client_methods.py
+++ b/tests/test_client_methods.py
@@ -72,6 +72,23 @@ class TestZammadClientMethods:
         assert result["title"] == "Updated Title"
         mock_instance.ticket.update.assert_called_once_with(1, {"title": "Updated Title", "state": "open"})
 
+    def test_update_ticket_with_customer(self, mock_zammad_api: Mock) -> None:
+        """Test update_ticket method with customer reassignment."""
+        mock_instance = Mock()
+        mock_instance.ticket.update.return_value = {
+            "id": 1,
+            "title": "Updated Title",
+            "customer": {"email": "new@example.com"},
+        }
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+
+        result = client.update_ticket(1, customer="new@example.com")
+
+        assert "customer" in result
+        mock_instance.ticket.update.assert_called_once_with(1, {"customer": "new@example.com"})
+
     def test_update_ticket_with_time_unit(self, mock_zammad_api: Mock) -> None:
         """Test update_ticket method with time_unit for time accounting."""
         mock_instance = Mock()

--- a/tests/test_client_methods.py
+++ b/tests/test_client_methods.py
@@ -86,7 +86,7 @@ class TestZammadClientMethods:
 
         result = client.update_ticket(1, customer="new@example.com")
 
-        assert "customer" in result
+        assert result["customer"]["email"] == "new@example.com"
         mock_instance.ticket.update.assert_called_once_with(1, {"customer": "new@example.com"})
 
     def test_update_ticket_with_time_unit(self, mock_zammad_api: Mock) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,6 +12,7 @@ from mcp_zammad.models import (
     ResponseFormat,
     TicketCreate,
     TicketUpdate,
+    TicketUpdateParams,
 )
 
 
@@ -68,6 +69,21 @@ class TestTicketUpdate:
         with pytest.raises(ValidationError) as exc_info:
             TicketUpdate(title="x" * 201)  # type: ignore[call-arg]  # Exceeds 200 char limit
         assert "String should have at most 200 characters" in str(exc_info.value)
+
+
+class TestTicketUpdateParams:
+    """Test TicketUpdateParams model validation."""
+
+    def test_customer_at_max_length_accepted(self):
+        """A 255-character customer value is accepted (max_length boundary)."""
+        params = TicketUpdateParams(ticket_id=1, customer="x" * 255)  # type: ignore[call-arg]
+        assert params.customer == "x" * 255
+
+    def test_customer_over_max_length_rejected(self):
+        """A 256-character customer value is rejected (exceeds max_length)."""
+        with pytest.raises(ValidationError) as exc_info:
+            TicketUpdateParams(ticket_id=1, customer="x" * 256)  # type: ignore[call-arg]
+        assert "String should have at most 255 characters" in str(exc_info.value)
 
 
 class TestArticleCreate:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1004,6 +1004,30 @@ def test_update_ticket_with_time_unit_tool(mock_zammad_client, sample_ticket_dat
     mock_instance.update_ticket.assert_called_once_with(ticket_id=1, title="Updated Title", time_unit=2.5)
 
 
+def test_update_ticket_with_customer_tool(mock_zammad_client, sample_ticket_data, decorator_capturer):
+    """Test zammad_update_ticket tool forwards customer for reassignment."""
+    mock_instance, _ = mock_zammad_client
+
+    updated_ticket = sample_ticket_data.copy()
+    updated_ticket["customer"] = {"id": 5, "email": "new@example.com"}
+
+    mock_instance.update_ticket.return_value = updated_ticket
+
+    server_inst = ZammadMCPServer()
+    server_inst.client = mock_instance
+
+    test_tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
+    server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
+    server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
+    server_inst._setup_tools()
+
+    params = TicketUpdateParams(ticket_id=1, customer="new@example.com")
+    result = test_tools["zammad_update_ticket"](params)
+
+    assert result.id == 1
+    mock_instance.update_ticket.assert_called_once_with(ticket_id=1, customer="new@example.com")
+
+
 def test_update_ticket_without_time_unit_tool(mock_zammad_client, sample_ticket_data, decorator_capturer):
     """Test zammad_update_ticket tool omits time_unit when not provided."""
     mock_instance, _ = mock_zammad_client


### PR DESCRIPTION
## Summary

Non-blocking follow-up from the Factory review of #318 (`feat/update-ticket-customer`). This branch is based on that PR's head and **lands after #318** — it comes from a fork, so this PR targets `main` rather than the contributor's branch.

Adds one supplemental test covering the finding the review recorded as non-blocking:

- **Server-tool-layer coverage for `customer`** — #318 tests `customer` at the `TicketUpdateParams` and `ZammadClient.update_ticket` layers; `test_update_ticket_with_customer_tool` asserts the full MCP path (`zammad_update_ticket` → `model_dump(exclude_none=True)` → `client.update_ticket(ticket_id=1, customer="new@example.com")`), mirroring the existing `test_update_ticket_with_time_unit_tool`.

## Test plan

- [x] `uv run pytest -q` — 226 passed
- [x] `uv run ruff check tests/test_server.py` / `ruff format --check` — clean

Co-authored with @bundabrg, whose PR this builds on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ticket updates now support reassigning a ticket to an existing customer by email or login.
  * Customer identifiers are validated to a maximum of 255 characters.

* **Tests**
  * Added coverage for customer reassignment and validation across client, server, and model behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->