### PR TITLE
feat(tickets): support custom Zammad object attributes on read and update

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,27 @@ on:
   workflow_dispatch:
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    if: github.repository == 'basher83/Zammad-MCP'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.28"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --dev --frozen --python "3.13"
+
+      - name: Run canonical release validation
+        run: ./scripts/validate.sh release
+
   test-and-coverage:
     runs-on: ubuntu-latest
     if: github.repository == 'basher83/Zammad-MCP'

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ An MCP server that connects AI assistants to Zammad, providing tools for managin
 
 - **Ticket Management**
   - `zammad_search_tickets` - Search tickets with multiple filters
-  - `zammad_get_ticket` - Get detailed ticket information with articles (supports pagination)
+  - `zammad_get_ticket` - Get detailed ticket information with articles (supports pagination); custom object attributes are included
   - `zammad_create_ticket` - Create new tickets
-  - `zammad_update_ticket` - Update ticket properties
+  - `zammad_update_ticket` - Update ticket properties, including custom object attributes via `custom_fields`
   - `zammad_add_article` - Add comments/notes to tickets
   - `zammad_add_ticket_tag` / `zammad_remove_ticket_tag` - Manage ticket tags
   - `zammad_get_ticket_tags` - Get tags assigned to a specific ticket

--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -248,24 +248,42 @@ class ZammadClient:
         owner: str | None = None,
         group: str | None = None,
         time_unit: float | None = None,
+        custom_fields: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Update an existing ticket."""
+        """Update an existing ticket.
+
+        Args:
+            ticket_id: Internal ticket ID.
+            title: Optional. New ticket title.
+            state: Optional. New state name.
+            priority: Optional. New priority name.
+            owner: Optional. New owner login/email.
+            group: Optional. New group name.
+            time_unit: Optional. Time spent for time accounting; must be > 0.
+            custom_fields: Optional. Custom object attributes sent as top-level ticket keys.
+
+        Returns:
+            The updated ticket as returned by Zammad.
+
+        Raises:
+            ValueError: If time_unit is not positive or a custom field shadows a built-in key.
+        """
         if time_unit is not None and time_unit <= 0:
             raise ValueError("time_unit must be greater than 0")
 
-        update_data: dict[str, Any] = {}
-        if title is not None:
-            update_data["title"] = title
-        if state is not None:
-            update_data["state"] = state
-        if priority is not None:
-            update_data["priority"] = priority
-        if owner is not None:
-            update_data["owner"] = owner
-        if group is not None:
-            update_data["group"] = group
-        if time_unit is not None:
-            update_data["time_unit"] = time_unit
+        built_in = {
+            "title": title,
+            "state": state,
+            "priority": priority,
+            "owner": owner,
+            "group": group,
+            "time_unit": time_unit,
+        }
+        update_data: dict[str, Any] = {key: value for key, value in built_in.items() if value is not None}
+        for name in custom_fields or {}:
+            if name in built_in:
+                raise ValueError(f"custom_fields key '{name}' is a built-in field; pass it as a named argument")
+        update_data.update(custom_fields or {})
 
         return dict(self.api.ticket.update(ticket_id, update_data))
 

--- a/mcp_zammad/models.py
+++ b/mcp_zammad/models.py
@@ -5,7 +5,7 @@ import html
 import os
 from datetime import date, datetime
 from enum import Enum
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
 
@@ -204,7 +204,13 @@ class Article(BaseModel):
 
 
 class Ticket(BaseModel):
-    """Zammad ticket."""
+    """Zammad ticket.
+
+    Custom object attributes defined in Zammad Admin arrive as additional
+    top-level keys and are retained as extra fields.
+    """
+
+    model_config = ConfigDict(extra="allow")
 
     id: int
     number: str
@@ -376,12 +382,30 @@ class TicketUpdateParams(StrictBaseModel):
     time_unit: float | None = Field(
         None, description="Time spent for time accounting (unit defined in Zammad admin settings)", gt=0
     )
+    custom_fields: dict[str, Any] | None = Field(
+        None,
+        description="Custom Zammad object attributes to set, keyed by attribute name (e.g. {'region': 'north'})",
+    )
 
     @field_validator("title")
     @classmethod
     def sanitize_title(cls, v: str | None) -> str | None:
         """Escape HTML to prevent XSS attacks."""
         return html.escape(v) if v else v
+
+    @field_validator("custom_fields")
+    @classmethod
+    def reject_reserved_custom_field_names(cls, v: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Reject custom field names that are empty or shadow built-in update fields."""
+        if v is None:
+            return v
+        reserved = set(cls.model_fields) - {"custom_fields"}
+        for name in v:
+            if not name:
+                raise ValueError("custom_fields keys must be non-empty attribute names")
+            if name in reserved:
+                raise ValueError(f"custom_fields key '{name}' is a built-in field; pass it as a top-level parameter")
+        return v
 
 
 class GetArticleAttachmentsParams(StrictBaseModel):

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -560,6 +560,33 @@ def _format_list_json(items: list[T]) -> str:
     return json.dumps(response, indent=2, default=str)
 
 
+def _format_custom_attribute_value(value: Any) -> str:
+    """Render a custom attribute value for Markdown output."""
+    if isinstance(value, list):
+        return ", ".join(str(item) for item in value)
+    if isinstance(value, dict):
+        return json.dumps(value, default=str)
+    return str(value)
+
+
+def _format_custom_attributes_markdown(ticket: Ticket) -> list[str]:
+    """Render custom object attributes retained on the ticket as a Markdown section.
+
+    Args:
+        ticket: Ticket whose extra (non-schema) fields are custom attributes.
+
+    Returns:
+        Markdown lines for the section, or an empty list when there are no custom attributes.
+    """
+    extras = ticket.model_extra or {}
+    if not extras:
+        return []
+    lines = ["## Custom Attributes", ""]
+    lines.extend(f"**{name}**: {_format_custom_attribute_value(value)}" for name, value in sorted(extras.items()))
+    lines.append("")
+    return lines
+
+
 def _format_ticket_detail_markdown(ticket: Ticket) -> str:
     """Format single ticket with full details as markdown.
 
@@ -579,6 +606,8 @@ def _format_ticket_detail_markdown(ticket: Ticket) -> str:
     lines.append(f"**Created**: {ticket.created_at.isoformat()}")
     lines.append(f"**Updated**: {ticket.updated_at.isoformat()}")
     lines.append("")
+
+    lines.extend(_format_custom_attributes_markdown(ticket))
 
     # Tags
     if hasattr(ticket, "tags") and ticket.tags:
@@ -1130,6 +1159,8 @@ class ZammadMCPServer:
                     - owner (str | None): New owner email/login
                     - customer (str | None): New customer email/login
                     - time_unit (float | None): Time spent for time accounting
+                    - custom_fields (dict[str, Any] | None): Custom object attributes defined in
+                      Zammad Admin, keyed by attribute name (e.g. {"region": "north"})
 
             Returns:
                 Ticket: The updated ticket object with schema:
@@ -1149,6 +1180,7 @@ class ZammadMCPServer:
                 - Use when: "Change ticket 123 to high priority" -> ticket_id=123, priority="high"
                 - Use when: "Close ticket 123" -> ticket_id=123, state="closed"
                 - Use when: "Reassign ticket to Alice" -> ticket_id=123, owner="alice@company.com"
+                - Use when: "Set region to north on ticket 123" -> ticket_id=123, custom_fields={"region": "north"}
                 - Don't use when: Adding comments (use zammad_add_article)
                 - Don't use when: Adding tags (use zammad_add_ticket_tag)
 

--- a/mise.toml
+++ b/mise.toml
@@ -103,6 +103,15 @@ run = "uv lock --upgrade"
 description = "Install Python dependencies"
 run = "uv sync"
 
+# === Validation tasks ===
+[tasks.validate]
+description = "Run canonical developer validation (format, lint, types, tests)"
+run = "./scripts/validate.sh developer"
+
+[tasks.validate-release]
+description = "Run canonical release-readiness validation (developer gates + build)"
+run = "./scripts/validate.sh release"
+
 # === Hooks tasks ===
 [tasks.hooks-install]
 description = "Install pre-commit and infisical hooks"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Run canonical local validation gates.
+set -euo pipefail
+
+mode="${1:-developer}"
+
+run_developer() {
+  uv run ruff format --check mcp_zammad tests
+  uv run ruff check mcp_zammad tests
+  uv run mypy mcp_zammad
+  uv run pytest "${@:2}"
+}
+
+run_release() {
+  run_developer
+  uv build
+}
+
+case "$mode" in
+  developer) run_developer "$@" ;;
+  release) run_release ;;
+  *) echo "Usage: $0 [developer [pytest args...]|release]" >&2; exit 2 ;;
+esac

--- a/tests/test_custom_ticket_attributes.py
+++ b/tests/test_custom_ticket_attributes.py
@@ -1,0 +1,153 @@
+"""Contract tests for custom Zammad ticket object attributes (issue #278)."""
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from mcp_zammad.client import ZammadClient
+from mcp_zammad.models import GetTicketParams, ResponseFormat, TicketSearchParams, TicketUpdateParams
+from mcp_zammad.server import ZammadMCPServer
+
+CUSTOM_ATTRIBUTES = {"region": "Lilongwe", "service_tier": "gold", "site_ids": ["LL-01", "LL-02"]}
+
+
+def _ticket_payload() -> dict:
+    """Build a Zammad ticket JSON payload that includes custom attributes."""
+    return {
+        "id": 123,
+        "number": "65003",
+        "title": "Fibre outage",
+        "group_id": 1,
+        "state_id": 1,
+        "priority_id": 2,
+        "customer_id": 1,
+        "created_by_id": 1,
+        "updated_by_id": 1,
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-01T00:00:00Z",
+        "state": {"id": 1, "name": "open", "state_type_id": 2},
+        "priority": {"id": 2, "name": "2 normal"},
+        "group": {"id": 1, "name": "Support"},
+        "customer": {"id": 1, "email": "customer@example.com"},
+        **CUSTOM_ATTRIBUTES,
+    }
+
+
+@pytest.fixture
+def ticket_tools(decorator_capturer):
+    """Provide captured ticket tools bound to a controlled client double."""
+    server_inst = ZammadMCPServer()
+    server_inst.client = Mock()
+    tools, capture_tool = decorator_capturer(server_inst.mcp.tool)
+    server_inst.mcp.tool = capture_tool  # type: ignore[method-assign, assignment]
+    server_inst.get_client = lambda: server_inst.client  # type: ignore[method-assign, assignment, return-value]
+    server_inst._setup_tools()
+    return tools, server_inst.client
+
+
+def test_get_ticket_json_includes_custom_attributes(ticket_tools):
+    tools, client = ticket_tools
+    client.get_ticket.return_value = _ticket_payload()
+
+    result = tools["zammad_get_ticket"](GetTicketParams(ticket_id=123, response_format=ResponseFormat.JSON))
+
+    parsed = json.loads(result)
+    assert parsed["region"] == "Lilongwe"
+    assert parsed["service_tier"] == "gold"
+    assert parsed["site_ids"] == ["LL-01", "LL-02"]
+
+
+def test_get_ticket_markdown_renders_custom_attributes(ticket_tools):
+    tools, client = ticket_tools
+    client.get_ticket.return_value = _ticket_payload()
+
+    result = tools["zammad_get_ticket"](GetTicketParams(ticket_id=123, response_format=ResponseFormat.MARKDOWN))
+
+    assert "## Custom Attributes" in result
+    assert "**region**: Lilongwe" in result
+    assert "**service_tier**: gold" in result
+    assert "**site_ids**: LL-01, LL-02" in result
+
+
+def test_get_ticket_markdown_omits_custom_section_without_custom_attributes(ticket_tools):
+    tools, client = ticket_tools
+    payload = _ticket_payload()
+    for key in CUSTOM_ATTRIBUTES:
+        del payload[key]
+    client.get_ticket.return_value = payload
+
+    result = tools["zammad_get_ticket"](GetTicketParams(ticket_id=123, response_format=ResponseFormat.MARKDOWN))
+
+    assert "## Custom Attributes" not in result
+
+
+def test_search_tickets_json_includes_custom_attributes(ticket_tools):
+    tools, client = ticket_tools
+    client.search_tickets.return_value = [_ticket_payload()]
+
+    result = tools["zammad_search_tickets"](TicketSearchParams(query="outage", response_format=ResponseFormat.JSON))
+
+    item = json.loads(result)["items"][0]
+    assert item["region"] == "Lilongwe"
+    assert item["service_tier"] == "gold"
+
+
+def test_update_ticket_tool_forwards_custom_fields(ticket_tools):
+    tools, client = ticket_tools
+    client.update_ticket.return_value = _ticket_payload()
+
+    params = TicketUpdateParams(ticket_id=123, state="open", custom_fields={"region": "Blantyre"})
+    result = tools["zammad_update_ticket"](params)
+
+    client.update_ticket.assert_called_once_with(ticket_id=123, state="open", custom_fields={"region": "Blantyre"})
+    assert result.model_dump()["region"] == "Lilongwe"
+
+
+@pytest.mark.parametrize("key", ["ticket_id", "title", "state", "priority", "owner", "group", "time_unit"])
+def test_update_params_reject_custom_fields_colliding_with_built_in_keys(key):
+    with pytest.raises(ValidationError, match=key):
+        TicketUpdateParams(ticket_id=1, custom_fields={key: "value"})
+
+
+def test_update_params_reject_empty_custom_field_name():
+    with pytest.raises(ValidationError, match="custom_fields"):
+        TicketUpdateParams(ticket_id=1, custom_fields={"": "value"})
+
+
+def test_update_params_omit_custom_fields_when_not_provided():
+    params = TicketUpdateParams(ticket_id=1, title="Renamed")
+
+    assert params.model_dump(exclude={"ticket_id"}, exclude_none=True) == {"title": "Renamed"}
+
+
+class TestClientCustomFields:
+    """ZammadClient forwards custom attributes as top-level ticket keys."""
+
+    @pytest.fixture
+    def mock_zammad_api(self):
+        with patch("mcp_zammad.client.ZammadAPI") as mock_api:
+            yield mock_api
+
+    def test_update_ticket_merges_custom_fields_into_payload(self, mock_zammad_api):
+        mock_instance = Mock()
+        mock_instance.ticket.update.return_value = _ticket_payload()
+        mock_zammad_api.return_value = mock_instance
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+
+        client.update_ticket(123, priority="3 high", custom_fields={"region": "Blantyre", "service_tier": "silver"})
+
+        mock_instance.ticket.update.assert_called_once_with(
+            123, {"priority": "3 high", "region": "Blantyre", "service_tier": "silver"}
+        )
+
+    def test_update_ticket_rejects_custom_fields_overwriting_built_in_keys(self, mock_zammad_api):
+        mock_instance = Mock()
+        mock_zammad_api.return_value = mock_instance
+        client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+
+        with pytest.raises(ValueError, match="title"):
+            client.update_ticket(123, custom_fields={"title": "hijacked"})
+
+        mock_instance.ticket.update.assert_not_called()


### PR DESCRIPTION
Closes #278

## Summary

Zammad lets admins define custom Ticket object attributes (single-select, tree-select, text, etc.). The MCP server dropped them on read and offered no way to set them on update, which blocked reporting and bulk-backfill workflows built on those fields.

- **Read:** `Ticket` retains unknown top-level keys. `zammad_get_ticket` and `zammad_search_tickets` now include custom attributes in JSON output, and the Markdown ticket view renders a `## Custom Attributes` section (omitted when there are none).
- **Update:** `zammad_update_ticket` accepts `custom_fields: dict[str, Any]`, forwarded as top-level ticket keys to the Zammad API. Keys that shadow built-in parameters (`title`, `state`, `priority`, `owner`, `group`, `time_unit`, `ticket_id`) and empty names are rejected with a clear validation error, both at the tool boundary and in `ZammadClient.update_ticket`.
- **Validation foundation:** adds `scripts/validate.sh` as the single canonical gate (ruff format/check, mypy, pytest, `uv build`), exposed as `mise run validate` / `mise run validate-release`, and a new `validate` CI job in `tests.yml` that runs the same script so local and GitHub checks match.

Custom attributes on `zammad_create_ticket` are intentionally out of scope; happy to follow up if wanted.

## Test plan

- [x] `tests/test_custom_ticket_attributes.py` (16 new tests, written first and failing before implementation): JSON/Markdown read passthrough, search passthrough, tool → client forwarding, built-in key collision rejection at model and client layers, payload merging.
- [x] `./scripts/validate.sh release` — ruff, mypy, 238 tests, wheel build all pass.
- [x] Coverage 88.52% (floor 86%).
- [x] `prek` hooks pass on changed files (ruff, mypy, bandit, semgrep, rumdl). `pip-audit` reports 27 pre-existing advisories that also fail on `main`; not addressed here.
- [ ] Manual check against a Zammad instance with a custom attribute: `zammad_get_ticket` shows it, `zammad_update_ticket(custom_fields={...})` persists it.
