### PR TITLE
feat(models): accept case-insensitive constant inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🚀 Features
 
+- *(models)* Accept case-insensitive response_format, article type/sender, and content_type inputs (#201)
 - Add tag listing and retrieval tools (#174)
 - *(time-accounting)* Add time_unit support to update_ticket and add_article (#211)
 - *(deps)* Migrate from bundled FastMCP 1 to standalone FastMCP 3

--- a/mcp_zammad/models.py
+++ b/mcp_zammad/models.py
@@ -5,9 +5,36 @@ import html
 import os
 from datetime import date, datetime
 from enum import Enum
-from typing import Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, ValidationInfo, field_validator, model_validator
+
+
+class CaseInsensitiveStrEnum(str, Enum):
+    """String enum that resolves members case-insensitively while keeping canonical values."""
+
+    @classmethod
+    def _missing_(cls, value: object) -> "CaseInsensitiveStrEnum | None":
+        """Return the member whose value matches ``value`` ignoring case, or None to trigger a normal error.
+
+        Args:
+            value: The raw lookup value that did not match a member exactly.
+
+        Returns:
+            The matching canonical member, or None when no member matches or ``value`` is not a string.
+        """
+        if not isinstance(value, str):
+            return None
+        folded = value.casefold()
+        return next((member for member in cls if member.value.casefold() == folded), None)
+
+
+def _casefold_str(value: Any) -> Any:
+    """Lowercase string input so literal validation is case-insensitive; leave other types untouched."""
+    return value.casefold() if isinstance(value, str) else value
+
+
+ContentType = Annotated[Literal["text/plain", "text/html"], BeforeValidator(_casefold_str)]
 
 
 class StrictBaseModel(BaseModel):
@@ -21,7 +48,7 @@ class StrictBaseModel(BaseModel):
     model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
 
-class ResponseFormat(str, Enum):
+class ResponseFormat(CaseInsensitiveStrEnum):
     """Output format for tool responses.
 
     Attributes:
@@ -33,7 +60,7 @@ class ResponseFormat(str, Enum):
     JSON = "json"
 
 
-class ArticleType(str, Enum):
+class ArticleType(CaseInsensitiveStrEnum):
     """Article type enumeration.
 
     Attributes:
@@ -47,7 +74,7 @@ class ArticleType(str, Enum):
     PHONE = "phone"
 
 
-class ArticleSender(str, Enum):
+class ArticleSender(CaseInsensitiveStrEnum):
     """Article sender type enumeration.
 
     Attributes:
@@ -329,7 +356,7 @@ class ArticleCreate(StrictBaseModel):
     subject: str | None = Field(default=None, max_length=500, description="Email subject")
     to: str | None = Field(default=None, max_length=1000, description="Email recipient")
     cc: str | None = Field(default=None, max_length=1000, description="Email CC recipient(s)")
-    content_type: Literal["text/plain", "text/html"] = Field(default="text/plain", description="Article content type")
+    content_type: ContentType = Field(default="text/plain", description="Article content type")
     time_unit: float | None = Field(
         default=None, description="Time spent for time accounting (unit defined in Zammad admin settings)", gt=0
     )

--- a/mcp_zammad/models.py
+++ b/mcp_zammad/models.py
@@ -15,14 +15,7 @@ class CaseInsensitiveStrEnum(str, Enum):
 
     @classmethod
     def _missing_(cls, value: object) -> "CaseInsensitiveStrEnum | None":
-        """Return the member whose value matches ``value`` ignoring case, or None to trigger a normal error.
-
-        Args:
-            value: The raw lookup value that did not match a member exactly.
-
-        Returns:
-            The matching canonical member, or None when no member matches or ``value`` is not a string.
-        """
+        """Return the member matching ``value`` case-insensitively, or None so Enum raises its usual error."""
         if not isinstance(value, str):
             return None
         folded = value.casefold()

--- a/tests/test_case_insensitive_constants.py
+++ b/tests/test_case_insensitive_constants.py
@@ -1,0 +1,94 @@
+"""Tests for case-insensitive constant inputs at public model boundaries."""
+
+import pytest
+from pydantic import ValidationError
+
+from mcp_zammad.models import ArticleCreate, ArticleSender, ArticleType, GetTicketParams, ResponseFormat
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("MARKDOWN", ResponseFormat.MARKDOWN),
+        ("Markdown", ResponseFormat.MARKDOWN),
+        ("JSON", ResponseFormat.JSON),
+        ("Json", ResponseFormat.JSON),
+        ("json", ResponseFormat.JSON),
+    ],
+)
+def test_response_format_accepts_any_case(raw: str, expected: ResponseFormat) -> None:
+    """Response format input should resolve to the canonical enum member regardless of case."""
+    params = GetTicketParams(ticket_id=1, response_format=raw)  # type: ignore[arg-type]
+    assert params.response_format is expected
+    assert params.response_format.value == expected.value
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("NOTE", ArticleType.NOTE),
+        ("Email", ArticleType.EMAIL),
+        ("PHONE", ArticleType.PHONE),
+    ],
+)
+def test_article_type_accepts_any_case(raw: str, expected: ArticleType) -> None:
+    """Article type input should resolve to the canonical enum member regardless of case."""
+    article = ArticleCreate(ticket_id=1, body="hi", article_type=raw)  # type: ignore[arg-type]
+    assert article.article_type is expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("agent", ArticleSender.AGENT),
+        ("CUSTOMER", ArticleSender.CUSTOMER),
+        ("system", ArticleSender.SYSTEM),
+    ],
+)
+def test_article_sender_accepts_any_case_and_keeps_canonical_value(raw: str, expected: ArticleSender) -> None:
+    """Sender input should resolve to the title-cased canonical value Zammad expects."""
+    article = ArticleCreate(ticket_id=1, body="hi", sender=raw)  # type: ignore[arg-type]
+    assert article.sender is expected
+    assert article.sender.value == expected.value
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected", "body", "expected_body"),
+    [
+        ("TEXT/HTML", "text/html", "<b>x</b>", "<b>x</b>"),
+        ("Text/Plain", "text/plain", "<b>x</b>", "&lt;b&gt;x&lt;/b&gt;"),
+    ],
+)
+def test_content_type_accepts_any_case(raw: str, expected: str, body: str, expected_body: str) -> None:
+    """Content type input should normalize to the canonical literal and drive body sanitization."""
+    article = ArticleCreate(ticket_id=1, body=body, content_type=raw)  # type: ignore[arg-type]
+    assert article.content_type == expected
+    assert article.body == expected_body
+
+
+def test_invalid_response_format_rejected() -> None:
+    """Case folding must not accept values outside the enum."""
+    with pytest.raises(ValidationError, match="response_format"):
+        GetTicketParams(ticket_id=1, response_format="xml")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("field", ["article_type", "sender", "content_type"])
+def test_invalid_article_constants_rejected(field: str) -> None:
+    """Case folding must not accept values outside each article constant set."""
+    with pytest.raises(ValidationError, match=field):
+        ArticleCreate(ticket_id=1, body="hi", **{field: "bogus"})
+
+
+def test_non_string_content_type_rejected() -> None:
+    """Non-string content type input should still fail standard validation."""
+    with pytest.raises(ValidationError, match="content_type"):
+        ArticleCreate(ticket_id=1, body="hi", content_type=42)  # type: ignore[arg-type]
+
+
+def test_schema_keeps_canonical_values() -> None:
+    """Generated schemas should still advertise only canonical values."""
+    ticket_schema = GetTicketParams.model_json_schema()
+    article_schema = ArticleCreate.model_json_schema()
+    assert ticket_schema["$defs"]["ResponseFormat"]["enum"] == ["markdown", "json"]
+    assert article_schema["$defs"]["ArticleSender"]["enum"] == ["Agent", "Customer", "System"]
+    assert article_schema["properties"]["content_type"]["enum"] == ["text/plain", "text/html"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,6 +25,15 @@ def test_transport_config_http_from_env(monkeypatch) -> None:
     assert config.port == 8080
 
 
+def test_transport_config_transport_case_insensitive(monkeypatch) -> None:
+    """Test MCP_TRANSPORT accepts any case."""
+    monkeypatch.setenv("MCP_TRANSPORT", "HTTP")
+    monkeypatch.setenv("MCP_PORT", "8080")
+
+    config = TransportConfig.from_env()
+    assert config.transport == TransportType.HTTP
+
+
 def test_transport_config_stdio_from_env(monkeypatch) -> None:
     """Test stdio transport configuration from environment."""
     monkeypatch.setenv("MCP_TRANSPORT", "stdio")


### PR DESCRIPTION
## Summary

Closes #201.

MCP agents often send constant-style parameters in upper or mixed case (`response_format="MARKDOWN"`, `sender="agent"`, `type="NOTE"`, `content_type="TEXT/HTML"`). Pydantic's enum and literal validation is case-sensitive, so these calls failed with `Input should be 'markdown' or 'json'` even though case carries no meaning for the values. Per the Robustness Principle, the server now accepts any casing for these inputs.

### What changed

- `mcp_zammad/models.py`
  - New `CaseInsensitiveStrEnum` base implementing `Enum._missing_` to resolve members by case-folded value. Non-string inputs and unknown values still return `None`, so Pydantic's normal validation error is preserved.
  - `ResponseFormat`, `ArticleType`, and `ArticleSender` inherit from it. Declared values are unchanged (including the title-cased `Agent`/`Customer`/`System` that Zammad expects).
  - `ArticleCreate.content_type` uses a `BeforeValidator` that case-folds strings before the existing `Literal["text/plain", "text/html"]` check.
- `tests/test_case_insensitive_constants.py` — public-model tests for canonical resolution across casings, rejection of invalid values and non-strings, and unchanged JSON schema enums.
- `tests/test_config.py` — regression test that `MCP_TRANSPORT=HTTP` still works (already normalized via `.lower()` in `TransportConfig.from_env()`; no production change).
- `CHANGELOG.md` — unreleased entry.

### Out of scope

Free-form fields such as ticket `state`, `priority`, `group`, `owner`, and `customer` are not constants — they resolve against Zammad API lookups — and are intentionally untouched.

## Test plan

- [x] RED: new tests failed on the base commit (12 failures), pass after the change
- [x] `uv run pytest tests/` — 242 passed, 88.43% coverage (≥ 86% floor)
- [x] `uv run ruff format --check`, `uv run ruff check`, `uv run mypy mcp_zammad` — clean
- [x] `prek` hooks on changed files (ruff, mypy, bandit, semgrep, rumdl) — pass
- [x] `uv build` — succeeds
- [x] Verified `model_json_schema()` still advertises only canonical values and `model_dump()` emits canonical values (`sender="agent"` → `"Agent"`)

Note: the `pip-audit` pre-commit hook reports 27 pre-existing dependency advisories on `main`; unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enum-based inputs now accept uppercase, lowercase, and mixed-case values for response formats, article types, and article senders.
  - Content type values such as `text/plain` and `text/html` are now accepted regardless of letter casing.
  - Transport configuration values, including `HTTP`, are now handled case-insensitively.
  - Inputs are normalized to their standard values while preserving existing validation and content handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->