### PR TITLE
fix!: remove zammad_delete_attachment, Zammad has no such endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug Fixes
 
+- [**breaking**] Remove zammad_delete_attachment, Zammad has no such endpoint
 - Address CodeRabbit review feedback
 - Resolve Codacy D-series docstring violations in changed files
 - *(tests)* Add local fake Zammad server to HTTP integration fixture

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ An MCP server that connects AI assistants to Zammad, providing tools for managin
 - **Attachment Support**
   - `zammad_get_article_attachments` - List attachments for a ticket article
   - `zammad_download_attachment` - Download attachment content (base64-encoded)
-  - `zammad_delete_attachment` - Delete attachments from ticket articles
+  - Note: Zammad's REST API has no endpoint for deleting individual attachments; deleting the article is the only supported removal path
 
 - **User & Organization Management**
   - `zammad_create_user` - Create a Zammad user
@@ -426,15 +426,6 @@ Use zammad_add_article with attachments parameter:
       "mime_type": "application/pdf"
     }
   ]
-```
-
-### Delete an Attachment
-
-```plaintext
-Use zammad_delete_attachment with:
-- ticket_id: 123
-- article_id: 456
-- attachment_id: 789
 ```
 
 ## Development

--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -331,24 +331,6 @@ class ZammadClient:
 
         return dict(self.api.ticket_article.create(article_data))
 
-    def delete_attachment(self, ticket_id: int, article_id: int, attachment_id: int) -> bool:
-        """Delete an attachment from a ticket article.
-
-        Args:
-            ticket_id: Ticket ID
-            article_id: Article ID
-            attachment_id: Attachment ID to delete
-
-        Returns:
-            True if deletion succeeded
-
-        Raises:
-            Exception if deletion fails
-        """
-        result = self.api.ticket_article_attachment.destroy(attachment_id, article_id, ticket_id)
-        # destroy() returns True on success, may return dict on error
-        return bool(result)
-
     def get_user(self, user_id: int) -> dict[str, Any]:
         """Get user information by ID."""
         return dict(self.api.user.find(user_id))

--- a/mcp_zammad/models.py
+++ b/mcp_zammad/models.py
@@ -402,24 +402,6 @@ class DownloadAttachmentParams(StrictBaseModel):
     )
 
 
-class DeleteAttachmentParams(StrictBaseModel):
-    """Delete attachment request parameters."""
-
-    ticket_id: int = Field(gt=0, description="Ticket ID")
-    article_id: int = Field(gt=0, description="Article ID")
-    attachment_id: int = Field(gt=0, description="Attachment ID")
-
-
-class DeleteAttachmentResult(StrictBaseModel):
-    """Result of attachment deletion operation."""
-
-    success: bool = Field(description="Whether the deletion succeeded")
-    ticket_id: int = Field(description="Ticket ID")
-    article_id: int = Field(description="Article ID")
-    attachment_id: int = Field(description="Attachment ID that was deleted")
-    message: str = Field(description="Human-readable result message")
-
-
 class TagOperationParams(StrictBaseModel):
     """Tag operation (add/remove) request parameters."""
 

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -26,8 +26,6 @@ from .models import (
     ArticleCreate,
     Attachment,
     AttachmentDownloadError,
-    DeleteAttachmentParams,
-    DeleteAttachmentResult,
     DownloadAttachmentParams,
     GetArticleAttachmentsParams,
     GetOrganizationParams,
@@ -59,28 +57,6 @@ from .models import (
 )
 
 
-class AttachmentDeletionError(Exception):
-    """Raised when attachment deletion fails."""
-
-    def __init__(self, ticket_id: int, article_id: int, attachment_id: int, reason: str) -> None:
-        """Initialize attachment deletion error.
-
-        Args:
-            ticket_id: Ticket ID
-            article_id: Article ID
-            attachment_id: Attachment ID that failed to delete
-            reason: Reason for failure
-        """
-        self.ticket_id = ticket_id
-        self.article_id = article_id
-        self.attachment_id = attachment_id
-        self.reason = reason
-        super().__init__(
-            f"Failed to delete attachment {attachment_id} from article {article_id} in ticket {ticket_id}: {reason}"
-        )
-
-
-# Protocol for items that can be dumped to dict (for type safety)
 class _Dumpable(Protocol):
     """Protocol for Pydantic models with id, name, and model_dump."""
 
@@ -1359,51 +1335,6 @@ class ZammadMCPServer:
 
             # Convert bytes to base64 string for transmission
             return base64.b64encode(attachment_data).decode("utf-8")
-
-        @self.mcp.tool(annotations=_destructive_write_annotations("Delete Attachment"))
-        def zammad_delete_attachment(params: DeleteAttachmentParams) -> DeleteAttachmentResult:
-            """Delete an attachment from a ticket article.
-
-            Args:
-                params: DeleteAttachmentParams with ticket_id, article_id, attachment_id
-
-            Returns:
-                DeleteAttachmentResult with success status and message
-
-            Examples:
-                - Use when: Removing incorrect file uploads or outdated attachments
-                - Don't use when: Attachment IDs unknown (list attachments first)
-
-            Note:
-                Requires Zammad delete permissions. Deletion is permanent.
-            """
-            client = self.get_client()
-
-            try:
-                success = client.delete_attachment(
-                    ticket_id=params.ticket_id,
-                    article_id=params.article_id,
-                    attachment_id=params.attachment_id,
-                )
-            except Exception as e:
-                raise AttachmentDeletionError(
-                    ticket_id=params.ticket_id,
-                    article_id=params.article_id,
-                    attachment_id=params.attachment_id,
-                    reason=str(e),
-                ) from e
-
-            return DeleteAttachmentResult(
-                success=success,
-                ticket_id=params.ticket_id,
-                article_id=params.article_id,
-                attachment_id=params.attachment_id,
-                message=(
-                    f"Successfully deleted attachment {params.attachment_id} from article {params.article_id} in ticket {params.ticket_id}"
-                    if success
-                    else f"Failed to delete attachment {params.attachment_id}"
-                ),
-            )
 
         @self.mcp.tool(annotations=_idempotent_write_annotations("Add Ticket Tag"))
         def zammad_add_ticket_tag(params: TagOperationParams) -> TagOperationResult:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,9 +2,10 @@
 
 import logging
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
+from zammad_py.api import TicketArticleAttachment
 
 from mcp_zammad.client import ConfigException, ZammadClient
 
@@ -178,6 +179,8 @@ def test_url_validation_private_network_warning(mock_api: MagicMock, caplog) -> 
 def test_download_attachment(mock_api: MagicMock) -> None:
     """Test downloading an attachment."""
     mock_instance = mock_api.return_value
+    # Spec the resource so a call the real class cannot accept fails here (see issue #320).
+    mock_instance.ticket_article_attachment = create_autospec(TicketArticleAttachment, instance=True)
     mock_instance.ticket_article_attachment.download.return_value = b"file content"
 
     with patch.dict(
@@ -289,34 +292,3 @@ def test_add_article_without_time_unit_excludes_field(mock_api: MagicMock) -> No
     assert result["id"] == 789
     call_args = mock_instance.ticket_article.create.call_args[0][0]
     assert "time_unit" not in call_args
-
-
-@patch("mcp_zammad.client.ZammadAPI")
-def test_delete_attachment_success(mock_api: MagicMock) -> None:
-    """Test successful attachment deletion."""
-    mock_instance = mock_api.return_value
-    mock_instance.ticket_article_attachment.destroy.return_value = True
-
-    with patch.dict(
-        os.environ, {"ZAMMAD_URL": "https://test.zammad.com/api/v1", "ZAMMAD_HTTP_TOKEN": "token"}, clear=True
-    ):
-        client = ZammadClient()
-        result = client.delete_attachment(ticket_id=123, article_id=456, attachment_id=789)
-
-    assert result is True
-    mock_instance.ticket_article_attachment.destroy.assert_called_once_with(789, 456, 123)
-
-
-@patch("mcp_zammad.client.ZammadAPI")
-def test_delete_attachment_failure(mock_api: MagicMock) -> None:
-    """Test attachment deletion failure."""
-    mock_instance = mock_api.return_value
-    mock_instance.ticket_article_attachment.destroy.return_value = False
-
-    with patch.dict(
-        os.environ, {"ZAMMAD_URL": "https://test.zammad.com/api/v1", "ZAMMAD_HTTP_TOKEN": "token"}, clear=True
-    ):
-        client = ZammadClient()
-        result = client.delete_attachment(ticket_id=123, article_id=456, attachment_id=789)
-
-    assert result is False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,8 +6,6 @@ from pydantic import ValidationError
 from mcp_zammad.models import (
     ArticleCreate,
     AttachmentUpload,
-    DeleteAttachmentParams,
-    DeleteAttachmentResult,
     GetTicketParams,
     ResponseFormat,
     TicketCreate,
@@ -185,53 +183,3 @@ class TestArticleCreateWithAttachments:
         assert article.ticket_id == 123
         assert article.body == "Simple comment"
         assert article.attachments is None
-
-
-class TestDeleteAttachmentParams:
-    """Tests for DeleteAttachmentParams model."""
-
-    def test_valid_params(self):
-        """Test creating valid delete attachment parameters."""
-        params = DeleteAttachmentParams(ticket_id=123, article_id=456, attachment_id=789)
-        assert params.ticket_id == 123
-        assert params.article_id == 456
-        assert params.attachment_id == 789
-
-    def test_invalid_ticket_id(self):
-        """Test that ticket_id must be positive."""
-        with pytest.raises(ValidationError, match="greater than 0"):
-            DeleteAttachmentParams(ticket_id=0, article_id=456, attachment_id=789)
-
-
-class TestDeleteAttachmentResult:
-    """Tests for DeleteAttachmentResult model."""
-
-    def test_successful_deletion(self):
-        """Test creating successful deletion result."""
-        result = DeleteAttachmentResult(
-            success=True,
-            ticket_id=123,
-            article_id=456,
-            attachment_id=789,
-            message="Successfully deleted attachment 789 from article 456 in ticket 123",
-        )
-        assert result.success is True
-        assert result.ticket_id == 123
-        assert result.article_id == 456
-        assert result.attachment_id == 789
-        assert "Successfully deleted" in result.message
-
-    def test_failed_deletion(self):
-        """Test creating failed deletion result."""
-        result = DeleteAttachmentResult(
-            success=False,
-            ticket_id=123,
-            article_id=456,
-            attachment_id=789,
-            message="Failed to delete attachment 789",
-        )
-        assert result.success is False
-        assert result.ticket_id == 123
-        assert result.article_id == 456
-        assert result.attachment_id == 789
-        assert "Failed" in result.message

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2594,14 +2594,8 @@ class TestAttachmentSupport:
             server_inst.client.download_attachment(123, 456, 789)  # type: ignore[union-attr]
 
     def test_no_attachment_deletion_tool_is_registered(self, decorator_capturer) -> None:
-        """
-        Zammad exposes no attachment-deletion endpoint, so no tool may claim to.
-
-        The Zammad REST API only routes GET /ticket_attachment/:ticket_id/:article_id/:id;
-        there is no DELETE counterpart. The closest supported operation is deleting the
-        whole article via DELETE /ticket_articles/:id. A former zammad_delete_attachment
-        tool failed on every call (issue #320) and must not be reintroduced.
-        """
+        # Zammad only provides a GET attachment route. It has no per-attachment DELETE
+        # endpoint; deleting the whole article is the closest supported operation.
         server_inst = ZammadMCPServer()
         server_inst.client = Mock()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -20,7 +20,6 @@ from mcp_zammad.models import (
     ArticleType,
     Attachment,
     AttachmentUpload,
-    DeleteAttachmentParams,
     GetOrganizationParams,
     GetTicketParams,
     GetTicketStatsParams,
@@ -45,7 +44,6 @@ from mcp_zammad.models import (
 )
 from mcp_zammad.server import (
     CHARACTER_LIMIT,
-    AttachmentDeletionError,
     ZammadMCPServer,
     _format_ticket_detail_markdown,
     main,
@@ -2595,64 +2593,23 @@ class TestAttachmentSupport:
         with pytest.raises(Exception, match="API Error"):
             server_inst.client.download_attachment(123, 456, 789)  # type: ignore[union-attr]
 
-    def test_delete_attachment_tool_success(self, decorator_capturer) -> None:
-        """Test zammad_delete_attachment tool success."""
+    def test_no_attachment_deletion_tool_is_registered(self, decorator_capturer) -> None:
+        """Zammad exposes no attachment-deletion endpoint, so no tool may claim to.
+
+        The Zammad REST API only routes GET /ticket_attachment/:ticket_id/:article_id/:id;
+        there is no DELETE counterpart. The closest supported operation is deleting the
+        whole article via DELETE /ticket_articles/:id. A former zammad_delete_attachment
+        tool failed on every call (issue #320) and must not be reintroduced.
+        """
         server_inst = ZammadMCPServer()
         server_inst.client = Mock()
 
-        # Mock successful deletion
-        server_inst.client.delete_attachment.return_value = True  # type: ignore[union-attr]
-
-        # Setup tools using decorator_capturer fixture
         test_tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
         server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
         server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
         server_inst._setup_tools()
 
-        # Create params
-        params = DeleteAttachmentParams(ticket_id=123, article_id=456, attachment_id=789)
-
-        # Call tool
-        result = test_tools["zammad_delete_attachment"](params)
-
-        # Verify result structure
-        assert result.success is True
-        assert result.ticket_id == 123
-        assert result.article_id == 456
-        assert result.attachment_id == 789
-        assert "Successfully deleted attachment 789" in result.message
-        assert "article 456" in result.message
-        assert "ticket 123" in result.message
-
-        # Verify client called correctly
-        server_inst.client.delete_attachment.assert_called_once_with(  # type: ignore[union-attr]
-            ticket_id=123, article_id=456, attachment_id=789
-        )
-
-    def test_delete_attachment_tool_not_found(self, decorator_capturer) -> None:
-        """Test zammad_delete_attachment with non-existent attachment."""
-        server_inst = ZammadMCPServer()
-        server_inst.client = Mock()
-
-        # Mock API error
-        server_inst.client.delete_attachment.side_effect = Exception("Attachment not found")  # type: ignore[union-attr]
-
-        # Setup tools using decorator_capturer fixture
-        test_tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
-        server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
-        server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
-        server_inst._setup_tools()
-
-        # Create params
-        params = DeleteAttachmentParams(ticket_id=123, article_id=456, attachment_id=999)
-
-        # Verify AttachmentDeletionError is raised
-        with pytest.raises(AttachmentDeletionError) as exc_info:
-            test_tools["zammad_delete_attachment"](params)
-
-        # Verify error details
-        assert exc_info.value.attachment_id == 999
-        assert "Attachment not found" in str(exc_info.value)
+        assert "zammad_delete_attachment" not in test_tools
 
 
 class TestJSONOutputAndTruncation:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2594,7 +2594,8 @@ class TestAttachmentSupport:
             server_inst.client.download_attachment(123, 456, 789)  # type: ignore[union-attr]
 
     def test_no_attachment_deletion_tool_is_registered(self, decorator_capturer) -> None:
-        """Zammad exposes no attachment-deletion endpoint, so no tool may claim to.
+        """
+        Zammad exposes no attachment-deletion endpoint, so no tool may claim to.
 
         The Zammad REST API only routes GET /ticket_attachment/:ticket_id/:article_id/:id;
         there is no DELETE counterpart. The closest supported operation is deleting the


### PR DESCRIPTION
## Summary

`zammad_delete_attachment` failed on every call with `Resource.destroy() takes 2 positional arguments but 4 were given`. Fixing the call would not help: Zammad only routes `GET /api/v1/ticket_attachment/:ticket_id/:article_id/:id` and has no DELETE counterpart, so there is nothing for the tool to call. The only supported removal path is deleting the whole article (`DELETE /api/v1/ticket_articles/:id`).

This PR removes the dead surface rather than stubbing it with an error, because the tool never worked and a registered-but-failing tool only misleads agents that see it in the tool list.

**Removed**
- `zammad_delete_attachment` tool and `AttachmentDeletionError` (`mcp_zammad/server.py`)
- `ZammadClient.delete_attachment` (`mcp_zammad/client.py`)
- `DeleteAttachmentParams` / `DeleteAttachmentResult` (`mcp_zammad/models.py`)
- README tool listing and usage example; a note now states Zammad has no per-attachment delete endpoint

**Tests**
- The former tests used plain `Mock()`/`MagicMock()`, which accept any signature and hid the arity bug. They are replaced by `test_no_attachment_deletion_tool_is_registered`, which asserts the tool is not registered and documents why in its docstring.
- `test_download_attachment` now uses `create_autospec(TicketArticleAttachment, instance=True)`, so a call the real zammad-py resource cannot accept fails in the unit suite.

**BREAKING CHANGE:** `zammad_delete_attachment` is no longer registered. No functioning integration can depend on it since it never succeeded.

Closes #320. Supersedes / same approach as #322 (thanks @jovamateus26 for the root-cause analysis).

## Test plan

- [x] `uv run ruff format --check mcp_zammad tests` / `uv run ruff check mcp_zammad tests` — clean
- [x] `uv run mypy mcp_zammad` — clean
- [x] `uv run pytest` — 215 passed, coverage 88.12% (gate 86%)
- [x] `prek run --all-files` — all hooks pass except `pip-audit`, which reports pre-existing dependency advisories unrelated to this change
- [ ] CI green
