### PR TITLE
Review follow-ups for #333: lowercase docstring values and enum rejection tests

### DIFF
--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -886,7 +886,7 @@ class ZammadMCPServer:
                     - customer (str | None): Filter by customer email/login
                     - page (int): Page number (default: 1)
                     - per_page (int): Results per page, 1-100 (default: 25)
-                    - response_format (ResponseFormat): Output format (default: MARKDOWN)
+                    - response_format (ResponseFormat): Output format - markdown or json (default: markdown)
 
             Returns:
                 str: Formatted response with the following schema:
@@ -978,7 +978,7 @@ class ZammadMCPServer:
                 include_articles (bool): Include ticket articles/comments (default: True)
                 article_limit (int): Maximum articles to return, -1 for all (default: 10)
                 article_offset (int): Number of articles to skip for pagination (default: 0)
-                response_format (ResponseFormat): Output format - MARKDOWN or JSON (default: MARKDOWN)
+                response_format (ResponseFormat): Output format - markdown or json (default: markdown)
 
             Returns:
                 str: Formatted response with the following schema:
@@ -1181,7 +1181,7 @@ class ZammadMCPServer:
                 params (ArticleCreate): Validated article creation parameters containing:
                     - ticket_id (int): Internal database ID (required, NOT display number)
                     - body (str): Article content/message (required)
-                    - article_type (ArticleType): Type enum - NOTE, EMAIL, etc. (required)
+                    - article_type (ArticleType): Article type - note, email, or phone (required)
                     - internal (bool): Internal note vs customer-visible (default: False)
                     - subject (str | None): Article subject (for emails)
                     - content_type (str | None): text/plain or text/html (default: text/plain)
@@ -1492,7 +1492,7 @@ class ZammadMCPServer:
 
             Parameters:
                 user_id (int): User's internal database ID (required)
-                response_format (ResponseFormat): Output format - MARKDOWN or JSON (default: MARKDOWN)
+                response_format (ResponseFormat): Output format - markdown or json (default: markdown)
 
             Returns:
                 str: Formatted user information with the following schema:
@@ -1552,7 +1552,7 @@ class ZammadMCPServer:
                     - query (str): Search string (matches name, email, login) (required)
                     - page (int): Page number (default: 1)
                     - per_page (int): Results per page, 1-100 (default: 25)
-                    - response_format (ResponseFormat): Output format (default: MARKDOWN)
+                    - response_format (ResponseFormat): Output format - markdown or json (default: markdown)
 
             Returns:
                 str: Formatted response with the following schema:
@@ -1711,7 +1711,7 @@ class ZammadMCPServer:
                     - query (str): Search string (matches name, domain, note) (required)
                     - page (int): Page number (default: 1)
                     - per_page (int): Results per page, 1-100 (default: 25)
-                    - response_format (ResponseFormat): Output format (default: MARKDOWN)
+                    - response_format (ResponseFormat): Output format - markdown or json (default: markdown)
 
             Returns:
                 str: Formatted response with the following schema:
@@ -2111,7 +2111,7 @@ class ZammadMCPServer:
 
             Args:
                 params (ListParams): Validated parameters containing:
-                    - response_format (ResponseFormat): Output format (default: MARKDOWN)
+                    - response_format (ResponseFormat): Output format - markdown or json (default: markdown)
 
             Returns:
                 str: Formatted response with the following schema:
@@ -2174,7 +2174,7 @@ class ZammadMCPServer:
 
             Args:
                 params (ListParams): Validated parameters containing:
-                    - response_format (ResponseFormat): Output format (default: MARKDOWN)
+                    - response_format (ResponseFormat): Output format - markdown or json (default: markdown)
 
             Returns:
                 str: Formatted response with the following schema:
@@ -2240,7 +2240,7 @@ class ZammadMCPServer:
 
             Args:
                 params (ListParams): Validated parameters containing:
-                    - response_format (ResponseFormat): Output format (default: MARKDOWN)
+                    - response_format (ResponseFormat): Output format - markdown or json (default: markdown)
 
             Returns:
                 str: Formatted response with the following schema:
@@ -2305,7 +2305,7 @@ class ZammadMCPServer:
 
             Args:
                 params (ListParams): Validated parameters containing:
-                    - response_format (ResponseFormat): Output format (default: MARKDOWN)
+                    - response_format (ResponseFormat): Output format - markdown or json (default: markdown)
 
             Returns:
                 str: Formatted response with the following schema:
@@ -2393,7 +2393,7 @@ class ZammadMCPServer:
             Args:
                 params (GetTicketTagsParams): Validated parameters containing:
                     - ticket_id (int): Ticket ID to get tags for
-                    - response_format (ResponseFormat): Output format (default: MARKDOWN)
+                    - response_format (ResponseFormat): Output format - markdown or json (default: markdown)
 
             Returns:
                 str: Formatted response with the following schema:

--- a/tests/test_case_insensitive_constants.py
+++ b/tests/test_case_insensitive_constants.py
@@ -85,10 +85,25 @@ def test_non_string_content_type_rejected() -> None:
         ArticleCreate(ticket_id=1, body="hi", content_type=42)  # type: ignore[arg-type]
 
 
+@pytest.mark.parametrize("raw", [42, None, ["json"]])
+def test_non_string_response_format_rejected(raw: object) -> None:
+    """Non-string enum input must not be case-folded; it should fail standard validation."""
+    with pytest.raises(ValidationError, match="response_format"):
+        GetTicketParams(ticket_id=1, response_format=raw)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("field", ["article_type", "sender"])
+def test_non_string_article_enums_rejected(field: str) -> None:
+    """Non-string article enum input should still fail standard validation."""
+    with pytest.raises(ValidationError, match=field):
+        ArticleCreate(ticket_id=1, body="hi", **{field: 42})
+
+
 def test_schema_keeps_canonical_values() -> None:
     """Generated schemas should still advertise only canonical values."""
     ticket_schema = GetTicketParams.model_json_schema()
     article_schema = ArticleCreate.model_json_schema()
     assert ticket_schema["$defs"]["ResponseFormat"]["enum"] == ["markdown", "json"]
+    assert article_schema["$defs"]["ArticleType"]["enum"] == ["note", "email", "phone"]
     assert article_schema["$defs"]["ArticleSender"]["enum"] == ["Agent", "Customer", "System"]
     assert article_schema["properties"]["content_type"]["enum"] == ["text/plain", "text/html"]


### PR DESCRIPTION
Non-blocking follow-ups from the Factory review of #333 (https://github.com/basher83/Zammad-MCP/pull/333#issuecomment-5579772220). Targets `factory/issue-201` so it can be merged into that PR directly.

## What changed

**Tool docstrings advertise the canonical lowercase values.** Eleven `server.py` docstrings described `response_format` as `MARKDOWN or JSON` and `article_type` as `NOTE, EMAIL, etc.` — the Python member names, not the values the JSON schema exposes. That mismatch is the root cause named in #201: agents copied the uppercase spelling from the description and were rejected. #333 makes the input case-insensitive, so the wrong spelling no longer fails, but the docstrings should still teach the canonical form. Docstring-only; no behavior change.

**Supplemental test coverage for the `CaseInsensitiveStrEnum` contract.** Addresses the CodeRabbit comment on `tests/test_case_insensitive_constants.py:69-79`:

- Non-string rejection is now asserted for `response_format` (`42`, `None`, `["json"]`), `article_type`, and `sender`, not just `content_type`. This pins the `_missing_` hook's "return `None` for non-strings" behavior for every enum that uses it.
- `test_schema_keeps_canonical_values` now also asserts `ArticleType`'s schema enum is `["note", "email", "phone"]`.

`b"json"` was deliberately not included as a non-string case: Pydantic's lax mode coerces `bytes` to `str` before the enum lookup, on base as well as on this branch, so it is not a rejection case this PR controls.

## Verification

- `uv run pytest tests/ --cov=mcp_zammad` → 247 passed, 88.50% coverage
- `uv run ruff format --check mcp_zammad tests`, `uv run ruff check mcp_zammad tests`, `uv run mypy mcp_zammad` → clean
