### PR TITLE
fix: populate state/priority/group/owner/customer in zammad_get_ticket

### DIFF
--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -5,6 +5,7 @@ import os
 from typing import Any
 from urllib.parse import urlparse
 
+import requests  # type: ignore[import-untyped]
 from zammad_py import ZammadAPI
 from zammad_py.exceptions import ConfigException
 
@@ -189,11 +190,34 @@ class ZammadClient:
 
         return list(result)
 
+    def _find_ticket_expanded(self, ticket_id: int) -> dict[str, Any]:
+        """Fetch a single ticket with ``expand=true``.
+
+        The expand value must be the lowercase string ``"true"`` — Zammad is
+        case-sensitive here and ``requests`` serializes the bool ``True`` as
+        ``"True"``, which Zammad ignores.
+
+        Raises:
+            requests.HTTPError: If the API request fails, carrying Zammad's
+                response body so callers can detect "Couldn't find Ticket ..."
+        """
+        response = self.api.session.get(f"{self.url}/tickets/{ticket_id}", params={"expand": "true"})
+        if not response.ok:
+            raise requests.HTTPError(response.text)
+        return dict(response.json())
+
     def get_ticket(
         self, ticket_id: int, include_articles: bool = True, article_limit: int = 10, article_offset: int = 0
     ) -> dict[str, Any]:
-        """Get a single ticket by ID with optional article pagination."""
-        ticket = self.api.ticket.find(ticket_id)
+        """Get a single ticket by ID with optional article pagination.
+
+        Uses a direct HTTP call via zammad_py's internal session because
+        ``Resource.find()`` accepts no filters, so there is no way to pass
+        ``expand=true`` through it. Without expansion Zammad only returns the
+        ``*_id`` fields and the state/priority/group/owner/customer names all
+        render as "Unknown".
+        """
+        ticket = self._find_ticket_expanded(ticket_id)
 
         if include_articles:
             articles = self.api.ticket.articles(ticket_id)

--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -5,7 +5,7 @@ import os
 from typing import Any
 from urllib.parse import urlparse
 
-import requests  # type: ignore[import-untyped]
+import requests
 from zammad_py import ZammadAPI
 from zammad_py.exceptions import ConfigException
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pydantic>=2.11.7",
     "python-dotenv>=1.2.2",
     "httpx>=0.28.1",
+    "requests>=2.32.0",
 ]
 
 [project.optional-dependencies]
@@ -38,6 +39,7 @@ dev = [
     "pytest-cov>=7.1.0",
     "ruff>=0.15.10",
     "mypy>=1.20.1",
+    "types-requests>=2.32.0",
     "pip-audit>=2.6.0",
     "bandit[sarif]>=1.9.4",
     "safety>=3.7.0",
@@ -112,6 +114,7 @@ dev = [
     "pytest-cov>=7.1.0",
     "ruff>=0.15.10",
     "mypy>=1.20.1",
+    "types-requests>=2.32.0",
     "pip-audit>=2.6.0",
     "bandit[sarif]>=1.9.4",
     "safety>=3.7.0",

--- a/tests/test_client_methods.py
+++ b/tests/test_client_methods.py
@@ -320,10 +320,20 @@ class TestZammadClientMethods:
         assert len(result) == 1
         mock_instance.ticket.all.assert_called_once_with(filters={"page": 1, "per_page": 25, "expand": "true"})
 
+    @staticmethod
+    def _mock_ticket_response(mock_instance: Mock, payload: dict, *, ok: bool = True, text: str = "") -> Mock:
+        """Point the client's session at a canned GET /tickets/{id} response."""
+        response = Mock()
+        response.ok = ok
+        response.text = text
+        response.json.return_value = payload
+        mock_instance.session.get.return_value = response
+        return response
+
     def test_get_ticket_with_articles(self, mock_zammad_api: Mock) -> None:
         """Test get_ticket with article pagination."""
         mock_instance = Mock()
-        mock_instance.ticket.find.return_value = {"id": 1, "title": "Test Ticket"}
+        self._mock_ticket_response(mock_instance, {"id": 1, "title": "Test Ticket"})
         mock_instance.ticket.articles.return_value = [
             {"id": 1, "body": "Article 1"},
             {"id": 2, "body": "Article 2"},
@@ -346,7 +356,7 @@ class TestZammadClientMethods:
     def test_get_ticket_all_articles(self, mock_zammad_api: Mock) -> None:
         """Test get_ticket with all articles."""
         mock_instance = Mock()
-        mock_instance.ticket.find.return_value = {"id": 1, "title": "Test Ticket"}
+        self._mock_ticket_response(mock_instance, {"id": 1, "title": "Test Ticket"})
         mock_instance.ticket.articles.return_value = [{"id": 1, "body": "Article 1"}, {"id": 2, "body": "Article 2"}]
         mock_zammad_api.return_value = mock_instance
 
@@ -356,6 +366,62 @@ class TestZammadClientMethods:
         result = client.get_ticket(1, include_articles=True, article_limit=-1)
 
         assert len(result["articles"]) == 2
+
+    def test_get_ticket_requests_expanded_fields(self, mock_zammad_api: Mock) -> None:
+        """get_ticket must ask for expand=true, otherwise names come back as None.
+
+        Regression test: without the flag Zammad only returns ``*_id`` fields and
+        the server renders State/Priority/Group/Owner/Customer as "Unknown".
+        """
+        mock_instance = Mock()
+        self._mock_ticket_response(
+            mock_instance,
+            {
+                "id": 1,
+                "title": "Test Ticket",
+                "state_id": 2,
+                "state": "open",
+                "priority_id": 3,
+                "priority": "3 high",
+                "group": "Support",
+            },
+        )
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+
+        result = client.get_ticket(1, include_articles=False)
+
+        mock_instance.session.get.assert_called_once_with(
+            "https://test.zammad.com/api/v1/tickets/1", params={"expand": "true"}
+        )
+        # The literal string "true" matters: requests serializes bool True as
+        # "True", which Zammad ignores because the parameter is case-sensitive.
+        _, kwargs = mock_instance.session.get.call_args
+        assert kwargs["params"]["expand"] == "true"
+        assert result["state"] == "open"
+        assert result["priority"] == "3 high"
+        assert result["group"] == "Support"
+
+    def test_get_ticket_not_found_raises_with_zammad_message(self, mock_zammad_api: Mock) -> None:
+        """A failed lookup must surface Zammad's body so the server can map it.
+
+        The server turns "Couldn't find Ticket ..." into TicketIdGuidanceError,
+        so the response text has to survive.
+        """
+        mock_instance = Mock()
+        self._mock_ticket_response(
+            mock_instance,
+            {},
+            ok=False,
+            text='{"error":"Couldn\'t find Ticket with \'id\'=999"}',
+        )
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+
+        with pytest.raises(requests.HTTPError, match="Couldn't find Ticket"):
+            client.get_ticket(999)
 
     def test_create_ticket(self, mock_zammad_api: Mock) -> None:
         """Test create_ticket method."""

--- a/uv.lock
+++ b/uv.lock
@@ -1154,6 +1154,7 @@ dependencies = [
     { name = "mcp" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "requests" },
     { name = "zammad-py" },
 ]
 
@@ -1169,6 +1170,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "safety" },
+    { name = "types-requests" },
 ]
 
 [package.dev-dependencies]
@@ -1183,6 +1185,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "safety" },
+    { name = "types-requests" },
 ]
 
 [package.metadata]
@@ -1200,8 +1203,10 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "requests", specifier = ">=2.32.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.10" },
     { name = "safety", marker = "extra == 'dev'", specifier = ">=3.7.0" },
+    { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.0" },
     { name = "zammad-py", specifier = ">=3.2.0" },
 ]
 provides-extras = ["dev"]
@@ -1218,6 +1223,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "ruff", specifier = ">=0.15.10" },
     { name = "safety", specifier = ">=3.7.0" },
+    { name = "types-requests", specifier = ">=2.32.0" },
 ]
 
 [[package]]
@@ -2400,6 +2406,18 @@ dependencies = [
 sdist = { url = "https://pkgs.safetycli.com/package/the-mothership/pypi/packages/fd/07/b822e1b307d40e263e8253d2384cf98c51aa2368cc7ba9a07e523a1d964b/typer-0.23.1.tar.gz", hash = "sha256:2070374e4d31c83e7b61362fd859aa683576432fd5b026b060ad6b4cd3b86134", size = 120047, upload-time = "2026-02-13T10:04:30.984Z" }
 wheels = [
     { url = "https://pkgs.safetycli.com/package/the-mothership/pypi/packages/d5/91/9b286ab899c008c2cb05e8be99814807e7fbbd33f0c0c960470826e5ac82/typer-0.23.1-py3-none-any.whl", hash = "sha256:3291ad0d3c701cbf522012faccfbb29352ff16ad262db2139e6b01f15781f14e", size = 56813, upload-time = "2026-02-13T10:04:32.008Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260906"
+source = { registry = "https://pkgs.safetycli.com/repository/the-mothership/pypi/simple/" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://pkgs.safetycli.com/package/the-mothership/pypi/packages/c0/18/4c2c0290953f8b3b9612adfcb07b57f144ade3ad32a76764fca42b77c5f3/types_requests-2.33.0.20260906.tar.gz", hash = "sha256:76ab8a0fb736744a0c3deee7aa57b2927e301f078d9e61f5391b3e92002416b9", size = 25263, upload-time = "2026-09-06T06:35:47.707Z" }
+wheels = [
+    { url = "https://pkgs.safetycli.com/package/the-mothership/pypi/packages/60/4c/51ec821d22a45b4162fa3f3e9e94ea4c0f8c49e82363b10955baa5438391/types_requests-2.33.0.20260906-py3-none-any.whl", hash = "sha256:9f53622652bd921ead7a54d665be1b8d518165c8b51cc9d68d944cd6b6bfa8fb", size = 21461, upload-time = "2026-09-06T06:35:45.856Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`zammad_get_ticket` (and the `zammad://ticket/{id}` resource) rendered **State, Priority, Group, Owner and Customer as "Unknown"** for every ticket, even though `zammad_search_tickets` showed the correct values for the same ticket.

**Root cause:** `ZammadClient.get_ticket` fetched the ticket through `zammad_py`'s `ticket.find()`, which issues a bare `GET /api/v1/tickets/{id}` with no way to pass query parameters. Zammad only includes the human-readable `state`/`priority`/`group`/`owner`/`customer` fields when `expand=true` is sent; without it the payload has just the `*_id` integers, the `Ticket` model leaves the name fields `None`, and the formatter falls back to `"Unknown"`. The earlier `expand` fix (#193) covered search/list calls but could not reach `find()`.

**Fix:** `get_ticket` now performs the lookup via zammad_py's authenticated session directly — `GET {url}/tickets/{id}?expand=true` — following the same pattern `list_tags` already uses. The `expand` value is the lowercase string `"true"` (Zammad is case-sensitive; `requests` would serialise a Python `True` as `"True"`). Error handling mirrors zammad_py's `_raise_or_return_json`: on a non-OK response it raises `requests.HTTPError(response.text)`, so Zammad's `"Couldn't find Ticket …"` body still reaches the server's not-found mapping to `TicketIdGuidanceError`.

Since `client.py` now imports `requests` directly, it is declared as an explicit runtime dependency and `types-requests` is added to the dev group, removing a `type: ignore` suppression.

The core fix is cherry-picked from #321 by @jovamateus26 (issue author) with authorship preserved. This supersedes #321 and the `get_ticket` portion of #313; the request-timeout feature in #313 is unrelated to this bug and would be best re-opened as its own PR.

Closes #319

## Changes

- `mcp_zammad/client.py` — new `_find_ticket_expanded()` helper; `get_ticket` uses it instead of `ticket.find()`.
- `tests/test_client_methods.py` — `_mock_ticket_response` helper; existing `get_ticket` tests updated to mock the session; new regression tests:
  - `test_get_ticket_requests_expanded_fields` — asserts exact URL and literal `params={"expand": "true"}`, and that the expanded fields flow through.
  - `test_get_ticket_not_found_raises_with_zammad_message` — asserts Zammad's error body survives so `TicketIdGuidanceError` mapping keeps working.
- `pyproject.toml` / `uv.lock` — add `requests` (runtime) and `types-requests` (dev).

## Test plan

- [x] New tests fail against `main`'s `client.py` and pass with the fix (verified by swapping the file).
- [x] `uv run pytest -q --cov=mcp_zammad` — 224 passed, coverage 88.47% (floor 86%).
- [x] `uv run mypy mcp_zammad` — clean, no suppressions.
- [x] `uv run ruff check mcp_zammad tests` / `uv run ruff format --check mcp_zammad tests` — clean.
- [ ] Manual: `zammad_get_ticket` against a live Zammad instance shows real State/Priority/Group/Owner/Customer (issue author and #313 author both confirmed this on Zammad 6.5 with the same change).

## Out of scope / follow-ups

- `_brief_field` in `server.py` only handles `StateBrief | PriorityBrief | UserBrief`; `GroupBrief`/`OrganizationBrief` objects would also render as "Unknown". Not triggered with `expand=true` (Zammad returns strings), so left for a separate small change.
- `ZAMMAD_REQUEST_TIMEOUT` support from #313.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ticket retrieval reliability by using direct requests.
  * Ticket details now include expanded fields when available.
  * Failed ticket lookups provide clearer error messages from the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->