### PR TITLE
feat(client): add rate limiting, retries, and circuit breaker for Zammad requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,25 @@ ZAMMAD_HTTP_TOKEN=your-api-token-here
 # Valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL
 # LOG_LEVEL=INFO
 
+# === Resilience (rate limiting, retries, circuit breaker) ===
+
+# Client-side throttling is opt-in. When enabled, at most ZAMMAD_RATE_LIMIT_REQUESTS
+# requests are sent per ZAMMAD_RATE_LIMIT_WINDOW seconds; extra requests wait.
+# ZAMMAD_RATE_LIMIT_ENABLED=false
+# ZAMMAD_RATE_LIMIT_REQUESTS=60
+# ZAMMAD_RATE_LIMIT_WINDOW=60
+
+# Retries apply only to safe reads (GET/HEAD/OPTIONS) on 429/5xx, connection, and
+# timeout failures. Writes are never retried. Delay = base * 2^attempt seconds unless
+# the server sends a Retry-After header (honored up to 60s). 0 disables retries.
+# ZAMMAD_MAX_RETRIES=3
+# ZAMMAD_RETRY_BACKOFF_BASE=1.0
+
+# After this many consecutive terminal failures the client fails fast without
+# contacting Zammad until the recovery timeout (seconds) elapses.
+# ZAMMAD_CIRCUIT_BREAKER_FAILURE_THRESHOLD=5
+# ZAMMAD_CIRCUIT_BREAKER_RECOVERY_TIMEOUT=30
+
 # === Transport Configuration ===
 
 # Transport type: stdio (default) or http

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -277,6 +277,11 @@ MCP errors include:
 - Environment variable configuration
 - No credential logging
 - HTTPS enforcement for API calls
+- Resilience layer (`mcp_zammad/resilience*.py`): `ZammadClient` replaces the `zammad_py`
+  `requests.Session` with a `ResilientSession`, so every API call passes through one boundary that
+  applies an opt-in fixed-window rate limiter, exponential backoff with `Retry-After` support for
+  safe methods only, and a closed/open/half-open circuit breaker. State is process-local; the clock
+  and sleeper are injected so behavior is deterministic under test.
 
 ### Needed Improvements
 
@@ -284,11 +289,6 @@ MCP errors include:
    - URL validation to prevent SSRF
    - Input sanitization for user data
    - Parameter bounds checking
-
-1. **Rate Limiting**
-   - Client-side rate limiting
-   - Exponential backoff
-   - Circuit breaker pattern
 
 1. **Audit Logging**
    - Operation logging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🚀 Features
 
+- *(client)* Add rate limiting, retries, and circuit breaker for Zammad requests (#120)
 - Add tag listing and retrieval tools (#174)
 - *(time-accounting)* Add time_unit support to update_ticket and add_article (#211)
 - *(deps)* Migrate from bundled FastMCP 1 to standalone FastMCP 3

--- a/README.md
+++ b/README.md
@@ -176,6 +176,15 @@ The server requires Zammad API credentials. Use a `.env` file:
    # Valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL
    # LOG_LEVEL=INFO
 
+   # Optional: Resilience (see "Rate Limiting" under Troubleshooting)
+   # ZAMMAD_RATE_LIMIT_ENABLED=false
+   # ZAMMAD_RATE_LIMIT_REQUESTS=60
+   # ZAMMAD_RATE_LIMIT_WINDOW=60
+   # ZAMMAD_MAX_RETRIES=3
+   # ZAMMAD_RETRY_BACKOFF_BASE=1.0
+   # ZAMMAD_CIRCUIT_BREAKER_FAILURE_THRESHOLD=5
+   # ZAMMAD_CIRCUIT_BREAKER_RECOVERY_TIMEOUT=30
+
    # Optional: Transport Configuration
    # MCP_TRANSPORT=stdio  # Transport type: stdio (default) or http
    # MCP_HOST=127.0.0.1   # Host address for HTTP transport
@@ -553,11 +562,26 @@ To generate an API token in Zammad:
 
 ### Rate Limiting
 
-The server respects Zammad's rate limits. If you hit rate limits:
+The client wraps every Zammad request with retries, an optional client-side throttle, and a circuit breaker.
 
-- Reduce request frequency
-- Paginate large result sets
-- Cache frequently accessed data
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `ZAMMAD_RATE_LIMIT_ENABLED` | `false` | Opt in to client-side throttling |
+| `ZAMMAD_RATE_LIMIT_REQUESTS` | `60` | Max requests per window (>= 1) |
+| `ZAMMAD_RATE_LIMIT_WINDOW` | `60` | Window length in seconds (> 0) |
+| `ZAMMAD_MAX_RETRIES` | `3` | Retries for safe reads; `0` disables |
+| `ZAMMAD_RETRY_BACKOFF_BASE` | `1.0` | Backoff seconds: `base * 2^attempt` |
+| `ZAMMAD_CIRCUIT_BREAKER_FAILURE_THRESHOLD` | `5` | Consecutive failures before failing fast |
+| `ZAMMAD_CIRCUIT_BREAKER_RECOVERY_TIMEOUT` | `30` | Seconds before a single probe request is allowed |
+
+Behavior to be aware of:
+
+- Only `GET`/`HEAD`/`OPTIONS` are retried, on HTTP 429/500/502/503/504, connection errors, and timeouts.
+  Writes (`POST`/`PUT`/`PATCH`/`DELETE`) are sent exactly once so a slow Zammad never duplicates a ticket or article.
+- A `Retry-After` header expressed in seconds overrides the backoff (capped at 60s); other formats fall back to backoff.
+- Throttling and circuit state are per process. Multiple server instances do not share a budget.
+- When retries are exhausted or the circuit is open, tools return an `Error:` message naming the cause and the
+  relevant variable. Reduce request frequency, paginate, or enable throttling if you keep hitting Zammad's limits.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ The client wraps every Zammad request with retries, an optional client-side thro
 | `ZAMMAD_MAX_RETRIES` | `3` | Retries for safe reads; `0` disables |
 | `ZAMMAD_RETRY_BACKOFF_BASE` | `1.0` | Backoff seconds: `base * 2^attempt` |
 | `ZAMMAD_CIRCUIT_BREAKER_FAILURE_THRESHOLD` | `5` | Consecutive failures before failing fast |
-| `ZAMMAD_CIRCUIT_BREAKER_RECOVERY_TIMEOUT` | `30` | Seconds before a single probe request is allowed |
+| `ZAMMAD_CIRCUIT_BREAKER_RECOVERY_TIMEOUT` | `30` | Seconds before requests are allowed again; one more failure re-opens the circuit |
 
 Behavior to be aware of:
 
@@ -580,8 +580,9 @@ Behavior to be aware of:
   Writes (`POST`/`PUT`/`PATCH`/`DELETE`) are sent exactly once so a slow Zammad never duplicates a ticket or article.
 - A `Retry-After` header expressed in seconds overrides the backoff (capped at 60s); other formats fall back to backoff.
 - Throttling and circuit state are per process. Multiple server instances do not share a budget.
-- When retries are exhausted or the circuit is open, tools return an `Error:` message naming the cause and the
-  relevant variable. Reduce request frequency, paginate, or enable throttling if you keep hitting Zammad's limits.
+- When retries are exhausted or the circuit is open, tools return an `Error:` message naming the cause: a 429
+  outcome (or a throttled write) points at rate limiting and `ZAMMAD_RATE_LIMIT_ENABLED`; a 5xx outcome reports a
+  server error. Reduce request frequency, paginate, or enable throttling if you keep hitting Zammad's limits.
 
 ## Security
 

--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -8,6 +8,9 @@ from urllib.parse import urlparse
 from zammad_py import ZammadAPI
 from zammad_py.exceptions import ConfigException
 
+from mcp_zammad.resilience import ResilientSession
+from mcp_zammad.resilience_config import ResilienceConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -47,6 +50,7 @@ class ZammadClient:
             oauth2_token or self._read_secret_file("ZAMMAD_OAUTH2_TOKEN_FILE") or os.getenv("ZAMMAD_OAUTH2_TOKEN")
         )
         self.insecure = insecure if insecure is not None else ZammadClient._parse_bool_env("ZAMMAD_INSECURE")
+        self.resilience = ResilienceConfig.from_env()
 
         if not self.url:
             raise ConfigException("Zammad URL is required. Set ZAMMAD_URL environment variable.")
@@ -90,6 +94,9 @@ class ZammadClient:
                 "TLS certificate verification is disabled (ZAMMAD_INSECURE=true). "
                 "urllib3 may emit InsecureRequestWarning on requests; fix or trust the server certificate when possible."
             )
+        # zammad-py routes every resource call through this session, so wrapping it once
+        # gives rate limiting, retries, and circuit breaking to all API operations.
+        self.api.session = ResilientSession(self.api.session, self.resilience)
 
     def _validate_url(self, url: str) -> None:
         """Validate URL format to prevent SSRF attacks."""

--- a/mcp_zammad/resilience.py
+++ b/mcp_zammad/resilience.py
@@ -63,7 +63,10 @@ def _settle(breaker: CircuitBreaker, method: str, url: str, attempts: int, outco
     breaker.record_failure()
     if method not in SAFE_METHODS:
         return response
-    raise RetryExhaustedError(f"{method} {url} failed after {attempts} attempts; last status {response.status_code}")
+    raise RetryExhaustedError(
+        f"{method} {url} failed after {attempts} attempts; last status {response.status_code}",
+        status_code=response.status_code,
+    )
 
 
 def _make_limiter(config: ResilienceConfig, clock: Clock) -> RateLimiter | None:

--- a/mcp_zammad/resilience.py
+++ b/mcp_zammad/resilience.py
@@ -1,0 +1,103 @@
+"""Resilient transport wrapper around the requests.Session that zammad-py uses for every call."""
+
+from __future__ import annotations
+
+import logging
+import time
+from functools import partial, partialmethod
+from typing import Any
+
+import requests  # type: ignore[import-untyped]
+
+from mcp_zammad.resilience_config import ResilienceConfig
+from mcp_zammad.resilience_retry import (
+    RETRYABLE_EXCEPTIONS,
+    SAFE_METHODS,
+    Outcome,
+    RetryExhaustedError,
+    Sleeper,
+    is_retryable,
+    run_with_retries,
+)
+from mcp_zammad.resilience_state import CircuitBreaker, CircuitOpenError, Clock, RateLimiter
+
+__all__ = ["CircuitOpenError", "ResilientSession", "RetryExhaustedError"]
+
+logger = logging.getLogger(__name__)
+
+
+class _Transport:
+    """Single attempt against the wrapped session, gated by the client-side rate limiter."""
+
+    def __init__(self, wrapped: Any, limiter: RateLimiter | None, sleep: Sleeper) -> None:
+        self._wrapped = wrapped
+        self._limiter = limiter
+        self._sleep = sleep
+
+    def send(self, method: str, url: str, kwargs: dict[str, Any]) -> Outcome:
+        self._throttle()
+        try:
+            return self._wrapped.request(method, url, **kwargs), None
+        except RETRYABLE_EXCEPTIONS as exc:
+            logger.warning("Zammad request %s %s failed: %s", method, url, exc)
+            return None, exc
+
+    def _throttle(self) -> None:
+        wait = self._limiter.acquire() if self._limiter is not None else 0.0
+        if wait > 0:
+            logger.info("Client-side rate limit reached; sleeping %.2fs before next Zammad request", wait)
+            self._sleep(wait)
+
+
+def _settle(breaker: CircuitBreaker, method: str, url: str, attempts: int, outcome: Outcome) -> requests.Response:
+    """Record the terminal outcome on the breaker, then return the response or raise."""
+    response, error = outcome
+    if error is not None:
+        breaker.record_failure()
+        raise error
+    if response is None:
+        raise RuntimeError(f"{method} {url} produced neither a response nor an error")
+    if not is_retryable(response):
+        breaker.record_success()
+        return response
+    breaker.record_failure()
+    if method not in SAFE_METHODS:
+        return response
+    raise RetryExhaustedError(f"{method} {url} failed after {attempts} attempts; last status {response.status_code}")
+
+
+def _make_limiter(config: ResilienceConfig, clock: Clock) -> RateLimiter | None:
+    if not config.rate_limit_enabled:
+        return None
+    return RateLimiter(config.rate_limit_requests, config.rate_limit_window, clock)
+
+
+class ResilientSession:
+    """Adds rate limiting, safe-method retries, and circuit breaking to a wrapped session."""
+
+    def __init__(
+        self, wrapped: Any, config: ResilienceConfig, *, clock: Clock = time.monotonic, sleeper: Sleeper = time.sleep
+    ) -> None:
+        self.wrapped = wrapped
+        self._config = config
+        self._sleep = sleeper
+        self._transport = _Transport(wrapped, _make_limiter(config, clock), sleeper)
+        self._breaker = CircuitBreaker(config.circuit_failure_threshold, config.circuit_recovery_timeout, clock)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.wrapped, name)
+
+    def request(self, method: str, url: str, **kwargs: Any) -> requests.Response:
+        """Send a request; raises CircuitOpenError when open, RetryExhaustedError when safe retries run out."""
+        self._breaker.check()
+        method = method.upper()
+        retries = self._config.max_retries if method in SAFE_METHODS else 0
+        send = partial(self._transport.send, method, url, kwargs)
+        outcome = run_with_retries(send, retries, self._config.retry_backoff_base, self._sleep)
+        return _settle(self._breaker, method, url, retries + 1, outcome)
+
+    get = partialmethod(request, "GET")
+    post = partialmethod(request, "POST")
+    put = partialmethod(request, "PUT")
+    patch = partialmethod(request, "PATCH")
+    delete = partialmethod(request, "DELETE")

--- a/mcp_zammad/resilience_config.py
+++ b/mcp_zammad/resilience_config.py
@@ -1,0 +1,79 @@
+"""Environment-backed configuration for client-side rate limiting, retries, and circuit breaking."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from zammad_py.exceptions import ConfigException
+
+_TRUE = {"1", "true", "yes", "on"}
+_FALSE = {"", "0", "false", "no", "off"}
+
+
+def _read_bool(name: str) -> bool:
+    """Parse a boolean environment variable, rejecting unrecognised values."""
+    value = os.getenv(name, "").strip().lower()
+    if value in _TRUE:
+        return True
+    if value in _FALSE:
+        return False
+    raise ConfigException(f"{name} must be one of 1/true/yes/on or 0/false/no/off, got {value!r}")
+
+
+def _read_int(name: str, default: int, minimum: int) -> int:
+    """Parse an integer environment variable that must be >= minimum."""
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ConfigException(f"{name} must be an integer >= {minimum}, got {raw!r}") from exc
+    if value < minimum:
+        raise ConfigException(f"{name} must be an integer >= {minimum}, got {raw!r}")
+    return value
+
+
+def _read_positive_float(name: str, default: float) -> float:
+    """Parse a floating-point environment variable that must be > 0."""
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise ConfigException(f"{name} must be a number > 0, got {raw!r}") from exc
+    if value <= 0:
+        raise ConfigException(f"{name} must be a number > 0, got {raw!r}")
+    return value
+
+
+@dataclass(frozen=True)
+class ResilienceConfig:
+    """Resolved resilience settings; rate limiting is opt-in, retries and circuit breaking are on."""
+
+    rate_limit_enabled: bool = False
+    rate_limit_requests: int = 60
+    rate_limit_window: float = 60.0
+    max_retries: int = 3
+    retry_backoff_base: float = 1.0
+    circuit_failure_threshold: int = 5
+    circuit_recovery_timeout: float = 30.0
+
+    @classmethod
+    def from_env(cls) -> ResilienceConfig:
+        """Build the configuration from ZAMMAD_* environment variables.
+
+        Raises:
+            ConfigException: If any variable is present but not a valid value.
+        """
+        return cls(
+            rate_limit_enabled=_read_bool("ZAMMAD_RATE_LIMIT_ENABLED"),
+            rate_limit_requests=_read_int("ZAMMAD_RATE_LIMIT_REQUESTS", 60, minimum=1),
+            rate_limit_window=_read_positive_float("ZAMMAD_RATE_LIMIT_WINDOW", 60.0),
+            max_retries=_read_int("ZAMMAD_MAX_RETRIES", 3, minimum=0),
+            retry_backoff_base=_read_positive_float("ZAMMAD_RETRY_BACKOFF_BASE", 1.0),
+            circuit_failure_threshold=_read_int("ZAMMAD_CIRCUIT_BREAKER_FAILURE_THRESHOLD", 5, minimum=1),
+            circuit_recovery_timeout=_read_positive_float("ZAMMAD_CIRCUIT_BREAKER_RECOVERY_TIMEOUT", 30.0),
+        )

--- a/mcp_zammad/resilience_retry.py
+++ b/mcp_zammad/resilience_retry.py
@@ -17,7 +17,16 @@ Sleeper = Callable[[float], None]
 
 
 class RetryExhaustedError(requests.exceptions.RequestException):
-    """Raised when a safe request still fails after the configured retries."""
+    """Raised when a safe request still fails after the configured retries.
+
+    Args:
+        message: Human-readable summary of the failed attempts.
+        status_code: HTTP status of the last response (429 or 5xx).
+    """
+
+    def __init__(self, message: str, *, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
 
 
 def is_retryable(response: requests.Response | None) -> bool:

--- a/mcp_zammad/resilience_retry.py
+++ b/mcp_zammad/resilience_retry.py
@@ -1,0 +1,53 @@
+"""Retry policy for safe HTTP methods: which outcomes retry, how long to wait, and the attempt loop."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import requests  # type: ignore[import-untyped]
+
+SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+RETRYABLE_STATUSES = frozenset({429, 500, 502, 503, 504})
+RETRYABLE_EXCEPTIONS = (requests.exceptions.ConnectionError, requests.exceptions.Timeout)
+MAX_RETRY_AFTER = 60.0
+
+Outcome = tuple["requests.Response | None", "Exception | None"]
+Send = Callable[[], Outcome]
+Sleeper = Callable[[float], None]
+
+
+class RetryExhaustedError(requests.exceptions.RequestException):
+    """Raised when a safe request still fails after the configured retries."""
+
+
+def is_retryable(response: requests.Response | None) -> bool:
+    """True when the outcome (no response, or a transient status) warrants another attempt."""
+    return response is None or response.status_code in RETRYABLE_STATUSES
+
+
+def retry_after_seconds(response: requests.Response | None) -> float | None:
+    """Return a bounded Retry-After delay in seconds, or None when absent or not delta-seconds."""
+    header = response.headers.get("Retry-After") if response is not None else None
+    if header is None:
+        return None
+    try:
+        return min(max(float(header), 0.0), MAX_RETRY_AFTER)
+    except ValueError:
+        return None
+
+
+def retry_delay(attempt: int, base: float, response: requests.Response | None) -> float:
+    """Prefer the server's Retry-After; otherwise exponential backoff from `base`."""
+    retry_after = retry_after_seconds(response)
+    return retry_after if retry_after is not None else base * (2**attempt)
+
+
+def run_with_retries(send: Send, retries: int, base: float, sleep: Sleeper) -> Outcome:
+    """Call `send` up to retries + 1 times, sleeping between retryable outcomes."""
+    response, error = send()
+    for attempt in range(retries):
+        if not is_retryable(response):
+            break
+        sleep(retry_delay(attempt, base, response))
+        response, error = send()
+    return response, error

--- a/mcp_zammad/resilience_state.py
+++ b/mcp_zammad/resilience_state.py
@@ -1,0 +1,78 @@
+"""Process-local rate limiter and circuit breaker state driven by an injected monotonic clock."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+
+import requests  # type: ignore[import-untyped]
+
+Clock = Callable[[], float]
+
+
+class CircuitOpenError(requests.exceptions.RequestException):
+    """Raised without contacting Zammad while the circuit breaker is open."""
+
+
+class RateLimiter:
+    """Fixed-window limiter: at most `limit` attempts per `window` seconds."""
+
+    def __init__(self, limit: int, window: float, clock: Clock) -> None:
+        self._limit = limit
+        self._window = window
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._window_start = clock()
+        self._count = 0
+
+    def acquire(self) -> float:
+        """Reserve one attempt and return how long the caller must sleep before sending it."""
+        with self._lock:
+            now = self._clock()
+            if now - self._window_start >= self._window:
+                self._window_start, self._count = now, 0
+            if self._count < self._limit:
+                self._count += 1
+                return 0.0
+            wait = self._window_start + self._window - now
+            self._window_start, self._count = now + wait, 1
+            return wait
+
+
+class CircuitBreaker:
+    """Closed → open after `threshold` terminal failures; half-open probe after `recovery_timeout`."""
+
+    def __init__(self, threshold: int, recovery_timeout: float, clock: Clock) -> None:
+        self._threshold = threshold
+        self._recovery_timeout = recovery_timeout
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._failures = 0
+        self._opened_at: float | None = None
+
+    def check(self) -> None:
+        """Raise CircuitOpenError while open; allow one probe once the recovery timeout has elapsed."""
+        with self._lock:
+            if self._opened_at is None:
+                return
+            remaining = self._opened_at + self._recovery_timeout - self._clock()
+            if remaining > 0:
+                raise CircuitOpenError(_open_message(self._failures, remaining, self._recovery_timeout))
+            self._opened_at = None
+
+    def record_success(self) -> None:
+        with self._lock:
+            self._failures = 0
+
+    def record_failure(self) -> None:
+        with self._lock:
+            self._failures += 1
+            if self._failures >= self._threshold:
+                self._opened_at = self._clock()
+
+
+def _open_message(failures: int, remaining: float, recovery_timeout: float) -> str:
+    return (
+        f"Zammad circuit breaker is open after {failures} consecutive failures; "
+        f"retry in {remaining:.1f}s (ZAMMAD_CIRCUIT_BREAKER_RECOVERY_TIMEOUT={recovery_timeout:g})"
+    )

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -8,6 +8,7 @@ import os
 import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from http import HTTPStatus
 from pathlib import Path
 from typing import Any, NoReturn, Protocol, TypeVar
 
@@ -754,6 +755,16 @@ def _format_organization_detail_markdown(org: Organization) -> str:
     return "\n".join(lines)
 
 
+_RATE_LIMIT_GUIDANCE = (
+    "Error: Zammad rate limit reached during {context}{detail}. "
+    "Wait before retrying, reduce request frequency or page size, or enable client-side "
+    "throttling with ZAMMAD_RATE_LIMIT_ENABLED=true."
+)
+_SERVER_ERROR_GUIDANCE = (
+    "Error: Zammad server error during {context}{detail}. "
+    "The server is failing or temporarily unavailable; retry later or check the Zammad instance."
+)
+
 _API_ERROR_GUIDANCE: tuple[tuple[tuple[str, ...], str], ...] = (
     (
         ("not found", "404"),
@@ -761,6 +772,7 @@ _API_ERROR_GUIDANCE: tuple[tuple[tuple[str, ...], str], ...] = (
     ),
     (("forbidden", "403"), "Error: Permission denied for {context}. Your credentials lack access to this resource."),
     (("unauthorized", "401"), "Error: Authentication failed for {context}. Check ZAMMAD_HTTP_TOKEN is valid."),
+    (("429", "too many requests", "rate limit"), _RATE_LIMIT_GUIDANCE),
     (
         ("timeout",),
         "Error: Request timeout during {context}. The server may be slow - try again or reduce the scope.",
@@ -775,11 +787,9 @@ _API_ERROR_GUIDANCE: tuple[tuple[tuple[str, ...], str], ...] = (
 def _resilience_error_message(e: Exception, context: str) -> str | None:
     """Return guidance for retry-exhaustion or open-circuit errors, else None."""
     if isinstance(e, RetryExhaustedError):
-        return (
-            f"Error: Zammad rate limit reached during {context} ({e}). "
-            "Wait before retrying, reduce request frequency or page size, or enable client-side "
-            "throttling with ZAMMAD_RATE_LIMIT_ENABLED=true."
-        )
+        throttled = e.status_code == HTTPStatus.TOO_MANY_REQUESTS
+        template = _RATE_LIMIT_GUIDANCE if throttled else _SERVER_ERROR_GUIDANCE
+        return template.format(context=context, detail=f" ({e})")
     if isinstance(e, CircuitOpenError):
         return f"Error: Zammad is temporarily unavailable during {context} ({e}). Wait for the recovery timeout."
     return None
@@ -804,7 +814,7 @@ def _handle_api_error(e: Exception, context: str = "operation") -> str:
     # First matching pattern wins; order mirrors the original precedence.
     for patterns, template in _API_ERROR_GUIDANCE:
         if any(pattern in error_msg for pattern in patterns):
-            return template.format(context=context)
+            return template.format(context=context, detail="")
 
     # Generic error with type information
     return f"Error during {context}: {type(e).__name__} - {e}"

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -57,6 +57,7 @@ from .models import (
     UserBrief,
     UserCreate,
 )
+from .resilience import CircuitOpenError, RetryExhaustedError
 
 
 class AttachmentDeletionError(Exception):
@@ -753,6 +754,37 @@ def _format_organization_detail_markdown(org: Organization) -> str:
     return "\n".join(lines)
 
 
+_API_ERROR_GUIDANCE: tuple[tuple[tuple[str, ...], str], ...] = (
+    (
+        ("not found", "404"),
+        "Error: Resource not found during {context}. Please verify the ID is correct and you have access.",
+    ),
+    (("forbidden", "403"), "Error: Permission denied for {context}. Your credentials lack access to this resource."),
+    (("unauthorized", "401"), "Error: Authentication failed for {context}. Check ZAMMAD_HTTP_TOKEN is valid."),
+    (
+        ("timeout",),
+        "Error: Request timeout during {context}. The server may be slow - try again or reduce the scope.",
+    ),
+    (
+        ("connection", "network"),
+        "Error: Network issue during {context}. Check ZAMMAD_URL is correct and the server is reachable.",
+    ),
+)
+
+
+def _resilience_error_message(e: Exception, context: str) -> str | None:
+    """Return guidance for retry-exhaustion or open-circuit errors, else None."""
+    if isinstance(e, RetryExhaustedError):
+        return (
+            f"Error: Zammad rate limit reached during {context} ({e}). "
+            "Wait before retrying, reduce request frequency or page size, or enable client-side "
+            "throttling with ZAMMAD_RATE_LIMIT_ENABLED=true."
+        )
+    if isinstance(e, CircuitOpenError):
+        return f"Error: Zammad is temporarily unavailable during {context} ({e}). Wait for the recovery timeout."
+    return None
+
+
 def _handle_api_error(e: Exception, context: str = "operation") -> str:
     """Format errors with actionable guidance for LLM agents.
 
@@ -763,23 +795,16 @@ def _handle_api_error(e: Exception, context: str = "operation") -> str:
     Returns:
         Formatted error message with guidance
     """
+    resilience_message = _resilience_error_message(e, context)
+    if resilience_message is not None:
+        return resilience_message
+
     error_msg = str(e).lower()
 
-    # Check for specific error patterns
-    if "not found" in error_msg or "404" in error_msg:
-        return f"Error: Resource not found during {context}. Please verify the ID is correct and you have access."
-
-    if "forbidden" in error_msg or "403" in error_msg:
-        return f"Error: Permission denied for {context}. Your credentials lack access to this resource."
-
-    if "unauthorized" in error_msg or "401" in error_msg:
-        return f"Error: Authentication failed for {context}. Check ZAMMAD_HTTP_TOKEN is valid."
-
-    if "timeout" in error_msg:
-        return f"Error: Request timeout during {context}. The server may be slow - try again or reduce the scope."
-
-    if "connection" in error_msg or "network" in error_msg:
-        return f"Error: Network issue during {context}. Check ZAMMAD_URL is correct and the server is reachable."
+    # First matching pattern wins; order mirrors the original precedence.
+    for patterns, template in _API_ERROR_GUIDANCE:
+        if any(pattern in error_msg for pattern in patterns):
+            return template.format(context=context)
 
     # Generic error with type information
     return f"Error during {context}: {type(e).__name__} - {e}"

--- a/tests/integration/test_resilience_http.py
+++ b/tests/integration/test_resilience_http.py
@@ -1,0 +1,67 @@
+"""Integration test: a real zammad-py session recovers from throttling via a fake Zammad server."""
+
+import json
+import os
+import threading
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import patch
+
+import pytest
+
+from mcp_zammad.client import ZammadClient
+
+
+class _ThrottlingZammad:
+    """Fake Zammad that answers 429, then 503, then succeeds for /users/me."""
+
+    def __init__(self) -> None:
+        self.statuses = [429, 503, 200]
+        self.hits: list[str] = []
+
+    def handler(self) -> type[BaseHTTPRequestHandler]:
+        fake = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                fake.hits.append(self.path)
+                status = fake.statuses.pop(0) if fake.statuses else 200
+                body = json.dumps({"id": 1, "login": "resilient"}).encode() if status == 200 else b"{}"
+                self.send_response(status)
+                if status == 429:
+                    self.send_header("Retry-After", "0")
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, fmt: str, *args: object) -> None:
+                pass
+
+        return _Handler
+
+
+@pytest.fixture
+def throttling_zammad() -> Iterator[tuple[str, _ThrottlingZammad]]:
+    fake = _ThrottlingZammad()
+    server = HTTPServer(("127.0.0.1", 0), fake.handler())
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/api/v1", fake
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+@pytest.mark.integration
+def test_read_recovers_after_throttled_responses(throttling_zammad: tuple[str, _ThrottlingZammad]) -> None:
+    url, fake = throttling_zammad
+    env = {"ZAMMAD_URL": url, "ZAMMAD_HTTP_TOKEN": "test-token", "ZAMMAD_RETRY_BACKOFF_BASE": "0.01"}
+
+    with patch.dict(os.environ, env, clear=True):
+        user = ZammadClient().get_current_user()
+
+    assert user["login"] == "resilient"
+    assert fake.hits == ["/api/v1/users/me"] * 3

--- a/tests/resilience_support.py
+++ b/tests/resilience_support.py
@@ -1,0 +1,72 @@
+"""Deterministic doubles for exercising the resilient session boundary."""
+
+from typing import Any
+
+import requests
+
+from mcp_zammad.resilience import ResilientSession
+from mcp_zammad.resilience_config import ResilienceConfig
+
+URL = "https://zammad.example.com/api/v1/tickets"
+
+
+def make_response(status: int, headers: dict[str, str] | None = None) -> requests.Response:
+    """Build a real requests.Response with the given status and headers."""
+    response = requests.Response()
+    response.status_code = status
+    response.headers.update(headers or {})
+    response._content = b"{}"
+    return response
+
+
+class FakeClock:
+    """Injectable monotonic clock."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class FakeSession:
+    """Scripted stand-in for requests.Session; outcomes are responses or exceptions."""
+
+    def __init__(self, outcomes: list[Any]) -> None:
+        self.outcomes = list(outcomes)
+        self.calls: list[tuple[str, str]] = []
+        self.headers: dict[str, str] = {}
+        self.verify = True
+        self.closed = False
+
+    def request(self, method: str, url: str, **kwargs: Any) -> requests.Response:
+        self.calls.append((method, url))
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class Harness:
+    """Bundle of the wrapper under test and its observable capability doubles."""
+
+    def __init__(self, outcomes: list[Any], clock: FakeClock | None = None, **overrides: Any) -> None:
+        self.inner = FakeSession(outcomes)
+        self.clock = clock or FakeClock()
+        self.sleeps: list[float] = []
+        config = ResilienceConfig(**overrides)
+        self.session = ResilientSession(self.inner, config, clock=self.clock, sleeper=self._sleep)
+
+    def _sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.clock.advance(seconds)
+
+    @property
+    def calls(self) -> list[tuple[str, str]]:
+        return self.inner.calls

--- a/tests/test_client_methods.py
+++ b/tests/test_client_methods.py
@@ -610,7 +610,9 @@ class TestZammadClientMethods:
             {"id": 3, "name": "feature-request", "count": 23},
         ]
         mock_response.raise_for_status = Mock()
-        mock_instance.session.get.return_value = mock_response
+        mock_response.status_code = 200
+        transport = mock_instance.session
+        transport.request.return_value = mock_response
         mock_zammad_api.return_value = mock_instance
 
         client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
@@ -622,7 +624,7 @@ class TestZammadClientMethods:
         assert result[0]["count"] == 15
         assert result[1]["name"] == "billing"
         assert result[2]["name"] == "feature-request"
-        mock_instance.session.get.assert_called_once_with("https://test.zammad.com/api/v1/tag_list")
+        transport.request.assert_called_once_with("GET", "https://test.zammad.com/api/v1/tag_list")
 
     def test_list_tags_empty(self, mock_zammad_api: Mock) -> None:
         """Test list_tags returns empty list when no tags defined."""
@@ -630,7 +632,9 @@ class TestZammadClientMethods:
         mock_response = Mock()
         mock_response.json.return_value = []
         mock_response.raise_for_status = Mock()
-        mock_instance.session.get.return_value = mock_response
+        mock_response.status_code = 200
+        transport = mock_instance.session
+        transport.request.return_value = mock_response
         mock_zammad_api.return_value = mock_instance
 
         client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
@@ -638,14 +642,15 @@ class TestZammadClientMethods:
         result = client.list_tags()
 
         assert result == []
-        mock_instance.session.get.assert_called_once()
+        transport.request.assert_called_once()
 
     def test_list_tags_permission_denied(self, mock_zammad_api: Mock) -> None:
         """Test list_tags raises error when lacking admin.tag permission."""
         mock_instance = Mock()
         mock_response = Mock()
         mock_response.raise_for_status.side_effect = requests.HTTPError("403 Forbidden")
-        mock_instance.session.get.return_value = mock_response
+        mock_response.status_code = 403
+        mock_instance.session.request.return_value = mock_response
         mock_zammad_api.return_value = mock_instance
 
         client = ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")

--- a/tests/test_client_resilience.py
+++ b/tests/test_client_resilience.py
@@ -1,0 +1,52 @@
+"""Tests proving ZammadClient installs the resilient session boundary."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from zammad_py.exceptions import ConfigException
+
+from mcp_zammad.client import ZammadClient
+from mcp_zammad.resilience import ResilientSession
+
+_ENV = {"ZAMMAD_URL": "https://test.zammad.com/api/v1", "ZAMMAD_HTTP_TOKEN": "test-token"}
+
+
+@patch("mcp_zammad.client.ZammadAPI")
+def test_client_wraps_api_session(mock_api: MagicMock) -> None:
+    original_session = mock_api.return_value.session
+
+    with patch.dict(os.environ, _ENV, clear=True):
+        client = ZammadClient()
+
+    assert isinstance(client.api.session, ResilientSession)
+    assert client.api.session.wrapped is original_session
+
+
+@patch("mcp_zammad.client.ZammadAPI")
+def test_client_reads_resilience_config_from_env(mock_api: MagicMock) -> None:
+    with patch.dict(os.environ, {**_ENV, "ZAMMAD_RATE_LIMIT_ENABLED": "true", "ZAMMAD_MAX_RETRIES": "7"}, clear=True):
+        client = ZammadClient()
+
+    assert client.resilience.rate_limit_enabled is True
+    assert client.resilience.max_retries == 7
+
+
+@patch("mcp_zammad.client.ZammadAPI")
+def test_client_rejects_invalid_resilience_config(mock_api: MagicMock) -> None:
+    with (
+        patch.dict(os.environ, {**_ENV, "ZAMMAD_MAX_RETRIES": "lots"}, clear=True),
+        pytest.raises(ConfigException, match="ZAMMAD_MAX_RETRIES"),
+    ):
+        ZammadClient()
+
+
+@patch("mcp_zammad.client.ZammadAPI")
+def test_insecure_mode_still_disables_tls_on_wrapped_session(mock_api: MagicMock) -> None:
+    original_session = mock_api.return_value.session
+
+    with patch.dict(os.environ, {**_ENV, "ZAMMAD_INSECURE": "true"}, clear=True):
+        client = ZammadClient()
+
+    assert original_session.verify is False
+    assert client.api.session.verify is False

--- a/tests/test_resilience_circuit.py
+++ b/tests/test_resilience_circuit.py
@@ -1,0 +1,103 @@
+"""Tests for circuit breaker state transitions at the resilient session boundary."""
+
+import pytest
+import requests
+
+from mcp_zammad.resilience import CircuitOpenError, RetryExhaustedError
+from tests.resilience_support import URL, FakeClock, Harness, make_response
+
+
+def _tripped_harness(outcomes: list[object], clock: FakeClock) -> Harness:
+    """Return a harness whose circuit has just opened after two failures."""
+    harness = Harness(
+        [make_response(503), make_response(503), *outcomes],
+        clock=clock,
+        max_retries=0,
+        circuit_failure_threshold=2,
+        circuit_recovery_timeout=30.0,
+    )
+    for _ in range(2):
+        with pytest.raises(RetryExhaustedError):
+            harness.session.get(URL)
+    return harness
+
+
+def test_circuit_opens_after_failure_threshold() -> None:
+    harness = _tripped_harness([make_response(200)], FakeClock())
+
+    with pytest.raises(CircuitOpenError, match="open") as exc_info:
+        harness.session.get(URL)
+
+    assert isinstance(exc_info.value, requests.exceptions.RequestException)
+    assert len(harness.calls) == 2
+
+
+def test_open_circuit_rejects_until_recovery_timeout() -> None:
+    clock = FakeClock()
+    harness = _tripped_harness([make_response(200)], clock)
+
+    clock.advance(29.0)
+    with pytest.raises(CircuitOpenError):
+        harness.session.get(URL)
+
+    clock.advance(1.0)
+    assert harness.session.get(URL).status_code == 200
+    assert len(harness.calls) == 3
+
+
+def test_half_open_success_closes_circuit_and_resets_failures() -> None:
+    clock = FakeClock()
+    harness = _tripped_harness([make_response(200), make_response(503), make_response(200)], clock)
+
+    clock.advance(30.0)
+    harness.session.get(URL)
+    with pytest.raises(RetryExhaustedError):
+        harness.session.get(URL)
+
+    # One failure after reset stays below the threshold of two, so the circuit remains closed.
+    assert harness.session.get(URL).status_code == 200
+    assert len(harness.calls) == 5
+
+
+def test_half_open_failure_reopens_circuit() -> None:
+    clock = FakeClock()
+    harness = _tripped_harness([make_response(503), make_response(200)], clock)
+
+    clock.advance(30.0)
+    with pytest.raises(RetryExhaustedError):
+        harness.session.get(URL)
+
+    with pytest.raises(CircuitOpenError):
+        harness.session.get(URL)
+    assert len(harness.calls) == 3
+
+
+def test_non_retryable_responses_do_not_count_as_failures() -> None:
+    harness = Harness([make_response(404), make_response(404), make_response(200)], circuit_failure_threshold=1)
+
+    harness.session.get(URL)
+    harness.session.get(URL)
+
+    assert harness.session.get(URL).status_code == 200
+    assert len(harness.calls) == 3
+
+
+def test_write_failures_count_toward_circuit() -> None:
+    harness = Harness([make_response(503), make_response(200)], circuit_failure_threshold=1)
+
+    harness.session.post(URL)
+
+    with pytest.raises(CircuitOpenError):
+        harness.session.get(URL)
+    assert len(harness.calls) == 1
+
+
+def test_circuit_open_error_reports_remaining_recovery_time() -> None:
+    clock = FakeClock()
+    harness = _tripped_harness([], clock)
+
+    clock.advance(10.0)
+    with pytest.raises(CircuitOpenError, match="20") as exc_info:
+        harness.session.get(URL)
+
+    assert "ZAMMAD_CIRCUIT_BREAKER_RECOVERY_TIMEOUT" in str(exc_info.value)

--- a/tests/test_resilience_config.py
+++ b/tests/test_resilience_config.py
@@ -1,0 +1,84 @@
+"""Tests for environment-backed resilience configuration."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from zammad_py.exceptions import ConfigException
+
+from mcp_zammad.resilience_config import ResilienceConfig
+
+_FULL_ENV = {
+    "ZAMMAD_RATE_LIMIT_ENABLED": "true",
+    "ZAMMAD_RATE_LIMIT_REQUESTS": "120",
+    "ZAMMAD_RATE_LIMIT_WINDOW": "30",
+    "ZAMMAD_MAX_RETRIES": "5",
+    "ZAMMAD_RETRY_BACKOFF_BASE": "0.5",
+    "ZAMMAD_CIRCUIT_BREAKER_FAILURE_THRESHOLD": "8",
+    "ZAMMAD_CIRCUIT_BREAKER_RECOVERY_TIMEOUT": "45",
+}
+
+
+def test_defaults_keep_rate_limiting_disabled() -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        config = ResilienceConfig.from_env()
+
+    assert config == ResilienceConfig(
+        rate_limit_enabled=False,
+        rate_limit_requests=60,
+        rate_limit_window=60.0,
+        max_retries=3,
+        retry_backoff_base=1.0,
+        circuit_failure_threshold=5,
+        circuit_recovery_timeout=30.0,
+    )
+
+
+def test_environment_values_are_parsed() -> None:
+    with patch.dict(os.environ, _FULL_ENV, clear=True):
+        config = ResilienceConfig.from_env()
+
+    assert config.rate_limit_enabled is True
+    assert config.rate_limit_requests == 120
+    assert config.rate_limit_window == 30.0
+    assert config.max_retries == 5
+    assert config.retry_backoff_base == 0.5
+    assert config.circuit_failure_threshold == 8
+    assert config.circuit_recovery_timeout == 45.0
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+def test_falsy_boolean_values_disable_rate_limiting(value: str) -> None:
+    with patch.dict(os.environ, {"ZAMMAD_RATE_LIMIT_ENABLED": value}, clear=True):
+        assert ResilienceConfig.from_env().rate_limit_enabled is False
+
+
+def test_invalid_boolean_is_rejected() -> None:
+    with (
+        patch.dict(os.environ, {"ZAMMAD_RATE_LIMIT_ENABLED": "maybe"}, clear=True),
+        pytest.raises(ConfigException, match="ZAMMAD_RATE_LIMIT_ENABLED"),
+    ):
+        ResilienceConfig.from_env()
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("ZAMMAD_RATE_LIMIT_REQUESTS", "0"),
+        ("ZAMMAD_RATE_LIMIT_REQUESTS", "ten"),
+        ("ZAMMAD_RATE_LIMIT_WINDOW", "-1"),
+        ("ZAMMAD_MAX_RETRIES", "-1"),
+        ("ZAMMAD_MAX_RETRIES", "2.5"),
+        ("ZAMMAD_RETRY_BACKOFF_BASE", "0"),
+        ("ZAMMAD_CIRCUIT_BREAKER_FAILURE_THRESHOLD", "0"),
+        ("ZAMMAD_CIRCUIT_BREAKER_RECOVERY_TIMEOUT", "abc"),
+    ],
+)
+def test_invalid_numeric_values_are_rejected(name: str, value: str) -> None:
+    with patch.dict(os.environ, {name: value}, clear=True), pytest.raises(ConfigException, match=name):
+        ResilienceConfig.from_env()
+
+
+def test_zero_retries_is_allowed() -> None:
+    with patch.dict(os.environ, {"ZAMMAD_MAX_RETRIES": "0"}, clear=True):
+        assert ResilienceConfig.from_env().max_retries == 0

--- a/tests/test_resilience_session.py
+++ b/tests/test_resilience_session.py
@@ -55,8 +55,18 @@ def test_retry_cap_raises_retry_exhausted() -> None:
         harness.session.get(URL)
 
     assert "429" in str(exc_info.value)
+    assert exc_info.value.status_code == 429
     assert isinstance(exc_info.value, requests.exceptions.RequestException)
     assert len(harness.calls) == 3
+
+
+def test_retry_exhausted_carries_last_server_error_status() -> None:
+    harness = Harness([make_response(503)] * 3, max_retries=2)
+
+    with pytest.raises(RetryExhaustedError) as exc_info:
+        harness.session.get(URL)
+
+    assert exc_info.value.status_code == 503
 
 
 def test_non_retryable_client_error_is_returned_once() -> None:

--- a/tests/test_resilience_session.py
+++ b/tests/test_resilience_session.py
@@ -1,0 +1,156 @@
+"""Tests for rate limiting and retry behavior of the resilient session."""
+
+import pytest
+import requests
+
+from mcp_zammad.resilience import RetryExhaustedError
+from tests.resilience_support import URL, FakeClock, Harness, make_response
+
+
+def test_safe_request_retries_until_success() -> None:
+    ok = make_response(200)
+    harness = Harness([make_response(429), make_response(503), ok])
+
+    assert harness.session.get(URL) is ok
+    assert harness.calls == [("GET", URL)] * 3
+    assert harness.sleeps == [1.0, 2.0]
+
+
+def test_backoff_base_scales_delays() -> None:
+    harness = Harness([make_response(502), make_response(502), make_response(200)], retry_backoff_base=0.5)
+
+    harness.session.get(URL)
+
+    assert harness.sleeps == [0.5, 1.0]
+
+
+def test_retry_after_header_overrides_backoff() -> None:
+    harness = Harness([make_response(429, {"Retry-After": "7"}), make_response(200)])
+
+    harness.session.get(URL)
+
+    assert harness.sleeps == [7.0]
+
+
+def test_malformed_retry_after_falls_back_to_backoff() -> None:
+    harness = Harness([make_response(429, {"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}), make_response(200)])
+
+    harness.session.get(URL)
+
+    assert harness.sleeps == [1.0]
+
+
+def test_retry_after_is_bounded() -> None:
+    harness = Harness([make_response(429, {"Retry-After": "999"}), make_response(200)])
+
+    harness.session.get(URL)
+
+    assert harness.sleeps == [60.0]
+
+
+def test_retry_cap_raises_retry_exhausted() -> None:
+    harness = Harness([make_response(429)] * 3, max_retries=2)
+
+    with pytest.raises(RetryExhaustedError, match="3 attempts") as exc_info:
+        harness.session.get(URL)
+
+    assert "429" in str(exc_info.value)
+    assert isinstance(exc_info.value, requests.exceptions.RequestException)
+    assert len(harness.calls) == 3
+
+
+def test_non_retryable_client_error_is_returned_once() -> None:
+    not_found = make_response(404)
+    harness = Harness([not_found])
+
+    assert harness.session.get(URL) is not_found
+    assert len(harness.calls) == 1
+    assert harness.sleeps == []
+
+
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+def test_write_methods_are_never_retried(method: str) -> None:
+    unavailable = make_response(503)
+    harness = Harness([unavailable])
+
+    assert harness.session.request(method, URL, json={}) is unavailable
+    assert harness.calls == [(method, URL)]
+    assert harness.sleeps == []
+
+
+def test_connection_errors_retry_then_reraise() -> None:
+    harness = Harness(
+        [requests.exceptions.ConnectionError("boom"), requests.exceptions.Timeout("slow")],
+        max_retries=1,
+    )
+
+    with pytest.raises(requests.exceptions.Timeout):
+        harness.session.get(URL)
+
+    assert len(harness.calls) == 2
+    assert harness.sleeps == [1.0]
+
+
+def test_rate_limit_disabled_by_default_never_sleeps() -> None:
+    harness = Harness([make_response(200)] * 5)
+
+    for _ in range(5):
+        harness.session.get(URL)
+
+    assert harness.sleeps == []
+
+
+def test_rate_limit_waits_for_next_window() -> None:
+    clock = FakeClock(start=1000.0)
+    harness = Harness(
+        [make_response(200)] * 4,
+        clock=clock,
+        rate_limit_enabled=True,
+        rate_limit_requests=2,
+        rate_limit_window=10.0,
+    )
+
+    harness.session.get(URL)
+    clock.advance(3.0)
+    harness.session.get(URL)
+    clock.advance(2.0)
+    harness.session.get(URL)
+    harness.session.get(URL)
+
+    assert harness.sleeps == [5.0]
+    assert len(harness.calls) == 4
+
+
+def test_rate_limit_counts_every_attempt() -> None:
+    harness = Harness(
+        [make_response(503), make_response(200)],
+        rate_limit_enabled=True,
+        rate_limit_requests=1,
+        rate_limit_window=10.0,
+    )
+
+    harness.session.get(URL)
+
+    # Retry backoff (1s) then wait for the rest of the window (9s) before the second attempt.
+    assert harness.sleeps == [1.0, 9.0]
+
+
+def test_verb_helpers_delegate_to_request() -> None:
+    harness = Harness([make_response(200)] * 3)
+
+    harness.session.post(URL, json={"title": "x"})
+    harness.session.put(URL)
+    harness.session.delete(URL)
+
+    assert [method for method, _ in harness.calls] == ["POST", "PUT", "DELETE"]
+
+
+def test_session_state_is_delegated_to_wrapped_session() -> None:
+    harness = Harness([])
+
+    harness.session.headers["X-On-Behalf-Of"] = "agent"
+    harness.session.close()
+
+    assert harness.inner.headers["X-On-Behalf-Of"] == "agent"
+    assert harness.session.verify is True
+    assert harness.inner.closed is True

--- a/tests/test_server_resilience_errors.py
+++ b/tests/test_server_resilience_errors.py
@@ -1,0 +1,32 @@
+"""Tests for MCP-visible guidance when resilience limits are hit."""
+
+import requests
+
+from mcp_zammad.resilience import CircuitOpenError, RetryExhaustedError
+from mcp_zammad.server import _handle_api_error
+
+
+def test_retry_exhausted_error_gives_rate_limit_guidance() -> None:
+    error = RetryExhaustedError("GET https://z/api/v1/tickets failed after 4 attempts; last status 429")
+
+    message = _handle_api_error(error, context="searching tickets")
+
+    assert message.startswith("Error: Zammad rate limit reached during searching tickets")
+    assert "4 attempts" in message
+    assert "ZAMMAD_RATE_LIMIT_ENABLED" in message
+
+
+def test_circuit_open_error_gives_recovery_guidance() -> None:
+    error = CircuitOpenError("Zammad circuit breaker is open; retry in 20.0s")
+
+    message = _handle_api_error(error, context="retrieving ticket 7")
+
+    assert message.startswith("Error: Zammad is temporarily unavailable during retrieving ticket 7")
+    assert "20.0s" in message
+
+
+def test_existing_error_branches_are_unchanged() -> None:
+    assert _handle_api_error(requests.exceptions.HTTPError("404 not found"), "x").startswith(
+        "Error: Resource not found"
+    )
+    assert _handle_api_error(requests.exceptions.Timeout("timeout"), "x").startswith("Error: Request timeout")

--- a/tests/test_server_resilience_errors.py
+++ b/tests/test_server_resilience_errors.py
@@ -1,5 +1,6 @@
 """Tests for MCP-visible guidance when resilience limits are hit."""
 
+import pytest
 import requests
 
 from mcp_zammad.resilience import CircuitOpenError, RetryExhaustedError
@@ -7,12 +8,42 @@ from mcp_zammad.server import _handle_api_error
 
 
 def test_retry_exhausted_error_gives_rate_limit_guidance() -> None:
-    error = RetryExhaustedError("GET https://z/api/v1/tickets failed after 4 attempts; last status 429")
+    error = RetryExhaustedError(
+        "GET https://z/api/v1/tickets failed after 4 attempts; last status 429", status_code=429
+    )
 
     message = _handle_api_error(error, context="searching tickets")
 
     assert message.startswith("Error: Zammad rate limit reached during searching tickets")
     assert "4 attempts" in message
+    assert "ZAMMAD_RATE_LIMIT_ENABLED" in message
+
+
+@pytest.mark.parametrize("status", [500, 502, 503, 504])
+def test_retry_exhausted_on_server_error_gives_outage_guidance(status: int) -> None:
+    error = RetryExhaustedError(
+        f"GET https://z/api/v1/tickets failed after 4 attempts; last status {status}", status_code=status
+    )
+
+    message = _handle_api_error(error, context="listing tickets")
+
+    assert message.startswith("Error: Zammad server error during listing tickets")
+    assert str(status) in message
+    assert "rate limit" not in message.lower()
+    assert "ZAMMAD_RATE_LIMIT_ENABLED" not in message
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        requests.exceptions.HTTPError("429 Client Error: Too Many Requests for url: https://z/api/v1/tickets"),
+        requests.exceptions.HTTPError('{"error": "Too many requests"}'),
+    ],
+)
+def test_throttled_write_gives_rate_limit_guidance(error: Exception) -> None:
+    message = _handle_api_error(error, context="creating ticket")
+
+    assert message.startswith("Error: Zammad rate limit reached during creating ticket")
     assert "ZAMMAD_RATE_LIMIT_ENABLED" in message
 
 


### PR DESCRIPTION
Closes #120

## Summary

Zammad returns HTTP 429 and transient 5xx errors under load. Until now each one surfaced immediately as a tool error with no recovery. This PR adds a resilience layer so the MCP server rides out throttling and short outages instead of failing on the first bad response.

`zammad-py` routes every resource call through a single `requests.Session`, so `ZammadClient` swaps that session for a `ResilientSession` rather than touching each of the ~23 API methods. The wrapper applies:

- **Client-side rate limiting** (opt-in, `ZAMMAD_RATE_LIMIT_ENABLED=true`): fixed-window throttle of `ZAMMAD_RATE_LIMIT_REQUESTS` per `ZAMMAD_RATE_LIMIT_WINDOW` seconds.
- **Retries with exponential backoff** for `GET`/`HEAD`/`OPTIONS` on 429/500/502/503/504, connection errors, and timeouts. Delay is `ZAMMAD_RETRY_BACKOFF_BASE * 2^attempt`, overridden by a numeric `Retry-After` header (capped at 60s). Writes are sent exactly once so a slow server never duplicates a ticket or article.
- **Circuit breaker**: after `ZAMMAD_CIRCUIT_BREAKER_FAILURE_THRESHOLD` consecutive terminal failures the client fails fast without contacting Zammad until `ZAMMAD_CIRCUIT_BREAKER_RECOVERY_TIMEOUT` elapses, then allows a single probe.

All settings are validated at startup; invalid values raise `ConfigException` rather than being ignored. Retry exhaustion and open-circuit errors render as actionable MCP error messages naming the relevant variable.

Defaults: rate limiting off, 3 retries, 1.0s backoff base, threshold 5, recovery 30s. Existing behaviour for callers that never hit errors is unchanged.

## Design notes

- Standard library only; no `tenacity` dependency added.
- Clock and sleeper are injected, so all retry/limiter/breaker tests are deterministic and run in under a second.
- State is process-local; multiple server instances do not share a budget (documented in README).
- `_handle_api_error` was refactored to a lookup table to add the two new branches without exceeding Ruff's return-count limit; existing messages are byte-identical.

## Test plan

- [x] 49 new tests: config parsing/validation, retry/backoff/Retry-After, write-method single-attempt, rate-limit window maths, circuit open/half-open/close transitions, client installs wrapper, MCP error rendering
- [x] Integration test drives the real `zammad-py` session against a throttling fake HTTP server (429 → 503 → 200) and confirms `get_current_user()` recovers
- [x] Full suite: 271 passed, coverage 89.98% (floor 86%)
- [x] `ruff format --check`, `ruff check`, `mypy`, `rumdl` clean
- [x] `./scripts/quality-check.sh`: bandit and semgrep pass; pip-audit reports pre-existing dependency advisories (27 findings in `click`, `cryptography`, `mcp`, `nltk`, …) that are identical on `main` and unrelated to this change

## Docs

- `.env.example` and README configuration block list the seven new variables
- README "Rate Limiting" troubleshooting section rewritten with a reference table and behavioural caveats
- `ARCHITECTURE.md` moves rate limiting from "Needed Improvements" to "Current Security Measures"
- Unreleased changelog entry added
