### PR TITLE
fix(tickets): bound bulk tag names like the single-tag tools

### DIFF
--- a/mcp_zammad/models.py
+++ b/mcp_zammad/models.py
@@ -5,7 +5,7 @@ import html
 import os
 from datetime import date, datetime
 from enum import Enum
-from typing import Literal
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
 
@@ -384,6 +384,10 @@ class TicketUpdateParams(StrictBaseModel):
         return html.escape(v) if v else v
 
 
+# Same bounds as TagOperationParams.tag so bulk and single-tag tools reject the same input.
+TagName = Annotated[str, Field(min_length=1, max_length=100)]
+
+
 class BulkTicketUpdateParams(StrictBaseModel):
     """Bulk ticket update request parameters."""
 
@@ -396,8 +400,8 @@ class BulkTicketUpdateParams(StrictBaseModel):
     owner: str | None = Field(None, description="New owner login/email", max_length=255)
     group: str | None = Field(None, description="New group name", max_length=100)
     time_unit: float | None = Field(None, description="Time spent per ticket for time accounting", gt=0)
-    add_tags: list[str] | None = Field(None, description="Tags to add to every ticket")
-    remove_tags: list[str] | None = Field(None, description="Tags to remove from every ticket")
+    add_tags: list[TagName] | None = Field(None, description="Tags to add to every ticket")
+    remove_tags: list[TagName] | None = Field(None, description="Tags to remove from every ticket")
     note: str | None = Field(None, description="Internal note to add to every ticket", max_length=10000)
     delay_seconds: float = Field(0, ge=0, description="Pause between tickets to reduce API pressure")
 

--- a/tests/test_bulk_models.py
+++ b/tests/test_bulk_models.py
@@ -68,6 +68,14 @@ def test_rejects_empty_tag_list_as_operation():
         BulkTicketUpdateParams(ticket_ids=[1], add_tags=[])
 
 
+@pytest.mark.parametrize("field", ["add_tags", "remove_tags"])
+@pytest.mark.parametrize("tag", ["", "x" * 101])
+def test_rejects_invalid_tag_names(field, tag):
+    """Tag names follow the same bounds as the single-tag tools."""
+    with pytest.raises(ValidationError, match=r"at (least|most)"):
+        BulkTicketUpdateParams(ticket_ids=[1], **{field: [tag]})
+
+
 def test_escapes_html_in_title_and_note():
     """Title and note follow the single-ticket sanitization rules."""
     params = BulkTicketUpdateParams(ticket_ids=[1], title="<b>x</b>", note="<script>y</script>")


### PR DESCRIPTION
## Summary

Non-blocking follow-up from the Factory review of #334 (review comment: https://github.com/basher83/Zammad-MCP/pull/334#issuecomment-5579761798). Targets the `factory/issue-15` branch so it can be merged into that PR directly.

`zammad_bulk_update_tickets` accepted empty or oversized tag names in `add_tags` / `remove_tags`, while the single-tag tools (`TagOperationParams.tag`) enforce 1–100 characters. This applies the same per-item bound to the bulk model so invalid tags fail validation before any ticket is touched, instead of surfacing as a per-ticket API error mid-batch.

## Changes

- `mcp_zammad/models.py`: add a `TagName` annotated type (`min_length=1, max_length=100`) and use it for `add_tags` / `remove_tags` items.
- `tests/test_bulk_models.py`: parametrized test rejecting empty and 101-char tag names on both fields.

## Test plan

- `uv run pytest tests/test_bulk_models.py tests/test_bulk_server.py tests/test_server.py` → 132 passed
- `uv run mypy mcp_zammad` → clean
- `uv run ruff check mcp_zammad tests` / `ruff format --check` → clean
- Verified the MCP tool schema now advertises `minLength: 1, maxLength: 100` on tag items.
