### PR TITLE
feat: receive Zammad webhook events and expose them via zammad_list_events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,9 @@ ZAMMAD_HTTP_TOKEN=your-api-token-here
 
 # Port to listen on (required for HTTP transport)
 # MCP_PORT=8000
+
+# === Webhook Events (HTTP transport only) ===
+
+# HMAC-SHA1 secret shared with the Zammad webhook (Manage -> Webhooks -> HMAC SHA1 Signature Token).
+# POST /webhooks/zammad returns 503 until this is set.
+# ZAMMAD_WEBHOOK_SECRET=change-me

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,40 @@ on:
   workflow_dispatch:
 
 jobs:
+  lint-and-types:
+    # Mirrors the non-mutating checks in scripts/quality-check.sh. Rules are
+    # defined once in pyproject.toml ([tool.ruff], [tool.mypy]).
+    runs-on: ubuntu-latest
+    if: github.repository == 'basher83/Zammad-MCP'
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.28"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install dependencies
+        run: uv sync --dev --frozen
+
+      - name: Check formatting
+        run: uv run ruff format --check mcp_zammad tests
+
+      - name: Lint
+        run: uv run ruff check mcp_zammad tests
+
+      - name: Type check
+        run: uv run mypy mcp_zammad
+
   test-and-coverage:
     runs-on: ubuntu-latest
     if: github.repository == 'basher83/Zammad-MCP'

--- a/README.md
+++ b/README.md
@@ -412,7 +412,8 @@ The server maps deliveries to `ticket.create` (first article), `ticket.article.c
 malformed payloads return `400`. Only identifiers and timestamps are retained — never article bodies.
 
 Retention is process-local and bounded (1000 events, oldest evicted first) and is lost on restart. Poll with
-`zammad_list_events`, pass the returned `next_since` as `since` on the next call, then fetch details with
+`zammad_list_events`, which returns the oldest events after `since` first (up to `limit`); pass the returned
+`next_since` as `since` on the next call and repeat until `events` is empty, then fetch details with
 `zammad_get_ticket`.
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ An MCP server that connects AI assistants to Zammad, providing tools for managin
   - `zammad_list_ticket_priorities` - Get all priority levels (cached for performance)
   - `zammad_get_ticket_stats` - Get ticket statistics (optimized with pagination)
 
+- **Webhook Events** (HTTP transport only)
+  - `zammad_list_events` - Poll ticket events delivered by Zammad webhooks (see [Webhook Events](#webhook-events-http-transport-only))
+
 ### Resources
 
 Access Zammad data directly:
@@ -380,6 +383,37 @@ Configure your MCP client to use HTTP transport:
 3. **HTTPS**: Use reverse proxy for TLS
 4. **Firewall**: Restrict access to trusted networks
 5. **Host/Origin Validation**: Configure this at the authenticated proxy; the server does not add it automatically
+
+### Webhook Events (HTTP Transport Only)
+
+Instead of repeatedly searching for changed tickets, Zammad can push ticket events to the server, and MCP clients poll
+them with `zammad_list_events`. This needs `MCP_TRANSPORT=http`; stdio mode has no inbound listener.
+
+1. **Configure a secret** (the endpoint answers `503` until it is set):
+
+   ```bash
+   export ZAMMAD_WEBHOOK_SECRET="$(openssl rand -hex 32)"
+   ```
+
+2. **Expose `POST /webhooks/zammad`** to your Zammad instance, behind TLS (reverse proxy). The signature proves the
+   payload came from Zammad but does not encrypt it.
+
+3. **Create the webhook in Zammad** (admin only): *Manage → Webhooks → New Webhook*
+   - Endpoint: `https://your-mcp-host/webhooks/zammad`
+   - HMAC SHA1 Signature Token: the same value as `ZAMMAD_WEBHOOK_SECRET`
+   - Keep the default JSON payload (the server reads `ticket.id`, `ticket.number`, `ticket.article_count`,
+     `ticket.updated_at`, and `article.id`)
+
+4. **Create a trigger** (*Manage → Triggers → New Trigger*) that fires on the ticket actions you care about and executes
+   the webhook.
+
+The server maps deliveries to `ticket.create` (first article), `ticket.article.create` (later articles), or
+`ticket.update` (no article in payload). Invalid or missing `X-Hub-Signature` headers return `401`; non-ticket or
+malformed payloads return `400`. Only identifiers and timestamps are retained — never article bodies.
+
+Retention is process-local and bounded (1000 events, oldest evicted first) and is lost on restart. Poll with
+`zammad_list_events`, pass the returned `next_since` as `since` on the next call, then fetch details with
+`zammad_get_ticket`.
 
 ## Examples
 

--- a/mcp_zammad/events.py
+++ b/mcp_zammad/events.py
@@ -73,11 +73,15 @@ class EventStore:
         self._events.append(event)
 
     def list(self, *, since: datetime | None = None, limit: int | None = None) -> list[WebhookEvent]:
-        """Return retained events in receipt order, newest ``limit`` after ``since``."""
+        """Return the oldest ``limit`` retained events received after ``since``, in receipt order.
+
+        Taking the oldest page (not the newest) lets a client pass the last ``received_at``
+        back as ``since`` and walk a backlog larger than ``limit`` without skipping events.
+        """
         events = list(self._events)
         if since is not None:
             cutoff = _as_utc(since)
             events = [e for e in events if _as_utc(e.received_at) > cutoff]
         if limit is not None:
-            events = events[-limit:]
+            events = events[:limit]
         return events

--- a/mcp_zammad/events.py
+++ b/mcp_zammad/events.py
@@ -1,0 +1,83 @@
+"""Bounded in-memory retention of normalized Zammad webhook events."""
+
+from collections import deque
+from datetime import datetime, timezone
+from typing import Literal
+
+from pydantic import Field
+
+from .models import StrictBaseModel
+
+DEFAULT_EVENT_CAPACITY = 1000
+MAX_LIST_LIMIT = 100
+
+EventType = Literal["ticket.create", "ticket.update", "ticket.article.create"]
+
+
+class WebhookEvent(StrictBaseModel):
+    """Normalized, body-free record of one accepted Zammad webhook delivery."""
+
+    event_type: EventType
+    ticket_id: int
+    ticket_number: str | None = None
+    article_id: int | None = None
+    trigger: str | None = None
+    source_timestamp: datetime | None = None
+    received_at: datetime
+
+
+class ListEventsParams(StrictBaseModel):
+    """Filter for the ``zammad_list_events`` tool."""
+
+    since: datetime | None = Field(
+        default=None,
+        description="Return only events received strictly after this timestamp (ISO 8601, naive means UTC).",
+    )
+    limit: int = Field(
+        default=50, ge=1, le=MAX_LIST_LIMIT, description=f"Maximum events to return (1-{MAX_LIST_LIMIT})."
+    )
+
+
+class ListEventsResult(StrictBaseModel):
+    """Tool output: retained events plus retention metadata for polling clients."""
+
+    events: list[WebhookEvent]
+    count: int
+    capacity: int
+    retained_total: int
+    next_since: datetime | None
+
+
+def _as_utc(value: datetime) -> datetime:
+    return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+
+
+class EventStore:
+    """Process-local FIFO store; oldest events are evicted once ``capacity`` is reached."""
+
+    def __init__(self, capacity: int = DEFAULT_EVENT_CAPACITY) -> None:
+        """Create an empty store that retains at most ``capacity`` events."""
+        self._events: deque[WebhookEvent] = deque(maxlen=capacity)
+
+    @property
+    def capacity(self) -> int:
+        """Maximum number of events retained before FIFO eviction."""
+        return self._events.maxlen or 0
+
+    def __len__(self) -> int:
+        """Number of currently retained events."""
+        return len(self._events)
+
+    def append(self, event: WebhookEvent) -> None:
+        """Retain ``event``, evicting the oldest event when at capacity."""
+        self._events.append(event)
+
+    def list(self, *, since: datetime | None = None, limit: int | None = None) -> list[WebhookEvent]:
+        """Return retained events in receipt order, newest ``limit`` after ``since``."""
+        events = list(self._events)
+        if since is not None:
+            cutoff = _as_utc(since)
+            events = [e for e in events if _as_utc(e.received_at) > cutoff]
+        if limit is not None:
+            events = events[-limit:]
+        return events

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -8,6 +8,7 @@ import os
 import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, NoReturn, Protocol, TypeVar
 
@@ -20,6 +21,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from .client import ZammadClient
+from .events import EventStore, ListEventsParams, ListEventsResult
 from .logging_config import configure_logging
 from .models import (
     Article,
@@ -57,6 +59,7 @@ from .models import (
     UserBrief,
     UserCreate,
 )
+from .webhooks import WebhookHandler
 
 
 class AttachmentDeletionError(Exception):
@@ -788,22 +791,27 @@ def _handle_api_error(e: Exception, context: str = "operation") -> str:
 class ZammadMCPServer:
     """Zammad MCP Server with proper client lifecycle management."""
 
-    def __init__(self, host: str | None = None, port: int | None = None) -> None:
+    def __init__(
+        self, host: str | None = None, port: int | None = None, *, event_store: EventStore | None = None
+    ) -> None:
         """Initialize the server.
 
         Args:
             host: Deprecated. Pass host to mcp.run() instead.
             port: Deprecated. Pass port to mcp.run() instead.
+            event_store: Optional. Retention for accepted webhook events; defaults to a bounded in-memory store.
 
         """
         if host is not None or port is not None:
             logger.warning("ZammadMCPServer(host=..., port=...) is deprecated; pass host/port to mcp.run(...) instead.")
         self.client: ZammadClient | None = None
+        self.event_store = event_store if event_store is not None else EventStore()
         # Create FastMCP with lifespan configured
         self.mcp = FastMCP("zammad_mcp", lifespan=self._create_lifespan())
         self._setup_tools()
         self._setup_resources()
         self._setup_prompts()
+        self._setup_webhooks()
 
     def _create_lifespan(self) -> Any:
         """Create the lifespan context manager for the server."""
@@ -868,6 +876,58 @@ class ZammadMCPServer:
         self._setup_ticket_tools()
         self._setup_user_org_tools()
         self._setup_system_tools()
+        self._setup_event_tools()
+
+    def _setup_webhooks(self) -> None:
+        """Expose the Zammad webhook ingress route (HTTP transport only)."""
+        handler = WebhookHandler(
+            secret_provider=lambda: os.getenv("ZAMMAD_WEBHOOK_SECRET"),
+            clock=lambda: datetime.now(timezone.utc),
+            sink=self.event_store,
+        )
+
+        @self.mcp.custom_route("/webhooks/zammad", methods=["POST"])
+        async def zammad_webhook(request: Request) -> JSONResponse:
+            result = handler.handle_delivery(await request.body(), request.headers)
+            return JSONResponse(result.body, status_code=result.status_code)
+
+    def _setup_event_tools(self) -> None:
+        """Register tools that read retained webhook events."""
+
+        @self.mcp.tool(annotations=_read_only_annotations("List Webhook Events"))
+        def zammad_list_events(params: ListEventsParams) -> ListEventsResult:
+            """List Zammad ticket events received via webhook, oldest first.
+
+            Events arrive only when the server runs with HTTP transport and a Zammad
+            webhook + trigger POST to `/webhooks/zammad` with a valid HMAC-SHA1 signature.
+            Retention is process-local and bounded (`capacity`); events are lost on restart.
+
+            Args:
+                params (ListEventsParams): Validated parameters containing:
+                    - since (datetime | None): Only events received strictly after this timestamp
+                    - limit (int): Maximum events to return, 1-100 (default: 50)
+
+            Returns:
+                ListEventsResult: `events` (event_type, ticket_id, ticket_number, article_id,
+                trigger, source_timestamp, received_at), `count`, `capacity`, `retained_total`,
+                and `next_since` (pass back as `since` on the next poll; null when no events).
+
+            Examples:
+                - Use when: "Any new ticket activity?" -> poll with since=<last next_since>
+                - Use when: "Which tickets changed recently?" -> then zammad_get_ticket per ticket_id
+                - Don't use when: You need ticket content (this returns identifiers only)
+
+            Error Handling:
+                - Returns a validation error if limit is outside 1-100 or since is not ISO 8601
+            """
+            events = self.event_store.list(since=params.since, limit=params.limit)
+            return ListEventsResult(
+                events=events,
+                count=len(events),
+                capacity=self.event_store.capacity,
+                retained_total=len(self.event_store),
+                next_since=events[-1].received_at if events else None,
+            )
 
     def _setup_ticket_tools(self) -> None:  # noqa: PLR0915
         """Register ticket-related tools."""

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -905,12 +905,15 @@ class ZammadMCPServer:
             Args:
                 params (ListEventsParams): Validated parameters containing:
                     - since (datetime | None): Only events received strictly after this timestamp
-                    - limit (int): Maximum events to return, 1-100 (default: 50)
+                    - limit (int): Maximum events per page, 1-100 (default: 50); the oldest
+                      matching events are returned first
 
             Returns:
                 ListEventsResult: `events` (event_type, ticket_id, ticket_number, article_id,
                 trigger, source_timestamp, received_at), `count`, `capacity`, `retained_total`,
-                and `next_since` (pass back as `since` on the next poll; null when no events).
+                and `next_since` (pass back as `since` on the next call; null when no events).
+                Keep calling with `next_since` until `events` is empty to drain a backlog
+                larger than `limit` without skipping anything.
 
             Examples:
                 - Use when: "Any new ticket activity?" -> poll with since=<last next_since>

--- a/mcp_zammad/webhooks.py
+++ b/mcp_zammad/webhooks.py
@@ -21,7 +21,8 @@ SIGNATURE_PREFIX = "sha1="
 class EventSink(Protocol):
     """Destination for accepted, normalized events."""
 
-    def append(self, event: WebhookEvent) -> None: ...  # codacy: ignore E704
+    def append(self, event: WebhookEvent) -> None:
+        """Retain one accepted event."""
 
 
 class WebhookRejectedError(Exception):
@@ -76,22 +77,34 @@ def _classify(ticket: Mapping[str, Any], article: Mapping[str, Any] | None) -> E
     return "ticket.article.create"
 
 
-def normalize_payload(payload: Any, *, trigger: str | None, received_at: datetime) -> WebhookEvent:
-    """Reduce a Zammad ticket webhook payload to its stable identifying fields.
-
-    Raises:
-        WebhookRejectedError: 400 when the payload is not a ticket delivery with integer identifiers.
-    """
+def _require_ticket(payload: Any) -> tuple[Mapping[str, Any], int]:
     ticket = payload.get("ticket") if isinstance(payload, Mapping) else None
     ticket_id = _optional_int(ticket.get("id")) if isinstance(ticket, Mapping) else None
     if ticket is None or ticket_id is None:
         raise WebhookRejectedError(
             400, "Unsupported payload: expected a Zammad ticket webhook with an integer ticket.id"
         )
+    return ticket, ticket_id
+
+
+def _optional_article(payload: Mapping[str, Any]) -> tuple[Mapping[str, Any] | None, int | None]:
     article = payload.get("article")
+    if article is None:
+        return None, None
     article_id = _optional_int(article.get("id")) if isinstance(article, Mapping) else None
-    if article is not None and article_id is None:
+    if article_id is None:
         raise WebhookRejectedError(400, "Unsupported payload: ticket article must carry an integer article.id")
+    return article, article_id
+
+
+def normalize_payload(payload: Any, *, trigger: str | None, received_at: datetime) -> WebhookEvent:
+    """Reduce a Zammad ticket webhook payload to its stable identifying fields.
+
+    Raises:
+        WebhookRejectedError: 400 when the payload is not a ticket delivery with integer identifiers.
+    """
+    ticket, ticket_id = _require_ticket(payload)
+    article, article_id = _optional_article(payload)
     number = ticket.get("number")
     return WebhookEvent(
         event_type=_classify(ticket, article),

--- a/mcp_zammad/webhooks.py
+++ b/mcp_zammad/webhooks.py
@@ -78,6 +78,18 @@ def _classify(ticket: Mapping[str, Any], article: Mapping[str, Any] | None) -> E
 
 
 def _require_ticket(payload: Any) -> tuple[Mapping[str, Any], int]:
+    """Extract the ticket object and its integer id from a webhook payload.
+
+    Args:
+        payload: Decoded JSON body of the delivery; any type is accepted.
+
+    Returns:
+        The ticket mapping and its id.
+
+    Raises:
+        WebhookRejectedError: 400 when the payload is not a mapping with an
+            integer ``ticket.id``.
+    """
     ticket = payload.get("ticket") if isinstance(payload, Mapping) else None
     ticket_id = _optional_int(ticket.get("id")) if isinstance(ticket, Mapping) else None
     if ticket is None or ticket_id is None:
@@ -88,6 +100,18 @@ def _require_ticket(payload: Any) -> tuple[Mapping[str, Any], int]:
 
 
 def _optional_article(payload: Mapping[str, Any]) -> tuple[Mapping[str, Any] | None, int | None]:
+    """Extract the article object and its integer id when the payload carries one.
+
+    Args:
+        payload: Decoded JSON body of the delivery, already known to be a mapping.
+
+    Returns:
+        ``(article, article_id)``, or ``(None, None)`` when no article is present.
+
+    Raises:
+        WebhookRejectedError: 400 when an article is present but lacks an
+            integer ``article.id``.
+    """
     article = payload.get("article")
     if article is None:
         return None, None

--- a/mcp_zammad/webhooks.py
+++ b/mcp_zammad/webhooks.py
@@ -1,0 +1,142 @@
+"""Zammad webhook delivery boundary: signature validation and payload normalization."""
+
+import hashlib
+import hmac
+import json
+import logging
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Protocol
+
+from .events import EventType, WebhookEvent
+
+logger = logging.getLogger(__name__)
+
+SIGNATURE_HEADER = "x-hub-signature"
+TRIGGER_HEADER = "x-zammad-trigger"
+SIGNATURE_PREFIX = "sha1="
+
+
+class EventSink(Protocol):
+    """Destination for accepted, normalized events."""
+
+    def append(self, event: WebhookEvent) -> None: ...  # codacy: ignore E704
+
+
+class WebhookRejectedError(Exception):
+    """Delivery rejected; carries the HTTP status and safe client-facing reason."""
+
+    def __init__(self, status_code: int, error: str) -> None:
+        """Record the rejection status and a message that never echoes payload content."""
+        self.status_code = status_code
+        self.error = error
+        super().__init__(error)
+
+
+@dataclass(frozen=True)
+class DeliveryResult:
+    """Transport-agnostic outcome of a webhook delivery."""
+
+    status_code: int
+    body: dict[str, Any]
+
+
+def verify_signature(body: bytes, header: str | None, secret: str) -> None:
+    """Validate Zammad's ``X-Hub-Signature`` (``sha1=<hex>``) against ``body`` in constant time.
+
+    Raises:
+        WebhookRejectedError: 401 when the header is missing, malformed, or does not match.
+    """
+    if not header or not header.startswith(SIGNATURE_PREFIX):
+        raise WebhookRejectedError(401, "Missing or malformed X-Hub-Signature header; expected 'sha1=<hex digest>'")
+    expected = hmac.new(secret.encode(), body, hashlib.sha1).hexdigest()
+    if not hmac.compare_digest(expected, header[len(SIGNATURE_PREFIX) :].lower()):
+        raise WebhookRejectedError(401, "X-Hub-Signature does not match the configured webhook secret")
+
+
+def _optional_int(value: Any) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _optional_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _classify(ticket: Mapping[str, Any], article: Mapping[str, Any] | None) -> EventType:
+    if article is None:
+        return "ticket.update"
+    if ticket.get("article_count") == 1:
+        return "ticket.create"
+    return "ticket.article.create"
+
+
+def normalize_payload(payload: Any, *, trigger: str | None, received_at: datetime) -> WebhookEvent:
+    """Reduce a Zammad ticket webhook payload to its stable identifying fields.
+
+    Raises:
+        WebhookRejectedError: 400 when the payload is not a ticket delivery with integer identifiers.
+    """
+    ticket = payload.get("ticket") if isinstance(payload, Mapping) else None
+    ticket_id = _optional_int(ticket.get("id")) if isinstance(ticket, Mapping) else None
+    if ticket is None or ticket_id is None:
+        raise WebhookRejectedError(
+            400, "Unsupported payload: expected a Zammad ticket webhook with an integer ticket.id"
+        )
+    article = payload.get("article")
+    article_id = _optional_int(article.get("id")) if isinstance(article, Mapping) else None
+    if article is not None and article_id is None:
+        raise WebhookRejectedError(400, "Unsupported payload: ticket article must carry an integer article.id")
+    number = ticket.get("number")
+    return WebhookEvent(
+        event_type=_classify(ticket, article),
+        ticket_id=ticket_id,
+        ticket_number=str(number) if number is not None else None,
+        article_id=article_id,
+        trigger=trigger,
+        source_timestamp=_optional_timestamp(ticket.get("updated_at")),
+        received_at=received_at,
+    )
+
+
+class WebhookHandler:
+    """Validate a raw Zammad delivery and hand the normalized event to the sink."""
+
+    def __init__(
+        self,
+        *,
+        secret_provider: Callable[[], str | None],
+        clock: Callable[[], datetime],
+        sink: EventSink,
+    ) -> None:
+        """Wire the injected secret lookup, receipt clock, and event sink."""
+        self._secret_provider = secret_provider
+        self._clock = clock
+        self._sink = sink
+
+    def handle_delivery(self, body: bytes, headers: Mapping[str, str]) -> DeliveryResult:
+        """Process one delivery and return the HTTP status/body to send back to Zammad."""
+        try:
+            event = self._accept(body, headers)
+        except WebhookRejectedError as rejected:
+            logger.warning("Rejected Zammad webhook delivery (%s): %s", rejected.status_code, rejected.error)
+            return DeliveryResult(rejected.status_code, {"status": "rejected", "error": rejected.error})
+        self._sink.append(event)
+        logger.info("Accepted Zammad webhook %s for ticket %s", event.event_type, event.ticket_id)
+        return DeliveryResult(202, {"status": "accepted", "event_type": event.event_type, "ticket_id": event.ticket_id})
+
+    def _accept(self, body: bytes, headers: Mapping[str, str]) -> WebhookEvent:
+        secret = self._secret_provider()
+        if not secret:
+            raise WebhookRejectedError(503, "Webhook ingestion is disabled: ZAMMAD_WEBHOOK_SECRET is not configured")
+        verify_signature(body, headers.get(SIGNATURE_HEADER), secret)
+        try:
+            payload = json.loads(body)
+        except ValueError:
+            raise WebhookRejectedError(400, "Request body is not valid JSON") from None
+        return normalize_payload(payload, trigger=headers.get(TRIGGER_HEADER), received_at=self._clock())

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -1,5 +1,8 @@
 """Integration tests for HTTP transport."""
 
+import asyncio
+import hashlib
+import hmac
 import json
 import logging
 import os
@@ -13,8 +16,18 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import httpx
 import pytest
+from fastmcp import Client
 
 logger = logging.getLogger(__name__)
+
+WEBHOOK_SECRET = "integration-webhook-secret"
+
+
+def signed_delivery(payload: dict, secret: str = WEBHOOK_SECRET) -> tuple[bytes, dict[str, str]]:
+    """Build a Zammad-style webhook body and HMAC-SHA1 ``X-Hub-Signature`` header."""
+    body = json.dumps(payload).encode()
+    signature = "sha1=" + hmac.new(secret.encode(), body, hashlib.sha1).hexdigest()
+    return body, {"Content-Type": "application/json", "X-Hub-Signature": signature}
 
 
 def start_mcp_server(
@@ -115,6 +128,7 @@ def http_server(mock_zammad_server: str) -> Iterator[str]:
             "MCP_PORT": str(port),
             "ZAMMAD_URL": mock_zammad_server,
             "ZAMMAD_HTTP_TOKEN": "test-token",
+            "ZAMMAD_WEBHOOK_SECRET": WEBHOOK_SECRET,
         }
     )
 
@@ -185,6 +199,31 @@ def test_mcp_endpoint_exists(http_server) -> None:
     assert location is not None, "Location header must be present in 307 redirect"
     # FastMCP redirects from /mcp/ (with slash) to /mcp (without slash)
     assert location.endswith("/mcp"), f"Expected redirect to /mcp endpoint, got: {location}"
+
+
+@pytest.mark.integration
+def test_webhook_delivery_is_retrievable_through_mcp(http_server) -> None:
+    """Signed deliveries are accepted, unsigned ones rejected, and events are listable via MCP."""
+    first, first_headers = signed_delivery({"ticket": {"id": 501, "number": "10501"}})
+    second, second_headers = signed_delivery({"ticket": {"id": 502, "article_count": 4}, "article": {"id": 9}})
+    forged, forged_headers = signed_delivery({"ticket": {"id": 503}}, secret="not-the-secret")
+
+    assert httpx.post(f"{http_server}/webhooks/zammad", content=first, headers=first_headers).status_code == 202
+    assert httpx.post(f"{http_server}/webhooks/zammad", content=second, headers=second_headers).status_code == 202
+    assert httpx.post(f"{http_server}/webhooks/zammad", content=forged, headers=forged_headers).status_code == 401
+
+    async def list_events() -> dict:
+        async with Client(f"{http_server}/mcp") as client:
+            result = await client.call_tool("zammad_list_events", {"params": {"limit": 10}})
+        return result.structured_content
+
+    data = asyncio.run(list_events())
+    assert [(e["event_type"], e["ticket_id"]) for e in data["events"]] == [
+        ("ticket.update", 501),
+        ("ticket.article.create", 502),
+    ]
+    assert data["events"][1]["article_id"] == 9
+    assert data["retained_total"] == 2
 
 
 @pytest.mark.integration

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -20,10 +20,10 @@ from fastmcp import Client
 
 logger = logging.getLogger(__name__)
 
-WEBHOOK_SECRET = "integration-webhook-secret"
+WEBHOOK_SIGNING_KEY = "integration-test-hmac-key"  # not a real credential
 
 
-def signed_delivery(payload: dict, secret: str = WEBHOOK_SECRET) -> tuple[bytes, dict[str, str]]:
+def signed_delivery(payload: dict, secret: str = WEBHOOK_SIGNING_KEY) -> tuple[bytes, dict[str, str]]:
     """Build a Zammad-style webhook body and HMAC-SHA1 ``X-Hub-Signature`` header."""
     body = json.dumps(payload).encode()
     signature = "sha1=" + hmac.new(secret.encode(), body, hashlib.sha1).hexdigest()
@@ -128,7 +128,7 @@ def http_server(mock_zammad_server: str) -> Iterator[str]:
             "MCP_PORT": str(port),
             "ZAMMAD_URL": mock_zammad_server,
             "ZAMMAD_HTTP_TOKEN": "test-token",
-            "ZAMMAD_WEBHOOK_SECRET": WEBHOOK_SECRET,
+            "ZAMMAD_WEBHOOK_SECRET": WEBHOOK_SIGNING_KEY,
         }
     )
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,69 @@
+"""Behavior tests for the bounded in-memory webhook event store."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from mcp_zammad.events import EventStore, ListEventsParams, WebhookEvent
+
+BASE = datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc)
+
+
+def event(seq: int) -> WebhookEvent:
+    return WebhookEvent(
+        event_type="ticket.update", ticket_id=seq, received_at=BASE + timedelta(seconds=seq), trigger=None
+    )
+
+
+def test_store_evicts_oldest_when_capacity_exceeded() -> None:
+    store = EventStore(capacity=2)
+    for seq in (1, 2, 3):
+        store.append(event(seq))
+
+    assert [e.ticket_id for e in store.list()] == [2, 3]
+    assert store.capacity == 2
+
+
+def test_list_returns_events_in_receipt_order() -> None:
+    store = EventStore(capacity=5)
+    for seq in (3, 1, 2):
+        store.append(event(seq))
+
+    assert [e.ticket_id for e in store.list()] == [3, 1, 2]
+
+
+def test_list_since_excludes_events_at_or_before_cursor() -> None:
+    store = EventStore(capacity=5)
+    for seq in (1, 2, 3):
+        store.append(event(seq))
+
+    result = store.list(since=BASE + timedelta(seconds=2))
+
+    assert [e.ticket_id for e in result] == [3]
+
+
+def test_list_limit_returns_most_recent_events() -> None:
+    store = EventStore(capacity=5)
+    for seq in (1, 2, 3):
+        store.append(event(seq))
+
+    assert [e.ticket_id for e in store.list(limit=2)] == [2, 3]
+
+
+def test_list_since_accepts_naive_cursor_as_utc() -> None:
+    store = EventStore(capacity=5)
+    store.append(event(1))
+
+    assert store.list(since=datetime(2026, 9, 8, 12, 0)) == store.list()  # noqa: DTZ001 - naive cursor is the case
+
+
+@pytest.mark.parametrize("limit", [0, -1, 101])
+def test_list_params_reject_out_of_range_limit(limit: int) -> None:
+    with pytest.raises(ValidationError):
+        ListEventsParams(limit=limit)
+
+
+def test_list_params_reject_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        ListEventsParams(sinc="2026-09-08T12:00:00Z")  # type: ignore[call-arg]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -43,12 +43,16 @@ def test_list_since_excludes_events_at_or_before_cursor() -> None:
     assert [e.ticket_id for e in result] == [3]
 
 
-def test_list_limit_returns_most_recent_events() -> None:
+def test_list_limit_returns_oldest_events_first_so_cursor_walks_backlog() -> None:
     store = EventStore(capacity=5)
     for seq in (1, 2, 3):
         store.append(event(seq))
 
-    assert [e.ticket_id for e in store.list(limit=2)] == [2, 3]
+    first_page = store.list(limit=2)
+    second_page = store.list(since=first_page[-1].received_at, limit=2)
+
+    assert [e.ticket_id for e in first_page] == [1, 2]
+    assert [e.ticket_id for e in second_page] == [3]
 
 
 def test_list_since_accepts_naive_cursor_as_utc() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -215,6 +215,7 @@ async def test_server_initialization(mock_zammad_client):
         "zammad_add_ticket_tag",
         "zammad_remove_ticket_tag",
         "zammad_get_current_user",
+        "zammad_list_events",
     ]
     for tool in expected_tools:
         assert tool in tool_names

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -126,9 +126,31 @@ async def test_list_events_tool_filters_since_and_limit(server_with_secret: Zamm
         result = await client.call_tool("zammad_list_events", {"params": {"since": "2026-09-08T12:01:00Z", "limit": 1}})
 
     data = result.structured_content
-    assert [e["ticket_id"] for e in data["events"]] == [3]
+    assert [e["ticket_id"] for e in data["events"]] == [2]
     assert data["retained_total"] == 3
-    assert data["next_since"].startswith("2026-09-08T12:03:00")
+    assert data["next_since"].startswith("2026-09-08T12:02:00")
+
+
+@pytest.mark.asyncio
+async def test_list_events_cursor_pages_backlog_larger_than_limit_to_completion(
+    server_with_secret: ZammadMCPServer,
+) -> None:
+    store = server_with_secret.event_store
+    base = datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc)
+    for seq in (1, 2, 3):
+        store.append(WebhookEvent(event_type="ticket.update", ticket_id=seq, received_at=base.replace(minute=seq)))
+
+    seen: list[int] = []
+    params: dict = {"limit": 2}
+    async with Client(server_with_secret.mcp) as client:
+        for _ in range(5):
+            data = (await client.call_tool("zammad_list_events", {"params": params})).structured_content
+            if not data["events"]:
+                break
+            seen.extend(e["ticket_id"] for e in data["events"])
+            params = {"limit": 2, "since": data["next_since"]}
+
+    assert seen == [1, 2, 3]
 
 
 @pytest.mark.asyncio

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -15,11 +15,11 @@ from fastmcp import Client
 from mcp_zammad.events import EventStore, WebhookEvent
 from mcp_zammad.server import ZammadMCPServer
 
-SECRET = "server-test-secret"
+SIGNING_KEY = "server-test-hmac-key"  # not a real credential
 ROUTE = "/webhooks/zammad"
 
 
-def signed(payload: dict, secret: str = SECRET) -> tuple[bytes, dict[str, str]]:
+def signed(payload: dict, secret: str = SIGNING_KEY) -> tuple[bytes, dict[str, str]]:
     body = json.dumps(payload).encode()
     signature = "sha1=" + hmac.new(secret.encode(), body, hashlib.sha1).hexdigest()
     return body, {"content-type": "application/json", "x-hub-signature": signature}
@@ -37,7 +37,7 @@ def zammad_client() -> Iterator[Mock]:
 
 @pytest.fixture
 def server_with_secret(zammad_client: Mock) -> Iterator[ZammadMCPServer]:
-    with patch.dict("os.environ", {"ZAMMAD_WEBHOOK_SECRET": SECRET}):
+    with patch.dict("os.environ", {"ZAMMAD_WEBHOOK_SECRET": SIGNING_KEY}):
         yield ZammadMCPServer(event_store=EventStore(capacity=3))
 
 

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -1,0 +1,153 @@
+"""Server-level tests: HTTP webhook route and the zammad_list_events MCP tool."""
+
+import hashlib
+import hmac
+import json
+from collections.abc import AsyncIterator, Iterator
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastmcp import Client
+
+from mcp_zammad.events import EventStore, WebhookEvent
+from mcp_zammad.server import ZammadMCPServer
+
+SECRET = "server-test-secret"
+ROUTE = "/webhooks/zammad"
+
+
+def signed(payload: dict, secret: str = SECRET) -> tuple[bytes, dict[str, str]]:
+    body = json.dumps(payload).encode()
+    signature = "sha1=" + hmac.new(secret.encode(), body, hashlib.sha1).hexdigest()
+    return body, {"content-type": "application/json", "x-hub-signature": signature}
+
+
+@pytest.fixture
+def zammad_client() -> Iterator[Mock]:
+    """Stand-in for the Zammad API so lifespan startup never touches the network."""
+    with patch("mcp_zammad.server.ZammadClient") as client_cls:
+        instance = Mock()
+        instance.get_current_user.return_value = {"id": 1}
+        client_cls.return_value = instance
+        yield instance
+
+
+@pytest.fixture
+def server_with_secret(zammad_client: Mock) -> Iterator[ZammadMCPServer]:
+    with patch.dict("os.environ", {"ZAMMAD_WEBHOOK_SECRET": SECRET}):
+        yield ZammadMCPServer(event_store=EventStore(capacity=3))
+
+
+@pytest_asyncio.fixture
+async def http(server_with_secret: ZammadMCPServer) -> AsyncIterator[httpx.AsyncClient]:
+    transport = httpx.ASGITransport(app=server_with_secret.mcp.http_app())
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_signed_delivery_is_accepted_over_http(http: httpx.AsyncClient) -> None:
+    body, headers = signed({"ticket": {"id": 7, "number": "10007"}})
+
+    response = await http.post(ROUTE, content=body, headers=headers)
+
+    assert response.status_code == 202
+    assert response.json() == {"status": "accepted", "event_type": "ticket.update", "ticket_id": 7}
+
+
+@pytest.mark.asyncio
+async def test_bad_signature_is_rejected_over_http(http: httpx.AsyncClient) -> None:
+    body, headers = signed({"ticket": {"id": 7}}, secret="wrong")
+
+    response = await http.post(ROUTE, content=body, headers=headers)
+
+    assert response.status_code == 401
+    assert response.json()["status"] == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_unset_secret_returns_503_over_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ZAMMAD_WEBHOOK_SECRET", raising=False)
+    server = ZammadMCPServer(event_store=EventStore(capacity=3))
+    transport = httpx.ASGITransport(app=server.mcp.http_app())
+    body, headers = signed({"ticket": {"id": 7}})
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as http:
+        response = await http.post(ROUTE, content=body, headers=headers)
+
+    assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_list_events_tool_is_registered_read_only(server_with_secret: ZammadMCPServer) -> None:
+    async with Client(server_with_secret.mcp) as client:
+        tools = {tool.name: tool for tool in await client.list_tools()}
+
+    tool = tools["zammad_list_events"]
+    assert tool.annotations is not None
+    assert tool.annotations.readOnlyHint is True
+    assert tool.annotations.destructiveHint is False
+
+
+@pytest.mark.asyncio
+async def test_accepted_delivery_is_observable_via_tool_without_zammad_calls(
+    server_with_secret: ZammadMCPServer, http: httpx.AsyncClient, zammad_client: Mock
+) -> None:
+    body, headers = signed({"ticket": {"id": 7, "number": "10007", "article_count": 2}, "article": {"id": 44}})
+    await http.post(ROUTE, content=body, headers=headers)
+
+    async with Client(server_with_secret.mcp) as client:
+        zammad_client.reset_mock()
+        result = await client.call_tool("zammad_list_events", {"params": {"limit": 10}})
+
+    assert zammad_client.method_calls == []
+    data = result.structured_content
+    assert data["count"] == 1
+    assert data["capacity"] == 3
+    assert data["retained_total"] == 1
+    [event] = data["events"]
+    assert event["event_type"] == "ticket.article.create"
+    assert event["ticket_id"] == 7
+    assert event["article_id"] == 44
+    assert data["next_since"] == event["received_at"]
+
+
+@pytest.mark.asyncio
+async def test_list_events_tool_filters_since_and_limit(server_with_secret: ZammadMCPServer) -> None:
+    store = server_with_secret.event_store
+    base = datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc)
+    for seq in range(1, 4):
+        store.append(WebhookEvent(event_type="ticket.update", ticket_id=seq, received_at=base.replace(minute=seq)))
+
+    async with Client(server_with_secret.mcp) as client:
+        result = await client.call_tool("zammad_list_events", {"params": {"since": "2026-09-08T12:01:00Z", "limit": 1}})
+
+    data = result.structured_content
+    assert [e["ticket_id"] for e in data["events"]] == [3]
+    assert data["retained_total"] == 3
+    assert data["next_since"].startswith("2026-09-08T12:03:00")
+
+
+@pytest.mark.asyncio
+async def test_list_events_tool_rejects_invalid_limit(server_with_secret: ZammadMCPServer) -> None:
+    async with Client(server_with_secret.mcp) as client:
+        result = await client.call_tool("zammad_list_events", {"params": {"limit": 0}}, raise_on_error=False)
+
+    assert result.is_error
+
+
+@pytest.mark.asyncio
+async def test_empty_store_returns_null_cursor(server_with_secret: ZammadMCPServer) -> None:
+    async with Client(server_with_secret.mcp) as client:
+        result = await client.call_tool("zammad_list_events", {"params": {}})
+
+    assert result.structured_content == {
+        "events": [],
+        "count": 0,
+        "capacity": 3,
+        "retained_total": 0,
+        "next_since": None,
+    }

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,151 @@
+"""Contract tests for the Zammad webhook delivery boundary."""
+
+import hashlib
+import hmac
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from mcp_zammad.events import EventStore
+from mcp_zammad.webhooks import WebhookHandler
+
+SECRET = "test-webhook-secret"
+RECEIVED_AT = datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc)
+
+
+def sign(body: bytes, secret: str = SECRET) -> str:
+    return "sha1=" + hmac.new(secret.encode(), body, hashlib.sha1).hexdigest()
+
+
+def ticket_payload(*, article: dict | None = None, article_count: int = 3) -> bytes:
+    ticket = {
+        "id": 81,
+        "number": "10081",
+        "title": "Webhook-Test",
+        "state": "open",
+        "article_count": article_count,
+        "updated_at": "2026-09-08T11:59:00.000Z",
+    }
+    return json.dumps({"ticket": ticket, "article": article}).encode()
+
+
+def article() -> dict:
+    return {"id": 104, "ticket_id": 81, "body": "<p>secret body</p>", "created_at": "2026-09-08T11:59:00.000Z"}
+
+
+def headers(signature: str | None, **extra: str) -> dict[str, str]:
+    result = {"content-type": "application/json", **extra}
+    if signature is not None:
+        result["x-hub-signature"] = signature
+    return result
+
+
+@pytest.fixture
+def store() -> EventStore:
+    return EventStore(capacity=10)
+
+
+@pytest.fixture
+def handler(store: EventStore) -> WebhookHandler:
+    return WebhookHandler(secret_provider=lambda: SECRET, clock=lambda: RECEIVED_AT, sink=store)
+
+
+def test_signed_ticket_update_is_accepted_and_normalized(handler: WebhookHandler, store: EventStore) -> None:
+    body = ticket_payload()
+
+    result = handler.handle_delivery(body, headers(sign(body), **{"x-zammad-trigger": "notify-mcp"}))
+
+    assert result.status_code == 202
+    assert result.body == {"status": "accepted", "event_type": "ticket.update", "ticket_id": 81}
+    [event] = store.list()
+    assert event.event_type == "ticket.update"
+    assert event.ticket_id == 81
+    assert event.ticket_number == "10081"
+    assert event.article_id is None
+    assert event.trigger == "notify-mcp"
+    assert event.received_at == RECEIVED_AT
+    assert event.source_timestamp == datetime(2026, 9, 8, 11, 59, tzinfo=timezone.utc)
+
+
+def test_article_delivery_is_classified_without_retaining_body(handler: WebhookHandler, store: EventStore) -> None:
+    body = ticket_payload(article=article())
+
+    result = handler.handle_delivery(body, headers(sign(body)))
+
+    assert result.status_code == 202
+    [event] = store.list()
+    assert event.event_type == "ticket.article.create"
+    assert event.article_id == 104
+    assert "secret body" not in event.model_dump_json()
+
+
+def test_first_article_is_classified_as_ticket_create(handler: WebhookHandler, store: EventStore) -> None:
+    body = ticket_payload(article=article(), article_count=1)
+
+    handler.handle_delivery(body, headers(sign(body)))
+
+    assert store.list()[0].event_type == "ticket.create"
+
+
+def test_missing_secret_returns_503_and_stores_nothing(store: EventStore) -> None:
+    handler = WebhookHandler(secret_provider=lambda: None, clock=lambda: RECEIVED_AT, sink=store)
+    body = ticket_payload()
+
+    result = handler.handle_delivery(body, headers(sign(body)))
+
+    assert result.status_code == 503
+    assert "ZAMMAD_WEBHOOK_SECRET" in result.body["error"]
+    assert store.list() == []
+
+
+@pytest.mark.parametrize(
+    "signature",
+    [None, "", "sha256=abc", "sha1=nothex", sign(b"other body"), sign(ticket_payload(), "wrong-secret")],
+)
+def test_missing_or_invalid_signature_returns_401(handler: WebhookHandler, store: EventStore, signature) -> None:
+    result = handler.handle_delivery(ticket_payload(), headers(signature))
+
+    assert result.status_code == 401
+    assert store.list() == []
+
+
+def test_malformed_json_returns_400(handler: WebhookHandler, store: EventStore) -> None:
+    body = b"{not json"
+
+    result = handler.handle_delivery(body, headers(sign(body)))
+
+    assert result.status_code == 400
+    assert store.list() == []
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"user": {"id": 1}},
+        {"ticket": {"number": "10081"}},
+        {"ticket": {"id": "eighty-one"}},
+        {"ticket": {"id": 81}, "article": {"body": "no id"}},
+        [1, 2, 3],
+    ],
+)
+def test_unsupported_payload_shape_returns_400(handler: WebhookHandler, store: EventStore, payload) -> None:
+    body = json.dumps(payload).encode()
+
+    result = handler.handle_delivery(body, headers(sign(body)))
+
+    assert result.status_code == 400
+    assert "ticket" in result.body["error"]
+    assert store.list() == []
+
+
+@pytest.mark.parametrize("updated_at", [None, "not-a-timestamp", 12345])
+def test_missing_or_unparseable_source_timestamp_is_tolerated(
+    handler: WebhookHandler, store: EventStore, updated_at
+) -> None:
+    body = json.dumps({"ticket": {"id": 5, "updated_at": updated_at}}).encode()
+
+    result = handler.handle_delivery(body, headers(sign(body)))
+
+    assert result.status_code == 202
+    assert store.list()[0].source_timestamp is None

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -10,11 +10,11 @@ import pytest
 from mcp_zammad.events import EventStore
 from mcp_zammad.webhooks import WebhookHandler
 
-SECRET = "test-webhook-secret"
+SIGNING_KEY = "unit-test-hmac-key"  # not a real credential
 RECEIVED_AT = datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc)
 
 
-def sign(body: bytes, secret: str = SECRET) -> str:
+def sign(body: bytes, secret: str = SIGNING_KEY) -> str:
     return "sha1=" + hmac.new(secret.encode(), body, hashlib.sha1).hexdigest()
 
 
@@ -48,7 +48,7 @@ def store() -> EventStore:
 
 @pytest.fixture
 def handler(store: EventStore) -> WebhookHandler:
-    return WebhookHandler(secret_provider=lambda: SECRET, clock=lambda: RECEIVED_AT, sink=store)
+    return WebhookHandler(secret_provider=lambda: SIGNING_KEY, clock=lambda: RECEIVED_AT, sink=store)
 
 
 def test_signed_ticket_update_is_accepted_and_normalized(handler: WebhookHandler, store: EventStore) -> None:


### PR DESCRIPTION
## Summary

Lets Zammad push ticket activity to the MCP server so clients can pick up changes with one cheap poll instead of repeatedly searching tickets. Implements the scoped MVP from the planning handoff on #16.

**What's new**

- `POST /webhooks/zammad` (HTTP transport only) receives Zammad webhook deliveries.
  - Verifies `X-Hub-Signature` with constant-time HMAC-SHA1 against `ZAMMAD_WEBHOOK_SECRET`.
  - `202` accepted · `401` missing/invalid signature · `400` malformed or non-ticket payload · `503` secret not configured.
  - Normalizes deliveries to `ticket.create` / `ticket.update` / `ticket.article.create` with identifiers and timestamps only — article bodies are never retained.
- Bounded, process-local event store (1000 events, FIFO eviction; lost on restart).
- `zammad_list_events` read-only tool with `since` / `limit` filters and a `next_since` cursor for polling. Does not touch the Zammad API.
- README section covering secret setup, TLS/reverse-proxy exposure, and the Zammad Webhook + Trigger admin steps; `.env.example` documents `ZAMMAD_WEBHOOK_SECRET`.
- CI: new `lint-and-types` job so ruff format/check and mypy run in GitHub like they do locally.

**Deliberately out of scope** (per plan): webhook auto-registration tool, persistence/Redis, deduplication, rate limiting, metrics, SSE/WebSocket streaming, user/organization events (Zammad triggers are ticket-centric).

## Test plan

- [x] `tests/test_webhooks.py` — signature/secret/payload contract via injected secret, clock, and sink (19 cases)
- [x] `tests/test_events.py` — FIFO eviction, ordering, `since`/`limit`, param validation
- [x] `tests/test_webhook_server.py` — route through the FastMCP ASGI app; tool through `fastmcp.Client`
- [x] `tests/integration/test_http_transport.py` — real subprocess: signed POSTs accepted, forged rejected, events read back over MCP HTTP
- [x] `ruff format --check`, `ruff check`, `mypy`, `bandit` clean; 259 tests pass at 89.57% coverage (floor 86%); `uv build` succeeds
- [ ] Manual: point a Zammad webhook + trigger at a deployed instance and confirm `zammad_list_events` shows the event

Closes #16
