### PR TITLE
fix(search): show date bounds in search results header (follow-ups to #315)

### DIFF
--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from datetime import date
 from typing import Any
 from urllib.parse import urlparse
 
@@ -160,10 +161,16 @@ class ZammadClient:
         group: str | None = None,
         owner: str | None = None,
         customer: str | None = None,
+        created_after: date | str | None = None,
+        created_before: date | str | None = None,
         page: int = 1,
         per_page: int = 25,
     ) -> list[dict[str, Any]]:
-        """Search tickets with various filters."""
+        """Search tickets with various filters.
+
+        created_after and created_before bound the search by creation date, inclusive
+        on both ends. Dates are passed to Zammad in ISO YYYY-MM-DD form.
+        """
         filters = {"page": page, "per_page": per_page, "expand": "true"}
 
         # Build search query
@@ -180,6 +187,10 @@ class ZammadClient:
             search_parts.append(f"owner.login:{owner}")
         if customer:
             search_parts.append(f"customer.email:{customer}")
+        if created_after:
+            search_parts.append(f"created_at:>={created_after}")
+        if created_before:
+            search_parts.append(f"created_at:<={created_before}")
 
         if search_parts:
             search_query = " AND ".join(search_parts)

--- a/mcp_zammad/models.py
+++ b/mcp_zammad/models.py
@@ -301,9 +301,18 @@ class TicketSearchParams(StrictBaseModel):
     group: str | None = Field(None, description="Filter by group name")
     owner: str | None = Field(None, description="Filter by owner login/email")
     customer: str | None = Field(None, description="Filter by customer email")
+    created_after: date | None = Field(None, description="Only tickets created on or after this date (YYYY-MM-DD)")
+    created_before: date | None = Field(None, description="Only tickets created on or before this date (YYYY-MM-DD)")
     page: int = Field(default=1, ge=1, description="Page number (must be >= 1)")
     per_page: int = Field(default=25, ge=1, le=100, description="Results per page (1-100)")
     response_format: ResponseFormat = Field(default=ResponseFormat.MARKDOWN, description="Output format")
+
+    @model_validator(mode="after")
+    def validate_date_range(self) -> "TicketSearchParams":
+        """Reject an inverted date range rather than silently returning nothing."""
+        if self.created_after and self.created_before and self.created_after > self.created_before:
+            raise ValueError("created_after must not be later than created_before")
+        return self
 
 
 class Attachment(BaseModel):

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -884,6 +884,8 @@ class ZammadMCPServer:
                     - group (str | None): Filter by group name
                     - owner (str | None): Filter by owner email/login
                     - customer (str | None): Filter by customer email/login
+                    - created_after (date | None): Only tickets created on/after YYYY-MM-DD
+                    - created_before (date | None): Only tickets created on/before YYYY-MM-DD
                     - page (int): Page number (default: 1)
                     - per_page (int): Results per page, 1-100 (default: 25)
                     - response_format (ResponseFormat): Output format (default: MARKDOWN)

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -959,6 +959,8 @@ class ZammadMCPServer:
                 "group": params.group,
                 "owner": params.owner,
                 "customer": params.customer,
+                "created_after": params.created_after,
+                "created_before": params.created_before,
             }
             filters = [f"{k}='{v}'" for k, v in filter_parts.items() if v]
             query_info = ", ".join(filters) if filters else "All tickets"

--- a/tests/test_client_methods.py
+++ b/tests/test_client_methods.py
@@ -3,12 +3,15 @@
 import os
 import pathlib
 from collections.abc import Generator
+from datetime import date
 from unittest.mock import Mock, patch
 
 import pytest
 import requests
+from pydantic import ValidationError
 
 from mcp_zammad.client import ZammadClient
+from mcp_zammad.models import TicketSearchParams
 
 # Test constants to avoid magic numbers
 EXPECTED_TWO_RESULTS = 2
@@ -652,3 +655,70 @@ class TestZammadClientMethods:
 
         with pytest.raises(requests.HTTPError, match="403"):
             client.list_tags()
+
+
+class TestSearchTicketsDateFilters:
+    """Creation-date bounds must reach the Zammad search query."""
+
+    @pytest.fixture
+    def mock_zammad_api(self):
+        with patch("mcp_zammad.client.ZammadAPI") as mock_api:
+            yield mock_api
+
+    def _client(self, mock_zammad_api: Mock) -> tuple[ZammadClient, Mock]:
+        mock_instance = Mock()
+        mock_instance.ticket.search.return_value = []
+        mock_instance.ticket.all.return_value = []
+        mock_zammad_api.return_value = mock_instance
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+        return client, mock_instance
+
+    def test_created_after_in_query(self, mock_zammad_api: Mock) -> None:
+        """created_after becomes a >= bound."""
+        client, mock_instance = self._client(mock_zammad_api)
+        client.search_tickets(created_after=date(2024, 1, 1))
+        assert mock_instance.ticket.search.call_args[0][0] == "created_at:>=2024-01-01"
+
+    def test_created_before_in_query(self, mock_zammad_api: Mock) -> None:
+        """created_before becomes a <= bound."""
+        client, mock_instance = self._client(mock_zammad_api)
+        client.search_tickets(created_before=date(2024, 12, 31))
+        assert mock_instance.ticket.search.call_args[0][0] == "created_at:<=2024-12-31"
+
+    def test_both_bounds_combine(self, mock_zammad_api: Mock) -> None:
+        """Both bounds AND together."""
+        client, mock_instance = self._client(mock_zammad_api)
+        client.search_tickets(created_after=date(2024, 1, 1), created_before=date(2024, 12, 31))
+        assert mock_instance.ticket.search.call_args[0][0] == "created_at:>=2024-01-01 AND created_at:<=2024-12-31"
+
+    def test_combines_with_other_filters(self, mock_zammad_api: Mock) -> None:
+        """Date bounds compose with existing filters."""
+        client, mock_instance = self._client(mock_zammad_api)
+        client.search_tickets(group="Support", created_after=date(2024, 1, 1))
+        assert mock_instance.ticket.search.call_args[0][0] == "group.name:Support AND created_at:>=2024-01-01"
+
+    def test_no_dates_leaves_query_untouched(self, mock_zammad_api: Mock) -> None:
+        """Without dates the unfiltered path still uses the list endpoint."""
+        client, mock_instance = self._client(mock_zammad_api)
+        client.search_tickets()
+        mock_instance.ticket.search.assert_not_called()
+        mock_instance.ticket.all.assert_called_once()
+
+
+class TestTicketSearchParamsDateValidation:
+    """The search params model validates the date range."""
+
+    def test_inverted_range_rejected(self) -> None:
+        """created_after later than created_before is a validation error."""
+        with pytest.raises(ValidationError, match="created_after must not be later"):
+            TicketSearchParams(created_after=date(2024, 12, 31), created_before=date(2024, 1, 1))
+
+    def test_equal_dates_allowed(self) -> None:
+        """A single-day window is valid."""
+        params = TicketSearchParams(created_after=date(2024, 6, 1), created_before=date(2024, 6, 1))
+        assert params.created_after == params.created_before
+
+    def test_string_dates_parsed(self) -> None:
+        """ISO strings coerce to dates."""
+        params = TicketSearchParams(created_after="2024-01-01")
+        assert params.created_after == date(2024, 1, 1)

--- a/tests/test_client_methods.py
+++ b/tests/test_client_methods.py
@@ -661,7 +661,8 @@ class TestSearchTicketsDateFilters:
     """Creation-date bounds must reach the Zammad search query."""
 
     @pytest.fixture
-    def mock_zammad_api(self):
+    def mock_zammad_api(self) -> Generator[Mock, None, None]:
+        """Mock the underlying zammad_py.ZammadAPI."""
         with patch("mcp_zammad.client.ZammadAPI") as mock_api:
             yield mock_api
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,7 +5,7 @@ import json
 import os
 import pathlib
 import tempfile
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -1791,6 +1791,23 @@ async def test_tool_implementations_are_called():
     assert isinstance(result, str)
     assert "Ticket #12345" in result
     server.client.search_tickets.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_search_tickets_date_filters_in_header():
+    """Date bounds appear in the markdown results header alongside other filters."""
+    server = ZammadMCPServer()
+    server.client = Mock()
+    server.client.search_tickets.return_value = []
+
+    search_tickets_tool = await server.mcp.get_tool("zammad_search_tickets")
+    assert search_tickets_tool is not None
+    params = TicketSearchParams(created_after=date(2024, 1, 1), created_before=date(2024, 3, 31))
+    result = search_tickets_tool.fn(params)
+
+    assert "created_after='2024-01-01'" in result
+    assert "created_before='2024-03-31'" in result
+    assert "All tickets" not in result
 
 
 def test_get_ticket_stats_pagination(decorator_capturer):


### PR DESCRIPTION
## Summary

Non-blocking follow-ups from the Factory review of #315 (creation date range filters for `zammad_search_tickets`). #315 was approved; this PR carries the mechanical touch-ups so they aren't left as homework for the author.

#315 comes from a fork, so this branches from its head and targets `main`. **It lands after #315 is merged** — merging this first would pull in #315's commit as well.

## Changes

- **Show date bounds in the markdown results header** (`mcp_zammad/server.py`). The header lists active filters so the reader can see what the result set was scoped to, but `created_after`/`created_before` were not included in `filter_parts`, so a date-only search rendered as `# Ticket Search Results: All tickets`. Now renders e.g. `created_after='2024-01-01', created_before='2024-03-31'`. JSON output is unaffected.
- **Test for the header** (`tests/test_server.py::test_search_tickets_date_filters_in_header`).
- **Fixture consistency** (`tests/test_client_methods.py`): the new `TestSearchTicketsDateFilters.mock_zammad_api` fixture now has the same `Generator[Mock, None, None]` annotation and docstring as the sibling fixture at the top of the file.

## Verification

- `uv run pytest tests/ -q` — 231 passed
- `uv run ruff check mcp_zammad tests` / `ruff format --check` — clean
- `uv run mypy mcp_zammad` — clean
