### PR TITLE
Review follow-ups for #340: add_article docstring default and example casing

### DIFF
--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -1181,7 +1181,7 @@ class ZammadMCPServer:
                 params (ArticleCreate): Validated article creation parameters containing:
                     - ticket_id (int): Internal database ID (required, NOT display number)
                     - body (str): Article content/message (required)
-                    - article_type (ArticleType): Article type - note, email, or phone (required)
+                    - article_type (ArticleType): Article type - note, email, or phone (default: note)
                     - internal (bool): Internal note vs customer-visible (default: False)
                     - subject (str | None): Article subject (for emails)
                     - content_type (str | None): text/plain or text/html (default: text/plain)
@@ -1205,9 +1205,9 @@ class ZammadMCPServer:
                 ```
 
             Examples:
-                - Use when: "Add note to ticket 123" -> ticket_id=123, body="text", article_type=NOTE
-                - Use when: "Reply to customer" -> ticket_id=123, body="reply", article_type=EMAIL
-                - Use when: "Internal comment" -> ticket_id=123, body="note", article_type=NOTE, internal=True
+                - Use when: "Add note to ticket 123" -> ticket_id=123, body="text", article_type="note"
+                - Use when: "Reply to customer" -> ticket_id=123, body="reply", article_type="email"
+                - Use when: "Internal comment" -> ticket_id=123, body="note", article_type="note", internal=True
                 - Use when: "Upload files with article" -> ticket_id=123, body="See attached", attachments=[...]
                 - Don't use when: Creating new ticket (use zammad_create_ticket with article)
                 - Don't use when: Updating ticket fields (use zammad_update_ticket)


### PR DESCRIPTION
Non-blocking follow-ups from the Factory review of #340. Targets `factory/review-followups-pr-333` so it can be merged into that PR directly.

## What changed

Both fixes are in the `zammad_add_article` docstring that #340 already edited — docstring-only, no behavior change.

- **`article_type` is documented as `(default: note)`, not `(required)`.** `ArticleCreate.article_type` defaults to `ArticleType.NOTE` (`mcp_zammad/models.py:346`) and the generated JSON schema lists only `ticket_id` and `body` as required. FastMCP lifts the `Args:` block into the `params` property description, so the `(required)` claim reached MCP clients.
- **Examples use the canonical lowercase values.** The `Use when:` lines still showed `article_type=NOTE` / `article_type=EMAIL` — the same uppercase member-name spelling #340 removed from the `Args:` line two dozen lines above. They now read `article_type="note"` / `"email"`. (The examples block is not lifted into the MCP description by FastMCP 3.2.4, so this is source-docs consistency only.)

## Verification

- `uv run ruff format --check mcp_zammad`, `uv run ruff check mcp_zammad` → clean
- `uv run pytest tests/test_server.py tests/test_case_insensitive_constants.py` → 132 passed
- Confirmed via `server.mcp.get_tool("zammad_add_article").parameters` that the generated `params` description now says `(default: note)`.
