### PR TITLE
feat(tickets): add zammad_bulk_update_tickets tool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -419,7 +419,6 @@ git tag v1.0.0-rc.1
 ### Long Term
 
 - Webhook support for real-time updates
-- Bulk operations
 - SLA management features
 - Async Zammad client
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ An MCP server that connects AI assistants to Zammad, providing tools for managin
   - `zammad_update_ticket` - Update ticket properties
   - `zammad_add_article` - Add comments/notes to tickets
   - `zammad_add_ticket_tag` / `zammad_remove_ticket_tag` - Manage ticket tags
+  - `zammad_bulk_update_tickets` - Update, assign, tag, or close up to 100 tickets in one call with per-ticket failure reporting
   - `zammad_get_ticket_tags` - Get tags assigned to a specific ticket
   - `zammad_list_tags` - List all tags defined in the system (requires admin.tag permission)
 

--- a/mcp_zammad/models.py
+++ b/mcp_zammad/models.py
@@ -384,6 +384,64 @@ class TicketUpdateParams(StrictBaseModel):
         return html.escape(v) if v else v
 
 
+class BulkTicketUpdateParams(StrictBaseModel):
+    """Bulk ticket update request parameters."""
+
+    ticket_ids: list[int] = Field(
+        min_length=1, max_length=100, description="Internal ticket IDs to update (1-100, no duplicates)"
+    )
+    title: str | None = Field(None, description="New ticket title", max_length=200)
+    state: str | None = Field(None, description="New state name", max_length=100)
+    priority: str | None = Field(None, description="New priority name", max_length=100)
+    owner: str | None = Field(None, description="New owner login/email", max_length=255)
+    group: str | None = Field(None, description="New group name", max_length=100)
+    time_unit: float | None = Field(None, description="Time spent per ticket for time accounting", gt=0)
+    add_tags: list[str] | None = Field(None, description="Tags to add to every ticket")
+    remove_tags: list[str] | None = Field(None, description="Tags to remove from every ticket")
+    note: str | None = Field(None, description="Internal note to add to every ticket", max_length=10000)
+    delay_seconds: float = Field(0, ge=0, description="Pause between tickets to reduce API pressure")
+
+    @field_validator("ticket_ids")
+    @classmethod
+    def validate_ticket_ids(cls, v: list[int]) -> list[int]:
+        """Require positive, unique ticket IDs."""
+        if any(ticket_id <= 0 for ticket_id in v):
+            raise ValueError("ticket_ids must be greater than 0")
+        if len(set(v)) != len(v):
+            raise ValueError("ticket_ids must be unique")
+        return v
+
+    @field_validator("title", "note")
+    @classmethod
+    def sanitize_text(cls, v: str | None) -> str | None:
+        """Escape HTML to prevent XSS attacks."""
+        return html.escape(v) if v else v
+
+    @model_validator(mode="after")
+    def require_operation(self) -> "BulkTicketUpdateParams":
+        """Reject requests that would change nothing."""
+        fields = (self.title, self.state, self.priority, self.owner, self.group, self.time_unit, self.note)
+        if any(value is not None for value in fields) or self.add_tags or self.remove_tags:
+            return self
+        raise ValueError("Specify at least one field, tag, or note to apply")
+
+
+class BulkUpdateFailure(StrictBaseModel):
+    """A single ticket that could not be fully updated."""
+
+    ticket_id: int = Field(description="Ticket ID that failed")
+    error: str = Field(description="Actionable error message")
+
+
+class BulkUpdateResult(StrictBaseModel):
+    """Outcome of a bulk ticket update."""
+
+    successful_ticket_ids: list[int] = Field(description="Tickets where every requested action succeeded")
+    failed: list[BulkUpdateFailure] = Field(description="Tickets that failed with their error")
+    total_processed: int = Field(description="Number of tickets attempted")
+    total_successful: int = Field(description="Number of tickets fully updated")
+
+
 class GetArticleAttachmentsParams(StrictBaseModel):
     """Get article attachments request parameters."""
 

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -26,6 +26,9 @@ from .models import (
     ArticleCreate,
     Attachment,
     AttachmentDownloadError,
+    BulkTicketUpdateParams,
+    BulkUpdateFailure,
+    BulkUpdateResult,
     DeleteAttachmentParams,
     DeleteAttachmentResult,
     DownloadAttachmentParams,
@@ -785,6 +788,61 @@ def _handle_api_error(e: Exception, context: str = "operation") -> str:
     return f"Error during {context}: {type(e).__name__} - {e}"
 
 
+_BULK_TICKET_FIELDS = {"title", "state", "priority", "owner", "group", "time_unit"}
+
+
+def _apply_bulk_ticket_actions(client: ZammadClient, ticket_id: int, params: BulkTicketUpdateParams) -> None:
+    """Apply every requested bulk action to a single ticket.
+
+    Args:
+        client: Zammad client boundary.
+        ticket_id: Internal ticket ID to modify.
+        params: Validated bulk request describing the actions.
+
+    Raises:
+        Exception: Any client error from the first failing action.
+    """
+    fields = params.model_dump(include=_BULK_TICKET_FIELDS, exclude_none=True)
+    if fields:
+        client.update_ticket(ticket_id=ticket_id, **fields)
+    for tag in params.add_tags or []:
+        client.add_ticket_tag(ticket_id, tag)
+    for tag in params.remove_tags or []:
+        client.remove_ticket_tag(ticket_id, tag)
+    if params.note is not None:
+        client.add_article(ticket_id=ticket_id, body=params.note, article_type="note", internal=True)
+
+
+def _run_bulk_ticket_update(client: ZammadClient, params: BulkTicketUpdateParams) -> BulkUpdateResult:
+    """Process tickets sequentially, collecting per-ticket outcomes.
+
+    Args:
+        client: Zammad client boundary.
+        params: Validated bulk request.
+
+    Returns:
+        BulkUpdateResult: Successful IDs, failures with reasons, and totals.
+    """
+    successful: list[int] = []
+    failed: list[BulkUpdateFailure] = []
+    last_index = len(params.ticket_ids) - 1
+    for index, ticket_id in enumerate(params.ticket_ids):
+        try:
+            _apply_bulk_ticket_actions(client, ticket_id, params)
+            successful.append(ticket_id)
+        except Exception as e:
+            error = _handle_api_error(e, f"bulk update of ticket {ticket_id}")
+            failed.append(BulkUpdateFailure(ticket_id=ticket_id, error=error))
+        if params.delay_seconds and index < last_index:
+            time.sleep(params.delay_seconds)
+    return BulkUpdateResult(
+        successful_ticket_ids=successful,
+        failed=failed,
+        total_processed=len(params.ticket_ids),
+        total_successful=len(successful),
+    )
+
+
 class ZammadMCPServer:
     """Zammad MCP Server with proper client lifecycle management."""
 
@@ -1482,6 +1540,52 @@ class ZammadMCPServer:
             client = self.get_client()
             result = client.remove_ticket_tag(params.ticket_id, params.tag)
             return TagOperationResult(**result)
+
+        @self.mcp.tool(annotations=_destructive_write_annotations("Bulk Update Tickets"))
+        def zammad_bulk_update_tickets(params: BulkTicketUpdateParams) -> BulkUpdateResult:
+            """Apply the same changes to up to 100 tickets in one call (update, assign, tag, close).
+
+            Args:
+                params (BulkTicketUpdateParams): Validated parameters containing:
+                    - ticket_ids (list[int]): 1-100 unique internal database IDs (NOT display numbers)
+                    - title, state, priority, owner, group, time_unit: Same semantics as zammad_update_ticket
+                    - add_tags (list[str] | None): Tags to add to every ticket
+                    - remove_tags (list[str] | None): Tags to remove from every ticket
+                    - note (str | None): Internal note added to every ticket
+                    - delay_seconds (float): Pause between tickets (default 0)
+                At least one field, tag, or note must be supplied.
+
+            Returns:
+                BulkUpdateResult: Per-ticket outcome summary with schema:
+
+                ```json
+                {
+                    "successful_ticket_ids": [1, 3],
+                    "failed": [{"ticket_id": 2, "error": "Error: Resource not found ..."}],
+                    "total_processed": 3,
+                    "total_successful": 2
+                }
+                ```
+
+            Examples:
+                - Use when: "Close tickets 1, 2, 3" -> ticket_ids=[1, 2, 3], state="closed"
+                - Use when: "Assign these to Alice" -> ticket_ids=[...], owner="alice@company.com"
+                - Use when: "Tag all as vip" -> ticket_ids=[...], add_tags=["vip"]
+                - Use when: "Close with a note" -> ticket_ids=[...], state="closed", note="Resolved"
+                - Don't use when: Changing a single ticket (use zammad_update_ticket)
+                - Don't use when: More than 100 tickets (split into multiple calls)
+
+            Error Handling:
+                - Tickets are processed one at a time; a failure never stops the batch
+                - Each failure is reported in `failed` with an actionable message
+                - A ticket appears in successful_ticket_ids only if every requested action succeeded
+                - Zammad has no bulk endpoint: earlier tickets stay changed if a later one fails
+
+            Note:
+                This is a destructive, non-atomic operation. Review ticket_ids carefully
+                (use zammad_search_tickets first) before applying mass state or owner changes.
+            """
+            return _run_bulk_ticket_update(self.get_client(), params)
 
     def _setup_user_org_tools(self) -> None:
         """Register user and organization tools."""

--- a/tests/test_bulk_models.py
+++ b/tests/test_bulk_models.py
@@ -1,0 +1,102 @@
+"""Tests for bulk ticket update request and result models."""
+
+import pytest
+from pydantic import ValidationError
+
+from mcp_zammad.models import BulkTicketUpdateParams, BulkUpdateFailure, BulkUpdateResult
+
+
+def test_accepts_full_request():
+    """A request with IDs and every supported action validates."""
+    params = BulkTicketUpdateParams(
+        ticket_ids=[1, 2, 3],
+        title="Escalated",
+        state="closed",
+        priority="3 high",
+        owner="agent@example.com",
+        group="Support",
+        time_unit=1.5,
+        add_tags=["vip"],
+        remove_tags=["pending-review"],
+        note="Closed in bulk",
+        delay_seconds=0.5,
+    )
+    assert params.ticket_ids == [1, 2, 3]
+    assert params.add_tags == ["vip"]
+    assert params.delay_seconds == 0.5
+
+
+def test_defaults_to_no_delay():
+    """Delay is off unless requested."""
+    params = BulkTicketUpdateParams(ticket_ids=[1], state="closed")
+    assert params.delay_seconds == 0
+
+
+def test_rejects_empty_ticket_ids():
+    """At least one ticket ID is required."""
+    with pytest.raises(ValidationError, match="ticket_ids"):
+        BulkTicketUpdateParams(ticket_ids=[], state="closed")
+
+
+def test_rejects_more_than_100_ticket_ids():
+    """The batch size is capped at 100."""
+    with pytest.raises(ValidationError, match="ticket_ids"):
+        BulkTicketUpdateParams(ticket_ids=list(range(1, 102)), state="closed")
+
+
+def test_rejects_duplicate_ticket_ids():
+    """Duplicate IDs would apply the same change twice."""
+    with pytest.raises(ValidationError, match="unique"):
+        BulkTicketUpdateParams(ticket_ids=[1, 1], state="closed")
+
+
+def test_rejects_non_positive_ticket_id():
+    """Ticket IDs must be positive database IDs."""
+    with pytest.raises(ValidationError, match="greater than 0"):
+        BulkTicketUpdateParams(ticket_ids=[0], state="closed")
+
+
+def test_rejects_request_without_any_operation():
+    """A request that changes nothing is a caller mistake."""
+    with pytest.raises(ValidationError, match="at least one"):
+        BulkTicketUpdateParams(ticket_ids=[1])
+
+
+def test_rejects_empty_tag_list_as_operation():
+    """Empty tag lists do not count as an operation."""
+    with pytest.raises(ValidationError, match="at least one"):
+        BulkTicketUpdateParams(ticket_ids=[1], add_tags=[])
+
+
+def test_escapes_html_in_title_and_note():
+    """Title and note follow the single-ticket sanitization rules."""
+    params = BulkTicketUpdateParams(ticket_ids=[1], title="<b>x</b>", note="<script>y</script>")
+    assert params.title == "&lt;b&gt;x&lt;/b&gt;"
+    assert params.note == "&lt;script&gt;y&lt;/script&gt;"
+
+
+@pytest.mark.parametrize("time_unit", [0, -1])
+def test_rejects_non_positive_time_unit(time_unit):
+    """Time accounting must be a positive amount."""
+    with pytest.raises(ValidationError, match="time_unit"):
+        BulkTicketUpdateParams(ticket_ids=[1], time_unit=time_unit)
+
+
+def test_rejects_negative_delay():
+    """A negative delay is meaningless."""
+    with pytest.raises(ValidationError, match="delay_seconds"):
+        BulkTicketUpdateParams(ticket_ids=[1], state="closed", delay_seconds=-1)
+
+
+def test_result_exposes_success_and_failure_details():
+    """The result reports exactly which tickets changed and why others failed."""
+    result = BulkUpdateResult(
+        successful_ticket_ids=[1, 3],
+        failed=[BulkUpdateFailure(ticket_id=2, error="Error: Resource not found")],
+        total_processed=3,
+        total_successful=2,
+    )
+    assert result.successful_ticket_ids == [1, 3]
+    assert result.failed[0].ticket_id == 2
+    assert result.total_processed == 3
+    assert result.total_successful == 2

--- a/tests/test_bulk_server.py
+++ b/tests/test_bulk_server.py
@@ -1,0 +1,112 @@
+"""Tests for the zammad_bulk_update_tickets MCP tool."""
+
+from typing import Any
+from unittest.mock import Mock, call, patch
+
+import pytest
+
+from mcp_zammad.models import BulkTicketUpdateParams
+from mcp_zammad.server import ZammadMCPServer
+
+
+@pytest.fixture
+def bulk_server() -> ZammadMCPServer:
+    """Server wired to a controlled client double (no Zammad access)."""
+    server = ZammadMCPServer()
+    server.client = Mock()
+    return server
+
+
+async def _run_bulk(server: ZammadMCPServer, **kwargs: Any) -> Any:
+    tool = await server.mcp.get_tool("zammad_bulk_update_tickets")
+    return tool.fn(BulkTicketUpdateParams(**kwargs))
+
+
+@pytest.mark.asyncio
+async def test_tool_is_registered_as_destructive(bulk_server):
+    """The bulk tool is exposed and flagged as destructive."""
+    tool = await bulk_server.mcp.get_tool("zammad_bulk_update_tickets")
+    assert tool.annotations is not None
+    assert tool.annotations.destructiveHint is True
+    assert tool.annotations.readOnlyHint is False
+
+
+@pytest.mark.asyncio
+async def test_updates_every_ticket_with_requested_fields(bulk_server):
+    """Ticket fields are forwarded to each ticket via the client boundary."""
+    result = await _run_bulk(bulk_server, ticket_ids=[1, 2], state="closed", owner="agent@example.com")
+
+    assert bulk_server.client.update_ticket.call_args_list == [
+        call(ticket_id=1, state="closed", owner="agent@example.com"),
+        call(ticket_id=2, state="closed", owner="agent@example.com"),
+    ]
+    assert result.successful_ticket_ids == [1, 2]
+    assert result.failed == []
+    assert result.total_processed == 2
+    assert result.total_successful == 2
+
+
+@pytest.mark.asyncio
+async def test_applies_tags_and_note_without_field_update(bulk_server):
+    """Tag and note actions work on their own and never call update_ticket."""
+    result = await _run_bulk(
+        bulk_server, ticket_ids=[7], add_tags=["vip", "urgent"], remove_tags=["stale"], note="Bulk note"
+    )
+
+    bulk_server.client.update_ticket.assert_not_called()
+    assert bulk_server.client.add_ticket_tag.call_args_list == [call(7, "vip"), call(7, "urgent")]
+    bulk_server.client.remove_ticket_tag.assert_called_once_with(7, "stale")
+    bulk_server.client.add_article.assert_called_once_with(
+        ticket_id=7, body="Bulk note", article_type="note", internal=True
+    )
+    assert result.successful_ticket_ids == [7]
+
+
+@pytest.mark.asyncio
+async def test_continues_after_failure_and_reports_reason(bulk_server):
+    """One failing ticket does not stop the batch, and its reason is reported."""
+    bulk_server.client.update_ticket.side_effect = [
+        {"id": 1},
+        Exception("Ticket not found"),
+        {"id": 3},
+    ]
+
+    result = await _run_bulk(bulk_server, ticket_ids=[1, 2, 3], priority="3 high")
+
+    assert bulk_server.client.update_ticket.call_count == 3
+    assert result.successful_ticket_ids == [1, 3]
+    assert [f.ticket_id for f in result.failed] == [2]
+    assert "Resource not found" in result.failed[0].error
+    assert result.total_processed == 3
+    assert result.total_successful == 2
+
+
+@pytest.mark.asyncio
+async def test_ticket_fails_when_tag_step_fails(bulk_server):
+    """A ticket is only successful when every requested action succeeds."""
+    bulk_server.client.add_ticket_tag.side_effect = Exception("forbidden")
+
+    result = await _run_bulk(bulk_server, ticket_ids=[5], state="open", add_tags=["vip"])
+
+    bulk_server.client.update_ticket.assert_called_once_with(ticket_id=5, state="open")
+    assert result.successful_ticket_ids == []
+    assert result.failed[0].ticket_id == 5
+    assert "Permission denied" in result.failed[0].error
+
+
+@pytest.mark.asyncio
+async def test_delay_applies_only_between_tickets(bulk_server):
+    """delay_seconds sleeps between tickets, not after the last one."""
+    with patch("mcp_zammad.server.time.sleep") as sleep:
+        await _run_bulk(bulk_server, ticket_ids=[1, 2, 3], state="closed", delay_seconds=0.25)
+
+    assert sleep.call_args_list == [call(0.25), call(0.25)]
+
+
+@pytest.mark.asyncio
+async def test_no_sleep_without_delay(bulk_server):
+    """No throttling happens by default."""
+    with patch("mcp_zammad.server.time.sleep") as sleep:
+        await _run_bulk(bulk_server, ticket_ids=[1, 2], state="closed")
+
+    sleep.assert_not_called()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -214,6 +214,7 @@ async def test_server_initialization(mock_zammad_client):
         "zammad_get_ticket_stats",
         "zammad_add_ticket_tag",
         "zammad_remove_ticket_tag",
+        "zammad_bulk_update_tickets",
         "zammad_get_current_user",
     ]
     for tool in expected_tools:


### PR DESCRIPTION
## Summary

Adds a single `zammad_bulk_update_tickets` MCP tool so agents can update, assign, tag, or close up to 100 tickets in one call instead of looping over `zammad_update_ticket`.

Zammad has no bulk HTTP endpoint, so the tool processes tickets sequentially through the existing client methods (`update_ticket`, `add_ticket_tag`, `remove_ticket_tag`, `add_article`) and returns a `BulkUpdateResult`:

- `successful_ticket_ids` — tickets where every requested action succeeded
- `failed` — `{ticket_id, error}` entries with the same actionable messages as other tools
- `total_processed` / `total_successful`

A failure on one ticket never stops the batch. An optional `delay_seconds` throttles between tickets.

**Request contract (`BulkTicketUpdateParams`)**: 1–100 unique positive `ticket_ids`; optional `title`, `state`, `priority`, `owner`, `group`, `time_unit`, `add_tags`, `remove_tags`, `note`; at least one operation is required. `title` and `note` are HTML-escaped like the single-ticket tools. The tool is annotated as destructive because mass state/owner changes have a high blast radius.

Out of scope (per the plan): atomic/transactional behavior, retries, parallel writes, progress streaming, custom fields (#278).

Closes #15

## Test plan

- [x] `tests/test_bulk_models.py` — contract validation (bounds, uniqueness, no-op rejection, sanitization, delay/time_unit constraints, result shape)
- [x] `tests/test_bulk_server.py` — tool registered as destructive via public FastMCP registry; field forwarding; tag/note-only requests; partial failure continues and reports reason; ticket fails when a tag step fails; delay only between tickets
- [x] `tests/test_server.py::test_server_initialization` updated with the new tool name
- [x] `uv run ruff format --check`, `uv run ruff check`, `uv run mypy mcp_zammad` clean
- [x] `uv run pytest tests/ --cov=mcp_zammad` — 242 passed, 88.99% coverage (floor 86%)
- [x] `rumdl check` clean on README/CONTRIBUTING
