### PR TITLE
fix(client): build get_ticket URL from zammad_py's normalised base (follow-up to #321)

### DIFF
--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -5,6 +5,7 @@ import os
 from typing import Any
 from urllib.parse import urlparse
 
+import requests  # type: ignore[import-untyped]
 from zammad_py import ZammadAPI
 from zammad_py.exceptions import ConfigException
 
@@ -189,11 +190,34 @@ class ZammadClient:
 
         return list(result)
 
+    def _find_ticket_expanded(self, ticket_id: int) -> dict[str, Any]:
+        """Fetch a single ticket with ``expand=true``.
+
+        The expand value must be the lowercase string ``"true"`` — Zammad is
+        case-sensitive here and ``requests`` serializes the bool ``True`` as
+        ``"True"``, which Zammad ignores.
+
+        Raises:
+            requests.HTTPError: If the API request fails, carrying Zammad's
+                response body so callers can detect "Couldn't find Ticket ..."
+        """
+        response = self.api.session.get(f"{self.url}/tickets/{ticket_id}", params={"expand": "true"})
+        if not response.ok:
+            raise requests.HTTPError(response.text)
+        return dict(response.json())
+
     def get_ticket(
         self, ticket_id: int, include_articles: bool = True, article_limit: int = 10, article_offset: int = 0
     ) -> dict[str, Any]:
-        """Get a single ticket by ID with optional article pagination."""
-        ticket = self.api.ticket.find(ticket_id)
+        """Get a single ticket by ID with optional article pagination.
+
+        Uses a direct HTTP call via zammad_py's internal session because
+        ``Resource.find()`` accepts no filters, so there is no way to pass
+        ``expand=true`` through it. Without expansion Zammad only returns the
+        ``*_id`` fields and the state/priority/group/owner/customer names all
+        render as "Unknown".
+        """
+        ticket = self._find_ticket_expanded(ticket_id)
 
         if include_articles:
             articles = self.api.ticket.articles(ticket_id)

--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -201,7 +201,9 @@ class ZammadClient:
             requests.HTTPError: If the API request fails, carrying Zammad's
                 response body so callers can detect "Couldn't find Ticket ..."
         """
-        response = self.api.session.get(f"{self.url}/tickets/{ticket_id}", params={"expand": "true"})
+        # self.api.url is zammad_py's normalised base (always ends in "/"), so a
+        # trailing slash on ZAMMAD_URL cannot produce ".../api/v1//tickets/1".
+        response = self.api.session.get(f"{self.api.url}tickets/{ticket_id}", params={"expand": "true"})
         if not response.ok:
             raise requests.HTTPError(response.text)
         return dict(response.json())

--- a/tests/test_client_methods.py
+++ b/tests/test_client_methods.py
@@ -320,10 +320,20 @@ class TestZammadClientMethods:
         assert len(result) == 1
         mock_instance.ticket.all.assert_called_once_with(filters={"page": 1, "per_page": 25, "expand": "true"})
 
+    @staticmethod
+    def _mock_ticket_response(mock_instance: Mock, payload: dict, *, ok: bool = True, text: str = "") -> Mock:
+        """Point the client's session at a canned GET /tickets/{id} response."""
+        response = Mock()
+        response.ok = ok
+        response.text = text
+        response.json.return_value = payload
+        mock_instance.session.get.return_value = response
+        return response
+
     def test_get_ticket_with_articles(self, mock_zammad_api: Mock) -> None:
         """Test get_ticket with article pagination."""
         mock_instance = Mock()
-        mock_instance.ticket.find.return_value = {"id": 1, "title": "Test Ticket"}
+        self._mock_ticket_response(mock_instance, {"id": 1, "title": "Test Ticket"})
         mock_instance.ticket.articles.return_value = [
             {"id": 1, "body": "Article 1"},
             {"id": 2, "body": "Article 2"},
@@ -346,7 +356,7 @@ class TestZammadClientMethods:
     def test_get_ticket_all_articles(self, mock_zammad_api: Mock) -> None:
         """Test get_ticket with all articles."""
         mock_instance = Mock()
-        mock_instance.ticket.find.return_value = {"id": 1, "title": "Test Ticket"}
+        self._mock_ticket_response(mock_instance, {"id": 1, "title": "Test Ticket"})
         mock_instance.ticket.articles.return_value = [{"id": 1, "body": "Article 1"}, {"id": 2, "body": "Article 2"}]
         mock_zammad_api.return_value = mock_instance
 
@@ -356,6 +366,62 @@ class TestZammadClientMethods:
         result = client.get_ticket(1, include_articles=True, article_limit=-1)
 
         assert len(result["articles"]) == 2
+
+    def test_get_ticket_requests_expanded_fields(self, mock_zammad_api: Mock) -> None:
+        """get_ticket must ask for expand=true, otherwise names come back as None.
+
+        Regression test: without the flag Zammad only returns ``*_id`` fields and
+        the server renders State/Priority/Group/Owner/Customer as "Unknown".
+        """
+        mock_instance = Mock()
+        self._mock_ticket_response(
+            mock_instance,
+            {
+                "id": 1,
+                "title": "Test Ticket",
+                "state_id": 2,
+                "state": "open",
+                "priority_id": 3,
+                "priority": "3 high",
+                "group": "Support",
+            },
+        )
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+
+        result = client.get_ticket(1, include_articles=False)
+
+        mock_instance.session.get.assert_called_once_with(
+            "https://test.zammad.com/api/v1/tickets/1", params={"expand": "true"}
+        )
+        # The literal string "true" matters: requests serializes bool True as
+        # "True", which Zammad ignores because the parameter is case-sensitive.
+        _, kwargs = mock_instance.session.get.call_args
+        assert kwargs["params"]["expand"] == "true"
+        assert result["state"] == "open"
+        assert result["priority"] == "3 high"
+        assert result["group"] == "Support"
+
+    def test_get_ticket_not_found_raises_with_zammad_message(self, mock_zammad_api: Mock) -> None:
+        """A failed lookup must surface Zammad's body so the server can map it.
+
+        The server turns "Couldn't find Ticket ..." into TicketIdGuidanceError,
+        so the response text has to survive.
+        """
+        mock_instance = Mock()
+        self._mock_ticket_response(
+            mock_instance,
+            {},
+            ok=False,
+            text='{"error":"Couldn\'t find Ticket with \'id\'=999"}',
+        )
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+
+        with pytest.raises(requests.HTTPError, match="Couldn't find Ticket"):
+            client.get_ticket(999)
 
     def test_create_ticket(self, mock_zammad_api: Mock) -> None:
         """Test create_ticket method."""

--- a/tests/test_client_methods.py
+++ b/tests/test_client_methods.py
@@ -323,6 +323,8 @@ class TestZammadClientMethods:
     @staticmethod
     def _mock_ticket_response(mock_instance: Mock, payload: dict, *, ok: bool = True, text: str = "") -> Mock:
         """Point the client's session at a canned GET /tickets/{id} response."""
+        # zammad_py normalises its base url to always end with "/".
+        mock_instance.url = "https://test.zammad.com/api/v1/"
         response = Mock()
         response.ok = ok
         response.text = text
@@ -422,6 +424,22 @@ class TestZammadClientMethods:
 
         with pytest.raises(requests.HTTPError, match="Couldn't find Ticket"):
             client.get_ticket(999)
+
+    @pytest.mark.parametrize("base_url", ["https://test.zammad.com/api/v1", "https://test.zammad.com/api/v1/"])
+    def test_get_ticket_url_tolerates_trailing_slash(self, base_url: str) -> None:
+        """A trailing slash on ZAMMAD_URL must not produce ``/api/v1//tickets/1``.
+
+        Uses the real ZammadAPI (which normalises its base url) and only stubs
+        the session, so the URL join is exercised for real.
+        """
+        client = ZammadClient(url=base_url, http_token="test-token")
+        session = Mock()
+        session.get.return_value = Mock(ok=True, json=Mock(return_value={"id": 1}))
+        client.api.session = session
+
+        client.get_ticket(1, include_articles=False)
+
+        session.get.assert_called_once_with("https://test.zammad.com/api/v1/tickets/1", params={"expand": "true"})
 
     def test_create_ticket(self, mock_zammad_api: Mock) -> None:
         """Test create_ticket method."""


### PR DESCRIPTION
Non-blocking follow-up from the Factory review of #321 (https://github.com/basher83/Zammad-MCP/pull/321#pullrequestreview). #321 comes from a fork, so this branch is based on its head commit and targets `main`; it lands **after** #321 (the first commit here is #321's own commit).

## Summary

`_find_ticket_expanded` (added in #321) joins `self.url` and `/tickets/{id}` by hand. When `ZAMMAD_URL` ends in `/`, that yields `…/api/v1//tickets/1`. `zammad_py`'s `find()` — which #321 replaced — never had this problem because `ZammadAPI` normalises its base url to always end in `/`.

This builds the URL from `self.api.url` instead, so both `…/api/v1` and `…/api/v1/` produce `…/api/v1/tickets/1`.

## Findings addressed

- **Trailing-slash `ZAMMAD_URL` produces a double slash** (`mcp_zammad/client.py:204`) — recorded as non-blocking in the #321 review because the docs never show a trailing slash and `list_tags` has the same construction. Fixed here for `get_ticket`; `list_tags` is untouched to keep this strictly scoped to the reviewed change.

## Test plan

- New `test_get_ticket_url_tolerates_trailing_slash`, parametrised over both spellings, using the real `ZammadAPI` with only the session stubbed so the join is exercised for real.
- `_mock_ticket_response` now sets `mock_instance.url` to the normalised base so the existing URL assertion in `test_get_ticket_requests_expanded_fields` keeps passing.
- `uv run pytest` → 226 passed; `ruff check`, `ruff format --check`, `mypy mcp_zammad` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ticket retrieval now includes expanded ticket details.
  - Improved handling of ticket lookup failures, including clearer error information.
  - Ticket URLs are constructed correctly whether or not the server address ends with a slash.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->