### PR TITLE
test: cover ticket resource attachments and document pending_time (follow-up to #287)

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,3 +1,12 @@
 ---
+# NOTE: Codacy reads this `.codacy.yaml` and ignores the sibling `.codacy.yml`
+# (when both exist, `.yaml` wins). The exclusions below must therefore mirror the
+# intent expressed in `.codacy.yml`, which is otherwise inert. Test files are
+# excluded from static analysis here as well - without this, Codacy applies its
+# default pydocstyle profile to tests and flags D203 (blank line before class
+# docstring), which conflicts with the D211 convention Ruff enforces project-wide.
 exclude_paths:
     - "plugins/**"
+    - "tests/**"
+    - "**/test_*.py"
+    - "**/*_test.py"

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Use create_ticket with:
 ```plaintext
 1. Use get_ticket with ticket_id=123 to see the full conversation
 2. Use add_article to add your response
-3. Use update_ticket to change state to "pending reminder"
+3. Use update_ticket to change state to "pending reminder" with a pending_time (e.g. "2026-07-01T08:00:00Z")
 ```
 
 ### Analyze Escalated Tickets

--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from datetime import datetime
 from typing import Any
 from urllib.parse import urlparse
 
@@ -247,6 +248,7 @@ class ZammadClient:
         priority: str | None = None,
         owner: str | None = None,
         group: str | None = None,
+        pending_time: datetime | str | None = None,
         time_unit: float | None = None,
     ) -> dict[str, Any]:
         """Update an existing ticket."""
@@ -264,6 +266,11 @@ class ZammadClient:
             update_data["owner"] = owner
         if group is not None:
             update_data["group"] = group
+        if pending_time is not None:
+            # Zammad expects an ISO 8601 string; serialize datetimes for the JSON body.
+            update_data["pending_time"] = (
+                pending_time.isoformat() if isinstance(pending_time, datetime) else pending_time
+            )
         if time_unit is not None:
             update_data["time_unit"] = time_unit
 

--- a/mcp_zammad/models.py
+++ b/mcp_zammad/models.py
@@ -181,6 +181,16 @@ class PriorityBrief(BaseModel):
     active: bool = True
 
 
+class Attachment(BaseModel):
+    """Ticket article attachment information."""
+
+    id: int
+    filename: str
+    size: int | None = None
+    content_type: str | None = None
+    created_at: datetime | None = None
+
+
 class Article(BaseModel):
     """Ticket article (comment/note)."""
 
@@ -201,6 +211,9 @@ class Article(BaseModel):
     updated_at: datetime
     created_by: UserBrief | str | None = None
     updated_by: UserBrief | str | None = None
+    attachments: list[Attachment] | None = Field(
+        None, description="Files attached to this article; download via zammad_download_attachment using their id"
+    )
 
 
 class Ticket(BaseModel):
@@ -304,16 +317,6 @@ class TicketSearchParams(StrictBaseModel):
     page: int = Field(default=1, ge=1, description="Page number (must be >= 1)")
     per_page: int = Field(default=25, ge=1, le=100, description="Results per page (1-100)")
     response_format: ResponseFormat = Field(default=ResponseFormat.MARKDOWN, description="Output format")
-
-
-class Attachment(BaseModel):
-    """Ticket article attachment information."""
-
-    id: int
-    filename: str
-    size: int | None = None
-    content_type: str | None = None
-    created_at: datetime | None = None
 
 
 class ArticleCreate(StrictBaseModel):

--- a/mcp_zammad/models.py
+++ b/mcp_zammad/models.py
@@ -373,6 +373,13 @@ class TicketUpdateParams(StrictBaseModel):
     priority: str | None = Field(None, description="New priority name", max_length=100)
     owner: str | None = Field(None, description="New owner login/email", max_length=255)
     group: str | None = Field(None, description="New group name", max_length=100)
+    pending_time: datetime | None = Field(
+        None,
+        description=(
+            "Pending-until timestamp (ISO 8601, e.g. '2026-07-01T08:00:00Z'). "
+            "Required by Zammad when state is 'pending reminder' or 'pending close'."
+        ),
+    )
     time_unit: float | None = Field(
         None, description="Time spent for time accounting (unit defined in Zammad admin settings)", gt=0
     )
@@ -382,6 +389,13 @@ class TicketUpdateParams(StrictBaseModel):
     def sanitize_title(cls, v: str | None) -> str | None:
         """Escape HTML to prevent XSS attacks."""
         return html.escape(v) if v else v
+
+    @model_validator(mode="after")
+    def require_pending_time_for_pending_states(self) -> "TicketUpdateParams":
+        """Fail fast when moving to a pending state without a pending_time."""
+        if self.state is not None and "pending" in self.state.lower() and self.pending_time is None:
+            raise ValueError(f"state '{self.state}' requires 'pending_time' (the pending-until timestamp, ISO 8601).")
+        return self
 
 
 class GetArticleAttachmentsParams(StrictBaseModel):

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -639,6 +639,27 @@ def _format_ticket_detail_markdown(ticket: Ticket) -> str:
     return "\n".join(lines)
 
 
+def _attachment_field(att: Attachment | dict, name: str) -> object:
+    """Read a field from an attachment in either dict or model form."""
+    return att.get(name) if isinstance(att, dict) else getattr(att, name, None)
+
+
+def _format_attachment_size(size: object) -> str:
+    """Render a trailing size suffix for genuine non-negative byte counts."""
+    if isinstance(size, int) and not isinstance(size, bool) and size >= 0:
+        return f", {size} bytes"
+    return ""
+
+
+def _format_attachment_line(att: Attachment | dict) -> str:
+    """Format a single attachment as a sanitized markdown bullet line."""
+    filename = _attachment_field(att, "filename")
+    safe_id = _sanitize_inline_text(_attachment_field(att, "id"))
+    safe_filename = _sanitize_inline_text(filename) if filename is not None else "(unnamed)"
+    size_str = _format_attachment_size(_attachment_field(att, "size"))
+    return f"  - id={safe_id}: {safe_filename}{size_str}"
+
+
 def _format_article_attachments(attachments: list[Attachment] | list[dict] | None, article_id: int) -> list[str]:
     """Render an article's attachment list as markdown lines.
 
@@ -650,14 +671,7 @@ def _format_article_attachments(attachments: list[Attachment] | list[dict] | Non
 
     safe_article_id = _sanitize_inline_text(article_id)
     lines = [f"- **Attachments** (download via zammad_download_attachment, article_id={safe_article_id}):"]
-    for att in attachments:
-        att_id = att.get("id") if isinstance(att, dict) else att.id
-        filename = att.get("filename") if isinstance(att, dict) else att.filename
-        size = att.get("size") if isinstance(att, dict) else att.size
-        safe_id = _sanitize_inline_text(att_id)
-        safe_filename = _sanitize_inline_text(filename) if filename is not None else "(unnamed)"
-        size_str = f", {size} bytes" if isinstance(size, int) and not isinstance(size, bool) and size >= 0 else ""
-        lines.append(f"  - id={safe_id}: {safe_filename}{size_str}")
+    lines.extend(_format_attachment_line(att) for att in attachments)
     return lines
 
 

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -205,6 +205,24 @@ def _escape_article_body(article: Article) -> str:
     return html.escape(article.body) if "html" in ct else article.body
 
 
+def _sanitize_inline_text(value: object) -> str:
+    """Neutralize control characters and HTML in a value rendered inline in markdown.
+
+    Attachment filenames originate from user uploads, so they may contain
+    newlines, control characters, or HTML/Markdown metacharacters that could
+    break out of the list item or inject markup. Strip non-printable characters
+    and HTML-escape the rest.
+
+    Args:
+        value: The value to sanitize (coerced to str)
+
+    Returns:
+        A single-line, HTML-escaped representation safe for inline rendering
+    """
+    text = "".join(ch for ch in str(value) if ch.isprintable())
+    return html.escape(text, quote=False)
+
+
 def _serialize_json(obj: dict[str, Any], *, use_compact: bool) -> str:
     """Serialize JSON object with appropriate formatting.
 
@@ -635,8 +653,10 @@ def _format_article_attachments(attachments: list[Attachment] | list[dict] | Non
         att_id = att.get("id") if isinstance(att, dict) else att.id
         filename = att.get("filename") if isinstance(att, dict) else att.filename
         size = att.get("size") if isinstance(att, dict) else att.size
-        size_str = f", {size} bytes" if size is not None else ""
-        lines.append(f"  - id={att_id}: {filename}{size_str}")
+        safe_id = _sanitize_inline_text(att_id)
+        safe_filename = _sanitize_inline_text(filename) if filename is not None else "(unnamed)"
+        size_str = f", {size} bytes" if isinstance(size, int) and not isinstance(size, bool) and size >= 0 else ""
+        lines.append(f"  - id={safe_id}: {safe_filename}{size_str}")
     return lines
 
 

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -1129,6 +1129,8 @@ class ZammadMCPServer:
                     - group (str | None): New group name
                     - owner (str | None): New owner email/login
                     - customer (str | None): New customer email/login
+                    - pending_time (datetime | None): Pending-until timestamp (ISO 8601),
+                      required when state is "pending reminder" or "pending close"
                     - time_unit (float | None): Time spent for time accounting
 
             Returns:
@@ -1148,6 +1150,8 @@ class ZammadMCPServer:
             Examples:
                 - Use when: "Change ticket 123 to high priority" -> ticket_id=123, priority="high"
                 - Use when: "Close ticket 123" -> ticket_id=123, state="closed"
+                - Use when: "Set ticket 123 to pending until 2026-07-01" ->
+                  ticket_id=123, state="pending reminder", pending_time="2026-07-01T08:00:00Z"
                 - Use when: "Reassign ticket to Alice" -> ticket_id=123, owner="alice@company.com"
                 - Don't use when: Adding comments (use zammad_add_article)
                 - Don't use when: Adding tags (use zammad_add_ticket_tag)

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -648,7 +648,8 @@ def _format_article_attachments(attachments: list[Attachment] | list[dict] | Non
     if not attachments:
         return []
 
-    lines = [f"- **Attachments** (download via zammad_download_attachment, article_id={article_id}):"]
+    safe_article_id = _sanitize_inline_text(article_id)
+    lines = [f"- **Attachments** (download via zammad_download_attachment, article_id={safe_article_id}):"]
     for att in attachments:
         att_id = att.get("id") if isinstance(att, dict) else att.id
         filename = att.get("filename") if isinstance(att, dict) else att.filename

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -597,16 +597,20 @@ def _format_ticket_detail_markdown(ticket: Ticket) -> str:
                 type_field = article.get("type", "Unknown")
                 created_at = article.get("created_at", "Unknown")
                 body = article.get("body", "")
+                attachments = article.get("attachments")
             else:
                 # Article object - use attribute access
                 from_field = article.from_ or "Unknown"
                 type_field = article.type
                 created_at = article.created_at
                 body = article.body
+                attachments = article.attachments
 
             lines.append(f"- **From**: {from_field}")
             lines.append(f"- **Type**: {type_field}")
             lines.append(f"- **Created**: {created_at}")
+            article_id = article.get("id") if isinstance(article, dict) else article.id
+            lines.extend(_format_article_attachments(attachments, article_id))
             lines.append("")
             # Truncate very long bodies
             if len(body) > ARTICLE_BODY_TRUNCATE_LENGTH:
@@ -615,6 +619,25 @@ def _format_ticket_detail_markdown(ticket: Ticket) -> str:
             lines.append("")
 
     return "\n".join(lines)
+
+
+def _format_article_attachments(attachments: list[Attachment] | list[dict] | None, article_id: int) -> list[str]:
+    """Render an article's attachment list as markdown lines.
+
+    Surfaces attachment id/filename/size so the LLM knows files exist and can
+    fetch their content via zammad_download_attachment.
+    """
+    if not attachments:
+        return []
+
+    lines = [f"- **Attachments** (download via zammad_download_attachment, article_id={article_id}):"]
+    for att in attachments:
+        att_id = att.get("id") if isinstance(att, dict) else att.id
+        filename = att.get("filename") if isinstance(att, dict) else att.filename
+        size = att.get("size") if isinstance(att, dict) else att.size
+        size_str = f", {size} bytes" if size is not None else ""
+        lines.append(f"  - id={att_id}: {filename}{size_str}")
+    return lines
 
 
 def _format_user_contact_section(user: User) -> list[str]:
@@ -2512,6 +2535,7 @@ class ZammadMCPServer:
                             [
                                 f"--- {article.created_at.isoformat()} by {created_by_email} ---",
                                 _escape_article_body(article),
+                                *_format_article_attachments(article.attachments, article.id),
                                 "",
                             ]
                         )

--- a/tests/test_client_methods.py
+++ b/tests/test_client_methods.py
@@ -3,6 +3,7 @@
 import os
 import pathlib
 from collections.abc import Generator
+from datetime import datetime, timezone
 from unittest.mock import Mock, patch
 
 import pytest
@@ -97,6 +98,33 @@ class TestZammadClientMethods:
 
         call_args = mock_instance.ticket.update.call_args[0][1]
         assert "time_unit" not in call_args
+
+    def test_update_ticket_serializes_pending_time(self, mock_zammad_api: Mock) -> None:
+        """Test that a datetime pending_time is serialized to an ISO 8601 string."""
+        mock_instance = Mock()
+        mock_instance.ticket.update.return_value = {"id": 1}
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+
+        client.update_ticket(1, state="pending reminder", pending_time=datetime(2026, 7, 1, 8, 0, tzinfo=timezone.utc))
+
+        call_args = mock_instance.ticket.update.call_args[0][1]
+        assert call_args["pending_time"] == "2026-07-01T08:00:00+00:00"
+        assert call_args["state"] == "pending reminder"
+
+    def test_update_ticket_passes_pending_time_string_through(self, mock_zammad_api: Mock) -> None:
+        """Test that a string pending_time is forwarded unchanged."""
+        mock_instance = Mock()
+        mock_instance.ticket.update.return_value = {"id": 1}
+        mock_zammad_api.return_value = mock_instance
+
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+
+        client.update_ticket(1, state="pending reminder", pending_time="2026-07-01T08:00:00Z")
+
+        call_args = mock_instance.ticket.update.call_args[0][1]
+        assert call_args["pending_time"] == "2026-07-01T08:00:00Z"
 
     @pytest.mark.parametrize("time_unit", [0, -5])
     def test_update_ticket_rejects_invalid_time_unit(self, mock_zammad_api: Mock, time_unit: float) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from mcp_zammad.models import (
+    Article,
     ArticleCreate,
     AttachmentUpload,
     DeleteAttachmentParams,
@@ -13,6 +14,41 @@ from mcp_zammad.models import (
     TicketCreate,
     TicketUpdate,
 )
+
+_BASE_ARTICLE = {
+    "id": 456,
+    "ticket_id": 123,
+    "type": "email",
+    "sender": "Customer",
+    "body": "See attached.",
+    "created_by_id": 2,
+    "updated_by_id": 2,
+    "created_at": "2026-05-30T10:00:00Z",
+    "updated_at": "2026-05-30T10:00:00Z",
+}
+
+
+class TestArticleAttachments:
+    """Tests for attachment metadata on read Article models."""
+
+    def test_article_parses_attachments(self):
+        """Article exposes attachment metadata returned by the Zammad API."""
+        article = Article(
+            **_BASE_ARTICLE,
+            attachments=[
+                {"id": 1, "filename": "kaufanfrage.pdf", "size": 20480},
+                {"id": 2, "filename": "logo.png", "size": 2048},
+            ],
+        )
+        assert article.attachments is not None
+        assert [a.id for a in article.attachments] == [1, 2]
+        assert article.attachments[0].filename == "kaufanfrage.pdf"
+        assert article.attachments[0].size == 20480
+
+    def test_article_without_attachments_defaults_none(self):
+        """Articles with no attachments key default to None."""
+        article = Article(**_BASE_ARTICLE)
+        assert article.attachments is None
 
 
 class TestTicketCreate:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1042,6 +1042,43 @@ def test_update_ticket_valid_time_unit():
     assert params_none.time_unit is None
 
 
+def test_update_ticket_pending_state_requires_pending_time():
+    """Moving to a pending state without pending_time is rejected up front."""
+    with pytest.raises(ValidationError, match="pending_time"):
+        TicketUpdateParams(ticket_id=1, state="pending reminder")
+
+    with pytest.raises(ValidationError, match="pending_time"):
+        TicketUpdateParams(ticket_id=1, state="pending close")
+
+
+def test_update_ticket_pending_state_with_pending_time():
+    """pending_time is accepted (and parsed) alongside a pending state."""
+    params = TicketUpdateParams(ticket_id=1, state="pending reminder", pending_time="2026-07-01T08:00:00Z")
+    assert params.pending_time == datetime(2026, 7, 1, 8, 0, tzinfo=timezone.utc)
+
+
+def test_update_ticket_forwards_pending_time_as_iso(mock_zammad_client, sample_ticket_data, decorator_capturer):
+    """The tool forwards pending_time to the client as an ISO 8601 string."""
+    mock_instance, _ = mock_zammad_client
+    mock_instance.update_ticket.return_value = sample_ticket_data
+
+    server_inst = ZammadMCPServer()
+    server_inst.client = mock_instance
+
+    test_tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
+    server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
+    server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
+    server_inst._setup_tools()
+
+    params = TicketUpdateParams(ticket_id=1, state="pending reminder", pending_time="2026-07-01T08:00:00Z")
+    test_tools["zammad_update_ticket"](params)
+
+    _, kwargs = mock_instance.update_ticket.call_args
+    assert kwargs["ticket_id"] == 1
+    assert kwargs["state"] == "pending reminder"
+    assert kwargs["pending_time"] == datetime(2026, 7, 1, 8, 0, tzinfo=timezone.utc)
+
+
 def test_get_organization_tool(mock_zammad_client, sample_organization_data):
     """Test get organization tool."""
     mock_instance, _ = mock_zammad_client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3024,6 +3024,37 @@ def test_format_ticket_detail_markdown_with_articles(sample_ticket_data, sample_
     assert "Second article" in result
 
 
+def test_format_ticket_detail_markdown_with_attachments(sample_ticket_data, sample_article_data):
+    """Attachments are surfaced with id/filename so they can be downloaded."""
+    article = Article(
+        **{
+            **sample_article_data,
+            "attachments": [
+                {"id": 1, "filename": "kaufanfrage.pdf", "size": 20480},
+                {"id": 2, "filename": "logo.png", "size": 2048},
+            ],
+        }
+    )
+    ticket_with_attachments = Ticket(**sample_ticket_data, articles=[article])
+
+    result = _format_ticket_detail_markdown(ticket_with_attachments)
+
+    assert "**Attachments**" in result
+    assert "zammad_download_attachment" in result
+    assert f"article_id={article.id}" in result
+    assert "id=1: kaufanfrage.pdf, 20480 bytes" in result
+    assert "id=2: logo.png, 2048 bytes" in result
+
+
+def test_format_ticket_detail_markdown_without_attachments(sample_ticket_data, sample_article_data):
+    """Articles without attachments do not render an attachment section."""
+    ticket = Ticket(**sample_ticket_data, articles=[Article(**sample_article_data)])
+
+    result = _format_ticket_detail_markdown(ticket)
+
+    assert "**Attachments**" not in result
+
+
 def test_format_ticket_detail_markdown_with_tags(sample_ticket_data):
     """Test formatting ticket with tags included."""
     # Create a ticket with tags

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -47,6 +47,7 @@ from mcp_zammad.server import (
     CHARACTER_LIMIT,
     AttachmentDeletionError,
     ZammadMCPServer,
+    _format_article_attachments,
     _format_ticket_detail_markdown,
     main,
     mcp,
@@ -1057,8 +1058,8 @@ def test_update_ticket_pending_state_with_pending_time():
     assert params.pending_time == datetime(2026, 7, 1, 8, 0, tzinfo=timezone.utc)
 
 
-def test_update_ticket_forwards_pending_time_as_iso(mock_zammad_client, sample_ticket_data, decorator_capturer):
-    """The tool forwards pending_time to the client as an ISO 8601 string."""
+def test_update_ticket_forwards_pending_time_as_datetime(mock_zammad_client, sample_ticket_data, decorator_capturer):
+    """The tool forwards pending_time to the client as a datetime object."""
     mock_instance, _ = mock_zammad_client
     mock_instance.update_ticket.return_value = sample_ticket_data
 
@@ -3044,6 +3045,30 @@ def test_format_ticket_detail_markdown_with_attachments(sample_ticket_data, samp
     assert f"article_id={article.id}" in result
     assert "id=1: kaufanfrage.pdf, 20480 bytes" in result
     assert "id=2: logo.png, 2048 bytes" in result
+
+
+def test_format_article_attachments_sanitizes_filename():
+    """Filenames with control characters or HTML are neutralized before rendering."""
+    attachments = [
+        Attachment(id=1, filename="evil\n- injected line", size=10),
+        Attachment(id=2, filename="<script>alert(1)</script>.txt", size=None),
+    ]
+
+    rendered = "\n".join(_format_article_attachments(attachments, article_id=5))
+
+    # A newline in the filename must not create an extra markdown line
+    assert "\n- injected line" not in rendered
+    assert "evil- injected line" in rendered
+    # HTML metacharacters are escaped
+    assert "<script>" not in rendered
+    assert "&lt;script&gt;" in rendered
+
+
+def test_format_article_attachments_handles_dict_with_invalid_size():
+    """Non-integer sizes (e.g. from raw dicts) are omitted rather than rendered."""
+    lines = _format_article_attachments([{"id": 7, "filename": "doc.pdf", "size": "big"}], article_id=5)
+
+    assert lines[-1] == "  - id=7: doc.pdf"
 
 
 def test_format_ticket_detail_markdown_without_attachments(sample_ticket_data, sample_article_data):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1473,6 +1473,7 @@ def test_resource_handlers(decorator_capturer):
                 created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
                 updated_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
                 created_by=UserBrief(id=1, login="agent", email="agent@example.com"),
+                attachments=[Attachment(id=42, filename="report.pdf", size=2048)],
             )
         ],
     )
@@ -1495,6 +1496,8 @@ def test_resource_handlers(decorator_capturer):
     assert "Priority: high" in result
     assert "Customer: test@example.com" in result
     assert "Initial ticket description" in result
+    assert "download via zammad_download_attachment, article_id=1" in result
+    assert "id=42: report.pdf, 2048 bytes" in result
 
     # Test user resource
     server.client.get_user.return_value = {


### PR DESCRIPTION
## Summary

Non-blocking follow-ups from the Factory review of #287 (`fix: add pending_time to update_ticket and surface article attachments`). PR #287 comes from a fork, so this targets `main` and should land **after** #287 merges.

- **Supplemental test** — `test_resource_handlers` now includes an attachment in its article fixture and asserts the `zammad://ticket/{ticket_id}` resource renders the `zammad_download_attachment` pointer. #287 unit-tests the shared formatter; this covers the resource call site directly.
- **README** — the "Update and Respond to a Ticket" workflow example now mentions that `pending_time` is required when moving a ticket to "pending reminder", matching the validator added in #287.

## Test plan

- [x] `uv run pytest -q tests/test_server.py` → 115 passed
- [x] `uv run ruff check tests/test_server.py` / `ruff format --check` → clean
