### PR TITLE
feat(audit): add opt-in JSON Lines audit logging for security events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,19 @@ ZAMMAD_HTTP_TOKEN=your-api-token-here
 # Valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL
 # LOG_LEVEL=INFO
 
+# === Audit Logging (Optional, disabled by default) ===
+
+# Emit one JSON object per line for tool calls, connection outcomes, and URL
+# security checks. Records never include tool arguments, API responses, or secrets.
+# Truthy values only: 1, true, yes, on.
+# ZAMMAD_AUDIT_LOG_ENABLED=true
+
+# Where records go: stderr (default, safe for stdio transport), file, or syslog
+# ZAMMAD_AUDIT_LOG_DESTINATION=stderr
+
+# Append target, required when ZAMMAD_AUDIT_LOG_DESTINATION=file
+# ZAMMAD_AUDIT_LOG_FILE=/var/log/mcp-zammad/audit.jsonl
+
 # === Transport Configuration ===
 
 # Transport type: stdio (default) or http

--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ The server requires Zammad API credentials. Use a `.env` file:
    # Valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL
    # LOG_LEVEL=INFO
 
+   # Optional: Audit logging (see "Audit Logging" below)
+   # ZAMMAD_AUDIT_LOG_ENABLED=true
+   # ZAMMAD_AUDIT_LOG_DESTINATION=stderr  # stderr (default), file, or syslog
+   # ZAMMAD_AUDIT_LOG_FILE=/var/log/mcp-zammad/audit.jsonl  # required for file
+
    # Optional: Transport Configuration
    # MCP_TRANSPORT=stdio  # Transport type: stdio (default) or http
    # MCP_HOST=127.0.0.1   # Host address for HTTP transport
@@ -191,6 +196,31 @@ The server requires Zammad API credentials. Use a `.env` file:
 | `MCP_TRANSPORT` | `stdio` | Transport type: `stdio` or `http` |
 | `MCP_HOST` | `127.0.0.1` | Host address for HTTP transport |
 | `MCP_PORT` | - | Port number for HTTP transport (required if `MCP_TRANSPORT=http`) |
+
+### Audit Logging (Optional)
+
+Audit logging is disabled by default. When enabled, the server writes one JSON object per line
+(JSON Lines) for every MCP tool call, each Zammad connection attempt at startup, and each URL
+security check that flags a local or private-network Zammad host.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ZAMMAD_AUDIT_LOG_ENABLED` | unset | Enable with `1`, `true`, `yes`, or `on` |
+| `ZAMMAD_AUDIT_LOG_DESTINATION` | `stderr` | `stderr`, `file`, or `syslog` |
+| `ZAMMAD_AUDIT_LOG_FILE` | - | Append target, required if destination is `file` |
+
+Example record:
+
+```json
+{"timestamp": "2026-09-08T12:00:00+00:00", "event_type": "tool_call", "action": "zammad_get_ticket", "success": true, "duration_ms": 12.5, "details": {}}
+```
+
+Event types are `tool_call`, `authentication`, and `security_validation`. Records never contain
+tool arguments, Zammad responses, credentials, or full URLs; failures are recorded by exception
+type only, and any `details` key containing `password`, `token`, `secret`, `authorization`,
+`credential`, or `data` is redacted. Audit output never uses stdout, so the default `stderr`
+destination is safe for the stdio transport. Invalid enabled configuration (unknown destination or
+missing file path) fails at startup.
 
 **Important**: Keep your `.env` file out of version control (already in `.gitignore`).
 
@@ -575,6 +605,7 @@ Report via [GitHub Security Advisories](https://github.com/basher83/Zammad-MCP/s
 - ⚠️ **URL Validation**: Rejects malformed and non-HTTP(S) URLs, but does not block private-network targets ([client.py](mcp_zammad/client.py))
 - ✅ **HTML Sanitization**: Sanitizes selected HTML-bearing fields ([models.py](mcp_zammad/models.py))
 - ✅ **Upstream Authentication**: Supports API tokens, OAuth2, and username/password for Zammad ([client.py](mcp_zammad/client.py))
+- ✅ **Audit Logging**: Opt-in JSON Lines records for tool calls, connection outcomes, and URL checks with secret redaction ([audit.py](mcp_zammad/audit.py))
 - ✅ **Dependency Scanning**: CI runs pip-audit; Dependabot security alerts are enabled separately in GitHub
 - ✅ **Security Testing**: CI runs Bandit, Safety, and pip-audit ([security-scan.yml](.github/workflows/security-scan.yml))
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -162,6 +162,18 @@ filtered_data = {k: v for k, v in data.items()
                 if k not in ['password', 'token', 'secret']}
 ```
 
+### MCP Server Audit Logging
+
+The server can emit an opt-in audit trail (`ZAMMAD_AUDIT_LOG_ENABLED=true`) as JSON Lines to
+stderr, a file, or syslog. It records tool-call outcomes, connection outcomes, and URL security
+checks for forensic review. It is an operator-controlled aid, not a compliance certification:
+
+- Records contain no tool arguments, Zammad responses, credentials, or full URLs; failures are
+  logged by exception type only, and sensitive-looking `details` keys are redacted.
+- Records are written locally only. Retention, rotation, and access control for file and syslog
+  destinations are the operator's responsibility; treat the audit file as sensitive metadata.
+- Audit output never uses stdout, so it cannot corrupt the stdio transport.
+
 ## Zammad Instance Security
 
 ### Instance Configuration

--- a/mcp_zammad/audit.py
+++ b/mcp_zammad/audit.py
@@ -11,17 +11,12 @@ Configuration is read from the environment at the composition boundary:
 import json
 import logging
 import sys
-import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from logging.handlers import SysLogHandler
 from pathlib import Path
 from typing import Any
-
-import mcp.types as mt
-from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
-from fastmcp.tools.tool import ToolResult
 
 AUDIT_LOGGER_NAME = "zammad.audit"
 DESTINATIONS = frozenset({"stderr", "file", "syslog"})
@@ -60,12 +55,27 @@ class AuditConfig:
 
 
 def _is_sensitive_key(key: Any) -> bool:
+    """Return whether a mapping key looks like it names a credential or payload.
+
+    Args:
+        key: Mapping key to inspect; coerced to a lowercase string.
+
+    Returns:
+        True when the key contains any fragment in ``SENSITIVE_KEY_FRAGMENTS``.
+    """
     lowered = str(key).lower()
     return any(fragment in lowered for fragment in SENSITIVE_KEY_FRAGMENTS)
 
 
 def redact(value: Any) -> Any:
-    """Return a copy of ``value`` with values under sensitive keys replaced by a marker."""
+    """Return a copy of ``value`` with values under sensitive keys replaced by a marker.
+
+    Args:
+        value: Arbitrary JSON-like value; mappings and sequences are walked recursively.
+
+    Returns:
+        The redacted copy, or ``value`` unchanged for scalars.
+    """
     if isinstance(value, Mapping):
         return {k: REDACTED if _is_sensitive_key(k) else redact(v) for k, v in value.items()}
     if isinstance(value, list | tuple):
@@ -74,6 +84,14 @@ def redact(value: Any) -> Any:
 
 
 def _build_handler(config: AuditConfig) -> logging.Handler:
+    """Create the logging handler for the configured sink; stdout is never used.
+
+    Args:
+        config: Validated audit settings selecting the destination.
+
+    Returns:
+        A file, syslog, or stderr handler.
+    """
     if config.destination == "file" and config.file_path is not None:
         config.file_path.parent.mkdir(parents=True, exist_ok=True)
         return logging.FileHandler(config.file_path, mode="a", encoding="utf-8")
@@ -86,6 +104,12 @@ class AuditLogger:
     """Emit structured JSON Lines audit records to the configured sink."""
 
     def __init__(self, config: AuditConfig, *, now: Callable[[], datetime] | None = None) -> None:
+        """Configure the ``zammad.audit`` logger for the given settings.
+
+        Args:
+            config: Validated audit settings; a disabled config installs no handler.
+            now: Optional. Clock returning timezone-aware datetimes, for deterministic tests.
+        """
         self._config = config
         self._now = now or (lambda: datetime.now(timezone.utc))
         self._logger = logging.getLogger(AUDIT_LOGGER_NAME)
@@ -120,7 +144,17 @@ class AuditLogger:
         duration_ms: float | None = None,
         details: Mapping[str, Any] | None = None,
     ) -> None:
-        """Write one audit record; a no-op when auditing is disabled."""
+        """Write one audit record; a no-op when auditing is disabled.
+
+        Args:
+            event_type: Category such as ``tool_call``, ``authentication`` or ``security_validation``.
+            action: What was attempted, e.g. the tool name.
+            success: Whether the action completed without error.
+            resource_type: Optional. Kind of resource acted on.
+            resource_id: Optional. Identifier of the resource acted on.
+            duration_ms: Optional. Elapsed wall-clock time in milliseconds.
+            details: Optional. Extra context; sensitive keys are redacted before writing.
+        """
         if not self._config.enabled:
             return
         record: dict[str, Any] = {
@@ -136,34 +170,15 @@ class AuditLogger:
 
 
 def error_details(exc: BaseException) -> dict[str, str]:
-    """Describe a failure by root-cause type only; messages may carry secrets."""
+    """Describe a failure by root-cause type only; messages may carry secrets.
+
+    Args:
+        exc: The caught exception; ``__cause__`` chains are followed to the root.
+
+    Returns:
+        A single-key mapping ``{"error_type": <class name>}``.
+    """
     root = exc
     while root.__cause__ is not None:
         root = root.__cause__
     return {"error_type": type(root).__name__}
-
-
-class AuditMiddleware(Middleware):
-    """Record one ``tool_call`` audit event per MCP tool invocation."""
-
-    def __init__(self, audit: AuditLogger) -> None:
-        self._audit = audit
-
-    async def on_call_tool(
-        self,
-        context: MiddlewareContext[mt.CallToolRequestParams],
-        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
-    ) -> ToolResult:
-        """Invoke the tool once, then audit its outcome without capturing arguments or results."""
-        started = time.monotonic()
-        try:
-            result = await call_next(context)
-        except BaseException as exc:
-            self._log(context.message.name, started, success=False, details=error_details(exc))
-            raise
-        self._log(context.message.name, started, success=True)
-        return result
-
-    def _log(self, tool: str, started: float, *, success: bool, details: dict[str, str] | None = None) -> None:
-        elapsed_ms = round((time.monotonic() - started) * 1000, 3)
-        self._audit.log_event("tool_call", tool, success=success, duration_ms=elapsed_ms, details=details)

--- a/mcp_zammad/audit.py
+++ b/mcp_zammad/audit.py
@@ -1,0 +1,169 @@
+"""Opt-in JSON Lines audit logging for security-relevant MCP operations.
+
+Audit records never go to stdout so the MCP stdio transport stays clean.
+Configuration is read from the environment at the composition boundary:
+
+- ``ZAMMAD_AUDIT_LOG_ENABLED``: 1/true/yes/on enables auditing (default: off)
+- ``ZAMMAD_AUDIT_LOG_DESTINATION``: ``stderr`` (default), ``file`` or ``syslog``
+- ``ZAMMAD_AUDIT_LOG_FILE``: append target, required when destination is ``file``
+"""
+
+import json
+import logging
+import sys
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from logging.handlers import SysLogHandler
+from pathlib import Path
+from typing import Any
+
+import mcp.types as mt
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools.tool import ToolResult
+
+AUDIT_LOGGER_NAME = "zammad.audit"
+DESTINATIONS = frozenset({"stderr", "file", "syslog"})
+REDACTED = "[REDACTED]"
+SENSITIVE_KEY_FRAGMENTS = ("password", "passwd", "token", "secret", "authorization", "credential", "data")
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+class AuditConfigError(ValueError):
+    """Raised when audit logging is enabled with an invalid configuration."""
+
+
+@dataclass(frozen=True)
+class AuditConfig:
+    """Validated audit logging settings."""
+
+    enabled: bool = False
+    destination: str = "stderr"
+    file_path: Path | None = None
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str]) -> "AuditConfig":
+        """Build a config from environment-style mapping; invalid enabled configs fail loudly."""
+        enabled = env.get("ZAMMAD_AUDIT_LOG_ENABLED", "").strip().lower() in _TRUTHY
+        if not enabled:
+            return cls()
+        destination = env.get("ZAMMAD_AUDIT_LOG_DESTINATION", "stderr").strip().lower()
+        if destination not in DESTINATIONS:
+            raise AuditConfigError(
+                f"ZAMMAD_AUDIT_LOG_DESTINATION must be one of {sorted(DESTINATIONS)}, got {destination!r}"
+            )
+        file_value = env.get("ZAMMAD_AUDIT_LOG_FILE", "").strip()
+        if destination == "file" and not file_value:
+            raise AuditConfigError("ZAMMAD_AUDIT_LOG_FILE is required when ZAMMAD_AUDIT_LOG_DESTINATION=file")
+        return cls(enabled=True, destination=destination, file_path=Path(file_value) if file_value else None)
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    lowered = str(key).lower()
+    return any(fragment in lowered for fragment in SENSITIVE_KEY_FRAGMENTS)
+
+
+def redact(value: Any) -> Any:
+    """Return a copy of ``value`` with values under sensitive keys replaced by a marker."""
+    if isinstance(value, Mapping):
+        return {k: REDACTED if _is_sensitive_key(k) else redact(v) for k, v in value.items()}
+    if isinstance(value, list | tuple):
+        return [redact(item) for item in value]
+    return value
+
+
+def _build_handler(config: AuditConfig) -> logging.Handler:
+    if config.destination == "file" and config.file_path is not None:
+        config.file_path.parent.mkdir(parents=True, exist_ok=True)
+        return logging.FileHandler(config.file_path, mode="a", encoding="utf-8")
+    if config.destination == "syslog":
+        return SysLogHandler()
+    return logging.StreamHandler(sys.stderr)
+
+
+class AuditLogger:
+    """Emit structured JSON Lines audit records to the configured sink."""
+
+    def __init__(self, config: AuditConfig, *, now: Callable[[], datetime] | None = None) -> None:
+        self._config = config
+        self._now = now or (lambda: datetime.now(timezone.utc))
+        self._logger = logging.getLogger(AUDIT_LOGGER_NAME)
+        self._configure_logger()
+
+    @property
+    def enabled(self) -> bool:
+        """Whether audit records are emitted."""
+        return self._config.enabled
+
+    def _configure_logger(self) -> None:
+        """Replace any existing audit handlers so reconfiguration never duplicates output."""
+        for handler in list(self._logger.handlers):
+            self._logger.removeHandler(handler)
+            handler.close()
+        self._logger.propagate = False
+        self._logger.setLevel(logging.INFO)
+        if not self._config.enabled:
+            return
+        handler = _build_handler(self._config)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        self._logger.addHandler(handler)
+
+    def log_event(
+        self,
+        event_type: str,
+        action: str,
+        *,
+        success: bool,
+        resource_type: str | None = None,
+        resource_id: int | str | None = None,
+        duration_ms: float | None = None,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Write one audit record; a no-op when auditing is disabled."""
+        if not self._config.enabled:
+            return
+        record: dict[str, Any] = {
+            "timestamp": self._now().isoformat(),
+            "event_type": event_type,
+            "action": action,
+            "success": success,
+        }
+        optional = {"resource_type": resource_type, "resource_id": resource_id, "duration_ms": duration_ms}
+        record.update({key: value for key, value in optional.items() if value is not None})
+        record["details"] = redact(dict(details or {}))
+        self._logger.info(json.dumps(record, default=str))
+
+
+def error_details(exc: BaseException) -> dict[str, str]:
+    """Describe a failure by root-cause type only; messages may carry secrets."""
+    root = exc
+    while root.__cause__ is not None:
+        root = root.__cause__
+    return {"error_type": type(root).__name__}
+
+
+class AuditMiddleware(Middleware):
+    """Record one ``tool_call`` audit event per MCP tool invocation."""
+
+    def __init__(self, audit: AuditLogger) -> None:
+        self._audit = audit
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        """Invoke the tool once, then audit its outcome without capturing arguments or results."""
+        started = time.monotonic()
+        try:
+            result = await call_next(context)
+        except BaseException as exc:
+            self._log(context.message.name, started, success=False, details=error_details(exc))
+            raise
+        self._log(context.message.name, started, success=True)
+        return result
+
+    def _log(self, tool: str, started: float, *, success: bool, details: dict[str, str] | None = None) -> None:
+        elapsed_ms = round((time.monotonic() - started) * 1000, 3)
+        self._audit.log_event("tool_call", tool, success=success, duration_ms=elapsed_ms, details=details)

--- a/mcp_zammad/audit_middleware.py
+++ b/mcp_zammad/audit_middleware.py
@@ -1,0 +1,59 @@
+"""FastMCP middleware that audits every tool invocation."""
+
+import time
+
+import mcp.types as mt
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools.tool import ToolResult
+
+from .audit import AuditLogger, error_details
+
+
+class AuditMiddleware(Middleware):
+    """Record one ``tool_call`` audit event per MCP tool invocation."""
+
+    def __init__(self, audit: AuditLogger) -> None:
+        """Bind the middleware to an audit sink.
+
+        Args:
+            audit: Logger that receives the ``tool_call`` records.
+        """
+        self._audit = audit
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        """Invoke the tool once, then audit its outcome without capturing arguments or results.
+
+        Args:
+            context: FastMCP middleware context carrying the tool-call request.
+            call_next: Continuation that executes the remaining pipeline and the tool.
+
+        Returns:
+            The tool result, unchanged.
+
+        Raises:
+            BaseException: Whatever the tool raised, re-raised after the failure is recorded.
+        """
+        started = time.monotonic()
+        try:
+            result = await call_next(context)
+        except BaseException as exc:
+            self._log(context.message.name, started, success=False, details=error_details(exc))
+            raise
+        self._log(context.message.name, started, success=True)
+        return result
+
+    def _log(self, tool: str, started: float, *, success: bool, details: dict[str, str] | None = None) -> None:
+        """Emit a ``tool_call`` record with the elapsed time since ``started``.
+
+        Args:
+            tool: Name of the invoked tool.
+            started: ``time.monotonic()`` reading taken before the call.
+            success: Whether the tool returned normally.
+            details: Optional. Failure description from ``error_details``.
+        """
+        elapsed_ms = round((time.monotonic() - started) * 1000, 3)
+        self._audit.log_event("tool_call", tool, success=success, duration_ms=elapsed_ms, details=details)

--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -8,6 +8,8 @@ from urllib.parse import urlparse
 from zammad_py import ZammadAPI
 from zammad_py.exceptions import ConfigException
 
+from .audit import AuditLogger
+
 logger = logging.getLogger(__name__)
 
 
@@ -23,6 +25,7 @@ class ZammadClient:
         oauth2_token: str | None = None,
         *,
         insecure: bool | None = None,
+        audit_logger: AuditLogger | None = None,
     ) -> None:
         """Initialize Zammad client with environment variables or provided credentials.
 
@@ -34,7 +37,10 @@ class ZammadClient:
         Set insecure=True, or set ZAMMAD_INSECURE to 1/true/yes/on, only for
         trusted self-signed/internal certificate chains. Defaults to secure TLS
         verification.
+
+        Pass audit_logger to receive security_validation events for URL checks.
         """
+        self._audit = audit_logger
         self.url = url or os.getenv("ZAMMAD_URL")
         self.username = username or os.getenv("ZAMMAD_USERNAME")
 
@@ -113,18 +119,32 @@ class ZammadClient:
             if not parsed.hostname:
                 _raise_config_error("Zammad URL must include a valid hostname")
 
-            # Block local/private networks (optional - adjust based on your security requirements)
-            hostname = parsed.hostname.lower() if parsed.hostname else ""
-            blocked_hosts = ["localhost", "127.0.0.1", "0.0.0.0", "::1"]  # nosec B104
-            if hostname in blocked_hosts:
-                logger.warning(f"Zammad URL points to local host: {hostname}")
-
-            # Check for private IP ranges (optional)
-            if hostname.startswith(("10.", "192.168.", "172.")):
-                logger.warning(f"Zammad URL points to private network: {hostname}")
+            self._check_host_network(parsed.hostname.lower() if parsed.hostname else "")
 
         except Exception as e:
             raise ConfigException(f"Invalid Zammad URL format: {e}") from e
+
+    def _check_host_network(self, hostname: str) -> None:
+        """Warn (and audit) when the Zammad host is local or on a private network."""
+        blocked_hosts = ["localhost", "127.0.0.1", "0.0.0.0", "::1"]  # nosec B104
+        if hostname in blocked_hosts:
+            logger.warning(f"Zammad URL points to local host: {hostname}")
+            self._audit_host("local_host", hostname)
+        elif hostname.startswith(("10.", "192.168.", "172.")):
+            logger.warning(f"Zammad URL points to private network: {hostname}")
+            self._audit_host("private_network", hostname)
+
+    def _audit_host(self, reason: str, hostname: str) -> None:
+        """Emit a security_validation audit event carrying only the hostname, never the full URL."""
+        if self._audit is None:
+            return
+        self._audit.log_event(
+            "security_validation",
+            "zammad_url_check",
+            success=False,
+            resource_type="zammad_url",
+            details={"reason": reason, "host": hostname},
+        )
 
     def _read_secret_file(self, env_var: str) -> str | None:
         """Read secret from file path specified in environment variable.

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -19,6 +19,7 @@ from pydantic import ValidationError
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from .audit import AuditConfig, AuditLogger, AuditMiddleware, error_details
 from .client import ZammadClient
 from .logging_config import configure_logging
 from .models import (
@@ -788,19 +789,31 @@ def _handle_api_error(e: Exception, context: str = "operation") -> str:
 class ZammadMCPServer:
     """Zammad MCP Server with proper client lifecycle management."""
 
-    def __init__(self, host: str | None = None, port: int | None = None) -> None:
+    def __init__(
+        self,
+        host: str | None = None,
+        port: int | None = None,
+        *,
+        audit_logger: AuditLogger | None = None,
+    ) -> None:
         """Initialize the server.
 
         Args:
             host: Deprecated. Pass host to mcp.run() instead.
             port: Deprecated. Pass port to mcp.run() instead.
+            audit_logger: Audit sink for tool-call and lifecycle events. Defaults to
+                one built from the ZAMMAD_AUDIT_LOG_* environment variables.
 
         """
         if host is not None or port is not None:
             logger.warning("ZammadMCPServer(host=..., port=...) is deprecated; pass host/port to mcp.run(...) instead.")
         self.client: ZammadClient | None = None
+        self._connected_user_id: int | str | None = None
+        self.audit = audit_logger or AuditLogger(AuditConfig.from_env(os.environ))
         # Create FastMCP with lifespan configured
         self.mcp = FastMCP("zammad_mcp", lifespan=self._create_lifespan())
+        if self.audit.enabled:
+            self.mcp.add_middleware(AuditMiddleware(self.audit))
         self._setup_tools()
         self._setup_resources()
         self._setup_prompts()
@@ -839,12 +852,13 @@ class ZammadMCPServer:
     def _create_client(self, *, verify_connection: bool) -> ZammadClient:
         """Create a Zammad client after loading environment configuration."""
         self._bootstrap_env()
-        client = ZammadClient()
+        client = ZammadClient(audit_logger=self.audit)
         logger.info("Zammad client initialized successfully")
 
         if verify_connection:
             current_user = client.get_current_user()
-            logger.info("Connected as user ID: %s", current_user.get("id", "unknown"))
+            self._connected_user_id = current_user.get("id")
+            logger.info("Connected as user ID: %s", self._connected_user_id or "unknown")
 
         return client
 
@@ -859,9 +873,12 @@ class ZammadMCPServer:
         """Initialize the Zammad client on server startup."""
         try:
             self.client = self._create_client(verify_connection=True)
-        except Exception:
+        except Exception as exc:
             logger.exception("Failed to initialize Zammad client")
+            self.audit.log_event("authentication", "zammad_connect", success=False, details=error_details(exc))
             raise
+        details = {"user_id": self._connected_user_id}
+        self.audit.log_event("authentication", "zammad_connect", success=True, details=details)
 
     def _setup_tools(self) -> None:
         """Register all tools with the MCP server."""

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -19,7 +19,8 @@ from pydantic import ValidationError
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from .audit import AuditConfig, AuditLogger, AuditMiddleware, error_details
+from .audit import AuditConfig, AuditLogger, error_details
+from .audit_middleware import AuditMiddleware
 from .client import ZammadClient
 from .logging_config import configure_logging
 from .models import (

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,159 @@
+"""Tests for the opt-in audit logging boundary (issue #121)."""
+
+import json
+import logging
+from datetime import datetime, timezone
+
+import pytest
+
+from mcp_zammad.audit import AuditConfig, AuditConfigError, AuditLogger, redact
+
+FIXED_TIME = datetime(2026, 9, 8, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _fixed_clock() -> datetime:
+    return FIXED_TIME
+
+
+def _stderr_logger(**overrides: str) -> AuditLogger:
+    env = {"ZAMMAD_AUDIT_LOG_ENABLED": "true", "ZAMMAD_AUDIT_LOG_DESTINATION": "stderr", **overrides}
+    return AuditLogger(AuditConfig.from_env(env), now=_fixed_clock)
+
+
+def _records(text: str) -> list[dict]:
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+def test_config_defaults_to_disabled() -> None:
+    config = AuditConfig.from_env({})
+    assert config.enabled is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "YES", "on"])
+def test_config_enabled_truthy_values(value: str) -> None:
+    config = AuditConfig.from_env({"ZAMMAD_AUDIT_LOG_ENABLED": value})
+    assert config.enabled is True
+    assert config.destination == "stderr"
+
+
+def test_config_rejects_unknown_destination() -> None:
+    env = {"ZAMMAD_AUDIT_LOG_ENABLED": "true", "ZAMMAD_AUDIT_LOG_DESTINATION": "elasticsearch"}
+    with pytest.raises(AuditConfigError, match="ZAMMAD_AUDIT_LOG_DESTINATION"):
+        AuditConfig.from_env(env)
+
+
+def test_config_file_destination_requires_path() -> None:
+    env = {"ZAMMAD_AUDIT_LOG_ENABLED": "true", "ZAMMAD_AUDIT_LOG_DESTINATION": "file"}
+    with pytest.raises(AuditConfigError, match="ZAMMAD_AUDIT_LOG_FILE"):
+        AuditConfig.from_env(env)
+
+
+def test_config_ignores_destination_when_disabled() -> None:
+    config = AuditConfig.from_env({"ZAMMAD_AUDIT_LOG_DESTINATION": "bogus"})
+    assert config.enabled is False
+
+
+def test_disabled_logger_emits_nothing(capsys: pytest.CaptureFixture[str], tmp_path) -> None:
+    file_path = tmp_path / "audit.jsonl"
+    env = {"ZAMMAD_AUDIT_LOG_DESTINATION": "file", "ZAMMAD_AUDIT_LOG_FILE": str(file_path)}
+    audit = AuditLogger(AuditConfig.from_env(env))
+
+    audit.log_event("tool_call", "zammad_get_ticket", success=True)
+
+    assert audit.enabled is False
+    assert not file_path.exists()
+    assert capsys.readouterr() == ("", "")
+    assert logging.getLogger("zammad.audit").handlers == []
+
+
+def test_stderr_sink_writes_json_lines_never_stdout(capsys: pytest.CaptureFixture[str]) -> None:
+    audit = _stderr_logger()
+
+    audit.log_event(
+        "tool_call",
+        "zammad_get_ticket",
+        success=True,
+        resource_type="ticket",
+        resource_id=42,
+        duration_ms=12.5,
+        details={"page": 1},
+    )
+
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert _records(err) == [
+        {
+            "timestamp": "2026-09-08T12:00:00+00:00",
+            "event_type": "tool_call",
+            "action": "zammad_get_ticket",
+            "success": True,
+            "resource_type": "ticket",
+            "resource_id": 42,
+            "duration_ms": 12.5,
+            "details": {"page": 1},
+        }
+    ]
+
+
+def test_file_sink_appends_json_lines(tmp_path) -> None:
+    file_path = tmp_path / "nested" / "audit.jsonl"
+    env = {"ZAMMAD_AUDIT_LOG_DESTINATION": "file", "ZAMMAD_AUDIT_LOG_FILE": str(file_path)}
+    audit = _stderr_logger(**env)
+
+    audit.log_event("tool_call", "first", success=True)
+    audit.log_event("tool_call", "second", success=False)
+
+    actions = [record["action"] for record in _records(file_path.read_text())]
+    assert actions == ["first", "second"]
+
+
+def test_syslog_sink_uses_syslog_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    emitted: list[str] = []
+
+    class FakeSysLogHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            emitted.append(self.format(record))
+
+    monkeypatch.setattr("mcp_zammad.audit.SysLogHandler", FakeSysLogHandler)
+    audit = _stderr_logger(ZAMMAD_AUDIT_LOG_DESTINATION="syslog")
+
+    audit.log_event("security_validation", "url_check", success=False)
+
+    assert [json.loads(line)["event_type"] for line in emitted] == ["security_validation"]
+
+
+def test_reconfiguration_does_not_duplicate_handlers(capsys: pytest.CaptureFixture[str]) -> None:
+    _stderr_logger()
+    audit = _stderr_logger()
+
+    audit.log_event("tool_call", "once", success=True)
+
+    assert len(_records(capsys.readouterr().err)) == 1
+
+
+def test_details_are_redacted_before_serialization(capsys: pytest.CaptureFixture[str]) -> None:
+    audit = _stderr_logger()
+    details = {
+        "password": "hunter2",
+        "nested": {"http_token": "abc123", "keep": "visible"},
+        "headers": [{"Authorization": "Bearer xyz"}],
+        "attachment": {"data": "aGVsbG8="},
+    }
+
+    audit.log_event("authentication", "login", success=True, details=details)
+
+    err = capsys.readouterr().err
+    for secret in ("hunter2", "abc123", "Bearer xyz", "aGVsbG8="):
+        assert secret not in err
+    record = _records(err)[0]
+    assert record["details"]["nested"]["keep"] == "visible"
+    assert record["details"]["password"] == "[REDACTED]"
+
+
+def test_redact_is_pure_and_case_insensitive() -> None:
+    original = {"SECRET_KEY": "s", "list": [{"api_token": "t"}, "plain"], "ok": 1}
+
+    result = redact(original)
+
+    assert result == {"SECRET_KEY": "[REDACTED]", "list": [{"api_token": "[REDACTED]"}, "plain"], "ok": 1}
+    assert original["SECRET_KEY"] == "s"

--- a/tests/test_audit_integration.py
+++ b/tests/test_audit_integration.py
@@ -1,0 +1,168 @@
+"""Tests for audit events emitted at the server and client boundaries (issue #121)."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+
+from mcp_zammad.audit import AuditConfig, AuditLogger
+from mcp_zammad.client import ZammadClient
+from mcp_zammad.server import ZammadMCPServer
+
+GROUP = {"id": 1, "name": "Users", "created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z"}
+
+
+@pytest.fixture
+def audit_file(tmp_path: Path) -> Path:
+    return tmp_path / "audit.jsonl"
+
+
+@pytest.fixture
+def audit(audit_file: Path) -> AuditLogger:
+    env = {
+        "ZAMMAD_AUDIT_LOG_ENABLED": "true",
+        "ZAMMAD_AUDIT_LOG_DESTINATION": "file",
+        "ZAMMAD_AUDIT_LOG_FILE": str(audit_file),
+    }
+    return AuditLogger(AuditConfig.from_env(env))
+
+
+@pytest.fixture
+def fake_zammad():
+    """Replace the Zammad client at the server boundary with a controlled double."""
+    with patch("mcp_zammad.server.ZammadClient") as mock_class:
+        instance = Mock()
+        instance.get_current_user.return_value = {"id": 1, "email": "agent@example.com"}
+        instance.get_groups.return_value = [GROUP]
+        mock_class.return_value = instance
+        yield instance, mock_class
+
+
+def _records(path: Path, event_type: str | None = None) -> list[dict]:
+    if not path.exists():
+        return []
+    records = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    return [r for r in records if event_type is None or r["event_type"] == event_type]
+
+
+@pytest.mark.asyncio
+async def test_successful_tool_call_emits_one_audit_record(fake_zammad, audit: AuditLogger, audit_file: Path) -> None:
+    server = ZammadMCPServer(audit_logger=audit)
+
+    async with Client(server.mcp) as client:
+        result = await client.call_tool("zammad_list_groups", {"params": {}})
+
+    assert "Users" in result.content[0].text
+    records = _records(audit_file, "tool_call")
+    assert len(records) == 1
+    assert records[0]["action"] == "zammad_list_groups"
+    assert records[0]["success"] is True
+    assert records[0]["duration_ms"] >= 0
+    assert records[0]["details"] == {}
+
+
+@pytest.mark.asyncio
+async def test_failed_tool_call_records_failure_and_reraises(fake_zammad, audit: AuditLogger, audit_file: Path) -> None:
+    instance, _ = fake_zammad
+    instance.get_groups.side_effect = RuntimeError("token=leaked-secret")
+    server = ZammadMCPServer(audit_logger=audit)
+
+    async with Client(server.mcp) as client:
+        with pytest.raises(ToolError):
+            await client.call_tool("zammad_list_groups", {"params": {}})
+
+    records = _records(audit_file, "tool_call")
+    assert len(records) == 1
+    assert records[0]["success"] is False
+    assert records[0]["details"] == {"error_type": "RuntimeError"}
+    assert "leaked-secret" not in audit_file.read_text()
+
+
+@pytest.mark.asyncio
+async def test_disabled_audit_keeps_tool_behavior_and_silence(fake_zammad, audit_file: Path) -> None:
+    disabled = AuditLogger(AuditConfig.from_env({"ZAMMAD_AUDIT_LOG_FILE": str(audit_file)}))
+    server = ZammadMCPServer(audit_logger=disabled)
+
+    async with Client(server.mcp) as client:
+        result = await client.call_tool("zammad_list_groups", {"params": {}})
+
+    assert "Users" in result.content[0].text
+    assert not audit_file.exists()
+
+
+def test_server_builds_audit_logger_from_environment(audit_file: Path) -> None:
+    env = {
+        "ZAMMAD_AUDIT_LOG_ENABLED": "true",
+        "ZAMMAD_AUDIT_LOG_DESTINATION": "file",
+        "ZAMMAD_AUDIT_LOG_FILE": str(audit_file),
+    }
+    with patch.dict(os.environ, env):
+        server = ZammadMCPServer()
+
+    server.audit.log_event("tool_call", "probe", success=True)
+    assert [r["action"] for r in _records(audit_file)] == ["probe"]
+
+
+@patch("mcp_zammad.client.ZammadAPI")
+def test_private_url_emits_redacted_security_event(mock_api: MagicMock, audit: AuditLogger, audit_file: Path) -> None:
+    url = "http://user:pw@192.168.1.100/api/v1?token=abc"
+    with patch.dict(os.environ, {"ZAMMAD_URL": url, "ZAMMAD_HTTP_TOKEN": "tok"}, clear=True):
+        ZammadClient(audit_logger=audit)
+
+    records = _records(audit_file, "security_validation")
+    assert len(records) == 1
+    assert records[0]["success"] is False
+    assert records[0]["details"] == {"reason": "private_network", "host": "192.168.1.100"}
+    text = audit_file.read_text()
+    for leaked in ("user:pw", "token=abc", "tok"):
+        assert leaked not in text
+
+
+@patch("mcp_zammad.client.ZammadAPI")
+def test_localhost_url_emits_security_event(mock_api: MagicMock, audit: AuditLogger, audit_file: Path) -> None:
+    with patch.dict(os.environ, {"ZAMMAD_URL": "http://localhost:3000", "ZAMMAD_HTTP_TOKEN": "tok"}, clear=True):
+        ZammadClient(audit_logger=audit)
+
+    records = _records(audit_file, "security_validation")
+    assert [r["details"]["reason"] for r in records] == ["local_host"]
+
+
+@patch("mcp_zammad.client.ZammadAPI")
+def test_public_url_emits_no_security_event(mock_api: MagicMock, audit: AuditLogger, audit_file: Path) -> None:
+    with patch.dict(os.environ, {"ZAMMAD_URL": "https://zammad.example.com", "ZAMMAD_HTTP_TOKEN": "tok"}, clear=True):
+        ZammadClient(audit_logger=audit)
+
+    assert _records(audit_file) == []
+
+
+@pytest.mark.asyncio
+async def test_initialize_audits_authentication_success(fake_zammad, audit: AuditLogger, audit_file: Path) -> None:
+    _, mock_class = fake_zammad
+    server = ZammadMCPServer(audit_logger=audit)
+
+    await server.initialize()
+
+    assert mock_class.call_args.kwargs["audit_logger"] is audit
+    records = _records(audit_file, "authentication")
+    assert records == [{**records[0], "success": True, "details": {"user_id": 1}}]
+
+
+@pytest.mark.asyncio
+async def test_initialize_audits_authentication_failure(audit: AuditLogger, audit_file: Path) -> None:
+    server = ZammadMCPServer(audit_logger=audit)
+
+    with (
+        patch("mcp_zammad.server.ZammadClient", side_effect=RuntimeError("password=oops")),
+        pytest.raises(RuntimeError),
+    ):
+        await server.initialize()
+
+    records = _records(audit_file, "authentication")
+    assert len(records) == 1
+    assert records[0]["success"] is False
+    assert records[0]["details"] == {"error_type": "RuntimeError"}
+    assert "oops" not in audit_file.read_text()


### PR DESCRIPTION
## Summary

Adds an opt-in, structured audit trail to the Zammad MCP server so operators can see what the server did without exposing customer data or credentials. Resolves #121.

When `ZAMMAD_AUDIT_LOG_ENABLED=true`, the server writes one JSON object per line for:

- **`tool_call`** — every MCP tool invocation, with success/failure and elapsed time (via FastMCP 3 middleware, a single interception point for all 22 tools)
- **`authentication`** — the Zammad connection outcome at startup, with the authenticated user ID on success
- **`security_validation`** — the existing URL guard flagging a `localhost` or private-network Zammad host

Destination is `stderr` (default, safe for stdio transport), `file` (`ZAMMAD_AUDIT_LOG_FILE`, append mode), or `syslog`. Invalid enabled configuration fails loudly at startup.

### Privacy and safety guarantees

- Records never contain tool arguments, Zammad responses, credentials, or full URLs (only the hostname for URL checks)
- Failures are recorded by root-cause exception type only — messages may carry secrets
- Any `details` key containing `password`, `token`, `secret`, `authorization`, `credential`, or `data` is redacted recursively
- stdout is never used; existing tool results and error semantics are preserved unchanged
- Audit logger setup is idempotent, so repeated server construction doesn't duplicate handlers
- Disabled (default) behavior is a no-op: no handlers, no files, no output

### Out of scope (deferred from the issue's proposal)

HTTP/Elasticsearch/Splunk sinks, retention-day pruning/rotation, per-event opt-outs, model-sanitizer trigger events, and client-IP/actor fields (not reliably available at the stdio tool-call boundary). Issue #120 (rate limiting) can emit into this boundary once it lands.

### Files

- `mcp_zammad/audit.py` — new: `AuditConfig`, `AuditLogger`, `AuditMiddleware`, `redact`
- `mcp_zammad/server.py` — builds the logger from env, registers middleware when enabled, audits connection outcome
- `mcp_zammad/client.py` — accepts an `audit_logger` and emits URL security events
- `tests/test_audit.py`, `tests/test_audit_integration.py` — 24 new boundary tests
- `.env.example`, `README.md`, `SECURITY.md` — configuration and guarantees

## Test plan

- [x] `uv run ruff format --check mcp_zammad tests` / `uv run ruff check mcp_zammad tests`
- [x] `uv run mypy mcp_zammad`
- [x] `uv run bandit -c pyproject.toml -r mcp_zammad --severity-level high`
- [x] `uv run pytest tests/ --cov=mcp_zammad --cov-fail-under=86` — 246 passed, 89.94% total, `audit.py` at 100%
- [x] `mise run markdown-lint`
- [x] Integration tests drive tools through the public `fastmcp.Client` and assert exactly one record per call, error re-raised unchanged, and that a poisoned error message (`token=leaked-secret`) and URL credentials/query string never reach the audit file
