### PR TITLE
feat(kb): add read-only Knowledge Base tools and resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ An MCP server that connects AI assistants to Zammad, providing tools for managin
   - `zammad_list_ticket_priorities` - Get all priority levels (cached for performance)
   - `zammad_get_ticket_stats` - Get ticket statistics (optimized with pagination)
 
+- **Knowledge Base (read-only)**
+  - `zammad_list_knowledge_bases` / `zammad_get_knowledge_base` - Discover knowledge bases visible to the current user
+  - `zammad_get_kb_category` - Browse a category's child categories and answers
+  - `zammad_list_kb_answers` / `zammad_search_kb_answers` - List answers or search them by title
+  - `zammad_get_kb_answer` - Read an answer including its body
+
 ### Resources
 
 Access Zammad data directly:
@@ -47,6 +53,9 @@ Access Zammad data directly:
 - `zammad://user/{id}` - User profile information
 - `zammad://organization/{id}` - Organization details
 - `zammad://queue/{group}` - Ticket queue for a group
+- `zammad://kb/{kb_id}` - Knowledge base summary
+- `zammad://kb/{kb_id}/category/{category_id}` - Knowledge base category
+- `zammad://kb/{kb_id}/answer/{answer_id}` - Knowledge base answer with body
 
 ### Prompts
 

--- a/mcp_zammad/client.py
+++ b/mcp_zammad/client.py
@@ -8,6 +8,13 @@ from urllib.parse import urlparse
 from zammad_py import ZammadAPI
 from zammad_py.exceptions import ConfigException
 
+from .knowledge_base import (
+    KnowledgeBaseNotFoundError,
+    KnowledgeBaseSnapshot,
+    extract_answer_body,
+    parse_init_assets,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -481,3 +488,79 @@ class ZammadClient:
         response = self.api.session.get(f"{self.url}/tag_list")
         response.raise_for_status()
         return list(response.json())
+
+    def _kb_snapshot(self) -> KnowledgeBaseSnapshot:
+        """Fetch the knowledge-base structure visible to the caller via ``init``.
+
+        Returns:
+            Parsed snapshot of visible knowledge bases, categories and answers.
+
+        Raises:
+            requests.HTTPError: If Zammad rejects the request.
+            KnowledgeBaseResponseError: If the payload has an unexpected shape.
+        """
+        return parse_init_assets(self.api.knowledge_bases.init())
+
+    def list_knowledge_bases(self) -> list[dict[str, Any]]:
+        """List knowledge bases visible to the authenticated user."""
+        return list(self._kb_snapshot().knowledge_bases.values())
+
+    def get_knowledge_base(self, kb_id: int) -> dict[str, Any]:
+        """Get one knowledge base by ID.
+
+        Raises:
+            KnowledgeBaseNotFoundError: If the knowledge base is not visible.
+        """
+        return _lookup(self._kb_snapshot().knowledge_bases, kb_id, "Knowledge base")
+
+    def get_kb_category(self, kb_id: int, category_id: int) -> dict[str, Any]:
+        """Get one category, including its child category and answer IDs.
+
+        Raises:
+            KnowledgeBaseNotFoundError: If the category is not visible in that knowledge base.
+        """
+        return _lookup(_scoped(self._kb_snapshot().categories, kb_id), category_id, "Category")
+
+    def list_kb_answers(self, kb_id: int, category_id: int | None = None) -> list[dict[str, Any]]:
+        """List visible answers in a knowledge base, optionally within one category.
+
+        Raises:
+            KnowledgeBaseNotFoundError: If the category is not visible in that knowledge base.
+        """
+        snapshot = self._kb_snapshot()
+        answers = list(_scoped(snapshot.answers, kb_id).values())
+        if category_id is None:
+            return answers
+        _lookup(_scoped(snapshot.categories, kb_id), category_id, "Category")
+        return [a for a in answers if a["category_id"] == category_id]
+
+    def search_kb_answers(self, kb_id: int, query: str) -> list[dict[str, Any]]:
+        """Find visible answers whose title contains ``query`` (case-insensitive)."""
+        needle = query.lower()
+        return [a for a in _scoped(self._kb_snapshot().answers, kb_id).values() if needle in a["title"].lower()]
+
+    def get_kb_answer(self, kb_id: int, answer_id: int) -> dict[str, Any]:
+        """Get one answer together with its primary-locale body.
+
+        Raises:
+            KnowledgeBaseNotFoundError: If the answer is not visible in that knowledge base.
+            KnowledgeBaseResponseError: If Zammad omits the requested content.
+        """
+        snapshot = self._kb_snapshot()
+        answer = dict(_lookup(_scoped(snapshot.answers, kb_id), answer_id, "Answer"))
+        content_id = snapshot.content_ids[answer_id]
+        payload = self.api.knowledge_bases_answers.find_answer(kb_id, answer_id, include_content_id=content_id)
+        answer["body"] = extract_answer_body(payload, content_id)
+        return answer
+
+
+def _scoped(items: dict[int, dict[str, Any]], kb_id: int) -> dict[int, dict[str, Any]]:
+    """Return only the items that belong to ``kb_id``."""
+    return {item_id: item for item_id, item in items.items() if item["knowledge_base_id"] == kb_id}
+
+
+def _lookup(items: dict[int, dict[str, Any]], item_id: int, kind: str) -> dict[str, Any]:
+    """Return ``items[item_id]`` or raise a loud not-found error."""
+    if item_id not in items:
+        raise KnowledgeBaseNotFoundError(f"{kind} {item_id} not found or not visible to the current user")
+    return items[item_id]

--- a/mcp_zammad/kb_docs.py
+++ b/mcp_zammad/kb_docs.py
@@ -1,0 +1,94 @@
+"""Tool descriptions for the read-only knowledge-base MCP tools."""
+
+from .docstring_templates import format_tool_docstring
+
+_FORMAT_ARG = "Output format: markdown (default) or json"
+_KB_ARG = "Knowledge base ID (> 0), from zammad_list_knowledge_bases"
+_LIST_SCHEMA = {"items": "list[object]", "count": "int"}
+_KB_SCHEMA = {
+    "id": "int",
+    "title": "str",
+    "active": "bool",
+    "root_category_ids": "list[int]",
+    "category_count": "int",
+    "answer_count": "int",
+}
+_CATEGORY_SCHEMA = {
+    "id": "int",
+    "knowledge_base_id": "int",
+    "parent_id": "int | None",
+    "title": "str",
+    "child_category_ids": "list[int]",
+    "answer_ids": "list[int]",
+}
+_ANSWER_SCHEMA = {
+    "id": "int",
+    "knowledge_base_id": "int",
+    "category_id": "int",
+    "title": "str",
+    "published_at": "str | None",
+    "internal_at": "str | None",
+    "archived_at": "str | None",
+    "promoted": "bool",
+}
+_PROVIDER_ERROR = "Raises a tool error if Zammad rejects the request or returns an unexpected payload"
+
+LIST_KNOWLEDGE_BASES = format_tool_docstring(
+    summary="List knowledge bases visible to the current user.",
+    args_doc={"response_format": _FORMAT_ARG},
+    return_schema=_LIST_SCHEMA,
+    examples=[],
+    use_when=["'What knowledge bases exist?' -> discover kb_id values for the other KB tools"],
+    dont_use_when=["You already know the kb_id (use zammad_get_knowledge_base)"],
+    errors=["Reports 'No knowledge bases are visible' when the user can see none", _PROVIDER_ERROR],
+)
+
+GET_KNOWLEDGE_BASE = format_tool_docstring(
+    summary="Get one knowledge base with its root category IDs and counts.",
+    args_doc={"kb_id": _KB_ARG, "response_format": _FORMAT_ARG},
+    return_schema=_KB_SCHEMA,
+    examples=[],
+    use_when=["'Show me knowledge base 1' -> kb_id=1"],
+    dont_use_when=["Listing all knowledge bases (use zammad_list_knowledge_bases)"],
+    errors=["Raises a tool error if the knowledge base is not visible", _PROVIDER_ERROR],
+)
+
+GET_KB_CATEGORY = format_tool_docstring(
+    summary="Get one knowledge-base category with its child category IDs and answer IDs.",
+    args_doc={"kb_id": _KB_ARG, "category_id": "Category ID (> 0)", "response_format": _FORMAT_ARG},
+    return_schema=_CATEGORY_SCHEMA,
+    examples=[],
+    use_when=["'Browse category 10 in knowledge base 1' -> kb_id=1, category_id=10"],
+    dont_use_when=["You need answer bodies (use zammad_get_kb_answer)"],
+    errors=["Raises a tool error if the category is not visible in that knowledge base", _PROVIDER_ERROR],
+)
+
+LIST_KB_ANSWERS = format_tool_docstring(
+    summary="List visible answers in a knowledge base, optionally restricted to one category. Bodies are omitted.",
+    args_doc={"kb_id": _KB_ARG, "category_id": "Optional category ID (> 0)", "response_format": _FORMAT_ARG},
+    return_schema=_LIST_SCHEMA,
+    examples=[],
+    use_when=["'What answers are in category 10?' -> kb_id=1, category_id=10"],
+    dont_use_when=["Searching by text (use zammad_search_kb_answers)"],
+    errors=["Raises a tool error if the category is not visible in that knowledge base", _PROVIDER_ERROR],
+)
+
+SEARCH_KB_ANSWERS = format_tool_docstring(
+    summary="Find visible answers whose title contains the query (case-insensitive). Bodies are omitted.",
+    args_doc={"kb_id": _KB_ARG, "query": "Text to match (1-200 chars)", "response_format": _FORMAT_ARG},
+    return_schema=_LIST_SCHEMA,
+    examples=[],
+    use_when=["'Find the VPN article' -> kb_id=1, query='vpn'"],
+    dont_use_when=["You know the answer_id (use zammad_get_kb_answer)"],
+    errors=["Reports 'No answers found' when nothing matches", _PROVIDER_ERROR],
+)
+
+GET_KB_ANSWER = format_tool_docstring(
+    summary="Get one answer including its primary-locale body (HTML as stored in Zammad).",
+    args_doc={"kb_id": _KB_ARG, "answer_id": "Answer ID (> 0)", "response_format": _FORMAT_ARG},
+    return_schema={**_ANSWER_SCHEMA, "body": "str"},
+    examples=[],
+    use_when=["'Read answer 100' -> kb_id=1, answer_id=100"],
+    dont_use_when=["Listing answers (use zammad_list_kb_answers)"],
+    errors=["Raises a tool error if the answer is not visible or its content is missing", _PROVIDER_ERROR],
+)

--- a/mcp_zammad/kb_format.py
+++ b/mcp_zammad/kb_format.py
@@ -1,0 +1,104 @@
+"""Render knowledge-base models as markdown or JSON for MCP responses."""
+
+import json
+from collections.abc import Callable, Sequence
+
+from pydantic import BaseModel
+
+from .kb_models import KnowledgeBase, KnowledgeBaseAnswer, KnowledgeBaseCategory
+from .models import ResponseFormat
+
+
+def render_one(item: BaseModel, fmt: ResponseFormat, markdown: Callable[..., str]) -> str:
+    """Render a single model in the requested format."""
+    if fmt == ResponseFormat.JSON:
+        return json.dumps(item.model_dump(), indent=2)
+    return markdown(item)
+
+
+def render_list(items: Sequence[BaseModel], fmt: ResponseFormat, markdown: Callable[..., str]) -> str:
+    """Render a list of models in the requested format."""
+    if fmt == ResponseFormat.JSON:
+        return json.dumps({"items": [i.model_dump() for i in items], "count": len(items)}, indent=2)
+    return markdown(items)
+
+
+def _ids(ids: Sequence[int]) -> str:
+    return ", ".join(str(i) for i in ids) if ids else "none"
+
+
+def knowledge_base_markdown(kb: KnowledgeBase) -> str:
+    """Format one knowledge base."""
+    return "\n".join(
+        [
+            f"# Knowledge Base: {kb.title} (ID: {kb.id})",
+            "",
+            f"- Active: {kb.active}",
+            f"- Categories: {kb.category_count}",
+            f"- Answers: {kb.answer_count}",
+            f"- Root category IDs: {_ids(kb.root_category_ids)}",
+        ]
+    )
+
+
+def knowledge_bases_markdown(kbs: Sequence[KnowledgeBase]) -> str:
+    """Format a knowledge-base list."""
+    if not kbs:
+        return "No knowledge bases are visible to the current user."
+    lines = ["# Knowledge Bases", "", f"Found {len(kbs)} knowledge base(s)", ""]
+    lines += [
+        f"- **{kb.title}** (ID: {kb.id}) - {kb.category_count} categories, {kb.answer_count} answers" for kb in kbs
+    ]
+    return "\n".join(lines)
+
+
+def category_markdown(category: KnowledgeBaseCategory) -> str:
+    """Format one category."""
+    return "\n".join(
+        [
+            f"# Category: {category.title} (ID: {category.id})",
+            "",
+            f"- Knowledge base ID: {category.knowledge_base_id}",
+            f"- Parent category ID: {category.parent_id if category.parent_id is not None else 'none (root)'}",
+            f"- Child category IDs: {_ids(category.child_category_ids)}",
+            f"- Answer IDs: {_ids(category.answer_ids)}",
+        ]
+    )
+
+
+def _answer_state(answer: KnowledgeBaseAnswer) -> str:
+    if answer.archived_at:
+        return "archived"
+    if answer.published_at:
+        return "published"
+    if answer.internal_at:
+        return "internal"
+    return "draft"
+
+
+def answers_markdown(answers: Sequence[KnowledgeBaseAnswer]) -> str:
+    """Format an answer list."""
+    if not answers:
+        return "No answers found."
+    lines = ["# Knowledge Base Answers", "", f"Found {len(answers)} answer(s)", ""]
+    lines += [f"- **{a.title}** (ID: {a.id}, category: {a.category_id}, {_answer_state(a)})" for a in answers]
+    return "\n".join(lines)
+
+
+def answer_markdown(answer: KnowledgeBaseAnswer) -> str:
+    """Format one answer including its body."""
+    return "\n".join(
+        [
+            f"# Answer: {answer.title} (ID: {answer.id})",
+            "",
+            f"- Knowledge base ID: {answer.knowledge_base_id}",
+            f"- Category ID: {answer.category_id}",
+            f"- State: {_answer_state(answer)}",
+            f"- Published at: {answer.published_at or 'never'}",
+            f"- Promoted: {answer.promoted}",
+            "",
+            "## Body",
+            "",
+            answer.body or "",
+        ]
+    )

--- a/mcp_zammad/kb_models.py
+++ b/mcp_zammad/kb_models.py
@@ -1,0 +1,88 @@
+"""Pydantic contracts for the read-only knowledge-base MCP tools."""
+
+from pydantic import BaseModel, Field
+
+from .models import ResponseFormat, StrictBaseModel
+
+_FORMAT = Field(default=ResponseFormat.MARKDOWN, description="Output format: markdown (default) or json")
+
+
+class ListKnowledgeBasesParams(StrictBaseModel):
+    """List knowledge bases request parameters."""
+
+    response_format: ResponseFormat = _FORMAT
+
+
+class GetKnowledgeBaseParams(StrictBaseModel):
+    """Get knowledge base request parameters."""
+
+    kb_id: int = Field(gt=0, description="Knowledge base ID")
+    response_format: ResponseFormat = _FORMAT
+
+
+class GetKbCategoryParams(StrictBaseModel):
+    """Get knowledge-base category request parameters."""
+
+    kb_id: int = Field(gt=0, description="Knowledge base ID")
+    category_id: int = Field(gt=0, description="Category ID")
+    response_format: ResponseFormat = _FORMAT
+
+
+class ListKbAnswersParams(StrictBaseModel):
+    """List knowledge-base answers request parameters."""
+
+    kb_id: int = Field(gt=0, description="Knowledge base ID")
+    category_id: int | None = Field(default=None, gt=0, description="Restrict to one category")
+    response_format: ResponseFormat = _FORMAT
+
+
+class SearchKbAnswersParams(StrictBaseModel):
+    """Search knowledge-base answers request parameters."""
+
+    kb_id: int = Field(gt=0, description="Knowledge base ID")
+    query: str = Field(min_length=1, max_length=200, description="Case-insensitive text to match in answer titles")
+    response_format: ResponseFormat = _FORMAT
+
+
+class GetKbAnswerParams(StrictBaseModel):
+    """Get knowledge-base answer request parameters."""
+
+    kb_id: int = Field(gt=0, description="Knowledge base ID")
+    answer_id: int = Field(gt=0, description="Answer ID")
+    response_format: ResponseFormat = _FORMAT
+
+
+class KnowledgeBase(BaseModel):
+    """Knowledge base summary."""
+
+    id: int
+    title: str
+    active: bool
+    root_category_ids: list[int]
+    category_count: int
+    answer_count: int
+
+
+class KnowledgeBaseCategory(BaseModel):
+    """Knowledge-base category with its direct children and answers."""
+
+    id: int
+    knowledge_base_id: int
+    parent_id: int | None
+    title: str
+    child_category_ids: list[int]
+    answer_ids: list[int]
+
+
+class KnowledgeBaseAnswer(BaseModel):
+    """Knowledge-base answer metadata plus optional body."""
+
+    id: int
+    knowledge_base_id: int
+    category_id: int
+    title: str
+    published_at: str | None = None
+    internal_at: str | None = None
+    archived_at: str | None = None
+    promoted: bool = False
+    body: str | None = None

--- a/mcp_zammad/kb_tools.py
+++ b/mcp_zammad/kb_tools.py
@@ -1,0 +1,112 @@
+"""Register the read-only knowledge-base MCP tools and resources.
+
+Failures from the client (HTTP errors, not-found, malformed payloads) propagate so FastMCP
+reports them as tool/resource errors instead of success-shaped strings.
+"""
+
+from collections.abc import Callable
+
+from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+from . import kb_docs as docs
+from . import kb_format as fmt
+from .client import ZammadClient
+from .kb_models import (
+    GetKbAnswerParams,
+    GetKbCategoryParams,
+    GetKnowledgeBaseParams,
+    KnowledgeBase,
+    KnowledgeBaseAnswer,
+    KnowledgeBaseCategory,
+    ListKbAnswersParams,
+    ListKnowledgeBasesParams,
+    SearchKbAnswersParams,
+)
+from .models import ResponseFormat
+
+ClientFactory = Callable[[], ZammadClient]
+Truncate = Callable[[str], str]
+Annotate = Callable[[str], ToolAnnotations]
+
+
+def register_knowledge_base_tools(
+    mcp: FastMCP, get_client: ClientFactory, truncate: Truncate, read_only: Annotate
+) -> None:
+    """Register read-only knowledge-base tools on ``mcp``.
+
+    Args:
+        mcp: FastMCP server to register on.
+        get_client: Supplies the Zammad client capability.
+        truncate: Bounds response size at the MCP boundary.
+        read_only: Builds read-only tool annotations from a title.
+    """
+    _register_structure_tools(mcp, get_client, truncate, read_only)
+    _register_answer_tools(mcp, get_client, truncate, read_only)
+
+
+def _register_structure_tools(mcp: FastMCP, get_client: ClientFactory, truncate: Truncate, read_only: Annotate) -> None:
+    """Register knowledge-base and category lookup tools."""
+
+    @mcp.tool(annotations=read_only("List Knowledge Bases"), description=docs.LIST_KNOWLEDGE_BASES)
+    def zammad_list_knowledge_bases(params: ListKnowledgeBasesParams) -> str:
+        kbs = [KnowledgeBase(**kb) for kb in get_client().list_knowledge_bases()]
+        return truncate(fmt.render_list(kbs, params.response_format, fmt.knowledge_bases_markdown))
+
+    @mcp.tool(annotations=read_only("Get Knowledge Base"), description=docs.GET_KNOWLEDGE_BASE)
+    def zammad_get_knowledge_base(params: GetKnowledgeBaseParams) -> str:
+        kb = KnowledgeBase(**get_client().get_knowledge_base(params.kb_id))
+        return truncate(fmt.render_one(kb, params.response_format, fmt.knowledge_base_markdown))
+
+    @mcp.tool(annotations=read_only("Get Knowledge Base Category"), description=docs.GET_KB_CATEGORY)
+    def zammad_get_kb_category(params: GetKbCategoryParams) -> str:
+        category = KnowledgeBaseCategory(**get_client().get_kb_category(params.kb_id, params.category_id))
+        return truncate(fmt.render_one(category, params.response_format, fmt.category_markdown))
+
+
+def _register_answer_tools(mcp: FastMCP, get_client: ClientFactory, truncate: Truncate, read_only: Annotate) -> None:
+    """Register answer listing, search and retrieval tools."""
+
+    @mcp.tool(annotations=read_only("List Knowledge Base Answers"), description=docs.LIST_KB_ANSWERS)
+    def zammad_list_kb_answers(params: ListKbAnswersParams) -> str:
+        raw = get_client().list_kb_answers(params.kb_id, category_id=params.category_id)
+        answers = [KnowledgeBaseAnswer(**a) for a in raw]
+        return truncate(fmt.render_list(answers, params.response_format, fmt.answers_markdown))
+
+    @mcp.tool(annotations=read_only("Search Knowledge Base Answers"), description=docs.SEARCH_KB_ANSWERS)
+    def zammad_search_kb_answers(params: SearchKbAnswersParams) -> str:
+        answers = [KnowledgeBaseAnswer(**a) for a in get_client().search_kb_answers(params.kb_id, params.query)]
+        return truncate(fmt.render_list(answers, params.response_format, fmt.answers_markdown))
+
+    @mcp.tool(annotations=read_only("Get Knowledge Base Answer"), description=docs.GET_KB_ANSWER)
+    def zammad_get_kb_answer(params: GetKbAnswerParams) -> str:
+        answer = KnowledgeBaseAnswer(**get_client().get_kb_answer(params.kb_id, params.answer_id))
+        return truncate(fmt.render_one(answer, params.response_format, fmt.answer_markdown))
+
+
+def register_knowledge_base_resources(mcp: FastMCP, get_client: ClientFactory, truncate: Truncate) -> None:
+    """Register ``zammad://kb/...`` resources on ``mcp``.
+
+    Args:
+        mcp: FastMCP server to register on.
+        get_client: Supplies the Zammad client capability.
+        truncate: Bounds response size at the MCP boundary.
+    """
+
+    @mcp.resource("zammad://kb/{kb_id}")
+    def get_kb_resource(kb_id: str) -> str:
+        """Get a knowledge base as a resource."""
+        kb = KnowledgeBase(**get_client().get_knowledge_base(int(kb_id)))
+        return truncate(fmt.render_one(kb, ResponseFormat.MARKDOWN, fmt.knowledge_base_markdown))
+
+    @mcp.resource("zammad://kb/{kb_id}/category/{category_id}")
+    def get_kb_category_resource(kb_id: str, category_id: str) -> str:
+        """Get a knowledge-base category as a resource."""
+        category = KnowledgeBaseCategory(**get_client().get_kb_category(int(kb_id), int(category_id)))
+        return truncate(fmt.render_one(category, ResponseFormat.MARKDOWN, fmt.category_markdown))
+
+    @mcp.resource("zammad://kb/{kb_id}/answer/{answer_id}")
+    def get_kb_answer_resource(kb_id: str, answer_id: str) -> str:
+        """Get a knowledge-base answer with body as a resource."""
+        answer = KnowledgeBaseAnswer(**get_client().get_kb_answer(int(kb_id), int(answer_id)))
+        return truncate(fmt.render_one(answer, ResponseFormat.MARKDOWN, fmt.answer_markdown))

--- a/mcp_zammad/knowledge_base.py
+++ b/mcp_zammad/knowledge_base.py
@@ -1,0 +1,175 @@
+"""Parse Zammad knowledge-base bootstrap assets into a read-only snapshot.
+
+Zammad exposes no flat knowledge-base index. ``POST /knowledge_bases/init`` returns every
+knowledge base, category and answer visible to the caller as keyed asset tables. This module
+turns that payload into plain dictionaries the MCP layer can expose.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class KnowledgeBaseNotFoundError(LookupError):
+    """Raised when a knowledge base, category or answer is not visible to the caller."""
+
+
+class KnowledgeBaseResponseError(ValueError):
+    """Raised when Zammad returns a knowledge-base payload with an unexpected shape."""
+
+
+@dataclass(frozen=True)
+class KnowledgeBaseSnapshot:
+    """Visible knowledge-base structure keyed by ID."""
+
+    knowledge_bases: dict[int, dict[str, Any]] = field(default_factory=dict)
+    categories: dict[int, dict[str, Any]] = field(default_factory=dict)
+    answers: dict[int, dict[str, Any]] = field(default_factory=dict)
+    content_ids: dict[int, int | None] = field(default_factory=dict)
+
+
+def _rows(assets: dict[str, Any], name: str) -> list[dict[str, Any]]:
+    """Return the asset rows of one type, sorted by ID.
+
+    Args:
+        assets: Asset tables keyed by model name.
+        name: Asset model name, e.g. ``KnowledgeBaseCategory``.
+
+    Returns:
+        Row dictionaries sorted by ``id``.
+
+    Raises:
+        KnowledgeBaseResponseError: If the table or its rows are not dictionaries.
+    """
+    table = assets.get(name, {})
+    if not isinstance(table, dict) or not all(isinstance(row, dict) for row in table.values()):
+        raise KnowledgeBaseResponseError(f"Unexpected shape for {name} assets: {type(table).__name__}")
+    return sorted(table.values(), key=lambda row: int(row["id"]))
+
+
+def _titles(rows: list[dict[str, Any]], owner_key: str, primary_locales: set[int]) -> dict[int, dict[str, Any]]:
+    """Pick one translation per owner, preferring the primary locale.
+
+    Args:
+        rows: Translation rows sorted by ID.
+        owner_key: Foreign key naming the translated object.
+        primary_locales: Locale IDs flagged as primary.
+
+    Returns:
+        Chosen translation row keyed by owner ID.
+    """
+    chosen: dict[int, dict[str, Any]] = {}
+    for row in sorted(rows, key=lambda r: r.get("kb_locale_id") not in primary_locales):
+        chosen.setdefault(int(row[owner_key]), row)
+    return chosen
+
+
+def _build_categories(assets: dict[str, Any], primary: set[int]) -> dict[int, dict[str, Any]]:
+    """Build category dictionaries with child and answer ID lists."""
+    titles = _titles(_rows(assets, "KnowledgeBaseCategoryTranslation"), "category_id", primary)
+    categories: dict[int, dict[str, Any]] = {}
+    for row in _rows(assets, "KnowledgeBaseCategory"):
+        categories[int(row["id"])] = {
+            "id": int(row["id"]),
+            "knowledge_base_id": int(row["knowledge_base_id"]),
+            "parent_id": row.get("parent_id"),
+            "title": titles.get(int(row["id"]), {}).get("title", ""),
+            "child_category_ids": [],
+            "answer_ids": [],
+        }
+    for category in categories.values():
+        parent = categories.get(category["parent_id"]) if category["parent_id"] is not None else None
+        if parent is not None:
+            parent["child_category_ids"].append(category["id"])
+    return categories
+
+
+def _build_answers(
+    assets: dict[str, Any], categories: dict[int, dict[str, Any]], primary: set[int]
+) -> tuple[dict[int, dict[str, Any]], dict[int, int | None]]:
+    """Build answer dictionaries and remember their primary translation content IDs."""
+    titles = _titles(_rows(assets, "KnowledgeBaseAnswerTranslation"), "answer_id", primary)
+    answers: dict[int, dict[str, Any]] = {}
+    content_ids: dict[int, int | None] = {}
+    for row in _rows(assets, "KnowledgeBaseAnswer"):
+        answer_id = int(row["id"])
+        category = categories[int(row["category_id"])]
+        translation = titles.get(answer_id, {})
+        answers[answer_id] = {
+            "id": answer_id,
+            "knowledge_base_id": category["knowledge_base_id"],
+            "category_id": category["id"],
+            "title": translation.get("title", ""),
+            "published_at": row.get("published_at"),
+            "internal_at": row.get("internal_at"),
+            "archived_at": row.get("archived_at"),
+            "promoted": bool(row.get("promoted", False)),
+        }
+        content_ids[answer_id] = translation.get("content_id")
+        category["answer_ids"].append(answer_id)
+    return answers, content_ids
+
+
+def _build_knowledge_bases(
+    assets: dict[str, Any], categories: dict[int, dict[str, Any]], answer_count: dict[int, int], primary: set[int]
+) -> dict[int, dict[str, Any]]:
+    """Build knowledge-base dictionaries with root categories and counts."""
+    titles = _titles(_rows(assets, "KnowledgeBaseTranslation"), "knowledge_base_id", primary)
+    bases: dict[int, dict[str, Any]] = {}
+    for row in _rows(assets, "KnowledgeBase"):
+        kb_id = int(row["id"])
+        owned = [c for c in categories.values() if c["knowledge_base_id"] == kb_id]
+        bases[kb_id] = {
+            "id": kb_id,
+            "title": titles.get(kb_id, {}).get("title", ""),
+            "active": bool(row.get("active", False)),
+            "root_category_ids": [c["id"] for c in owned if c["parent_id"] is None],
+            "category_count": len(owned),
+            "answer_count": answer_count.get(kb_id, 0),
+        }
+    return bases
+
+
+def parse_init_assets(payload: Any) -> KnowledgeBaseSnapshot:
+    """Parse a ``knowledge_bases/init`` payload into a snapshot.
+
+    Args:
+        payload: Decoded JSON returned by ``ZammadAPI.knowledge_bases.init()``.
+
+    Returns:
+        Snapshot of every visible knowledge base, category and answer. Empty when the
+        caller can see no knowledge base.
+
+    Raises:
+        KnowledgeBaseResponseError: If the payload is not the expected asset mapping.
+    """
+    if not isinstance(payload, dict):
+        raise KnowledgeBaseResponseError(f"Expected knowledge-base assets mapping, got {type(payload).__name__}")
+    primary = {int(r["id"]) for r in _rows(payload, "KnowledgeBaseLocale") if r.get("primary")}
+    categories = _build_categories(payload, primary)
+    answers, content_ids = _build_answers(payload, categories, primary)
+    answer_count: dict[int, int] = {}
+    for answer in answers.values():
+        answer_count[answer["knowledge_base_id"]] = answer_count.get(answer["knowledge_base_id"], 0) + 1
+    bases = _build_knowledge_bases(payload, categories, answer_count, primary)
+    return KnowledgeBaseSnapshot(bases, categories, answers, content_ids)
+
+
+def extract_answer_body(payload: Any, content_id: int | None) -> str:
+    """Extract the answer body from a ``find_answer`` payload.
+
+    Args:
+        payload: Decoded JSON returned by ``ZammadAPI.knowledge_bases_answers.find_answer``.
+        content_id: Translation content ID that was requested via ``include_contents``.
+
+    Returns:
+        The HTML body of the requested translation content.
+
+    Raises:
+        KnowledgeBaseResponseError: If the requested content is absent from the payload.
+    """
+    assets = payload.get("assets") if isinstance(payload, dict) else None
+    contents = _rows(assets, "KnowledgeBaseAnswerTranslationContent") if isinstance(assets, dict) else []
+    for content in contents:
+        if content_id is not None and int(content["id"]) == content_id and "body" in content:
+            return str(content["body"])
+    raise KnowledgeBaseResponseError(f"Answer payload did not include translation content {content_id}")

--- a/mcp_zammad/server.py
+++ b/mcp_zammad/server.py
@@ -20,6 +20,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from .client import ZammadClient
+from .kb_tools import register_knowledge_base_resources, register_knowledge_base_tools
 from .logging_config import configure_logging
 from .models import (
     Article,
@@ -868,6 +869,7 @@ class ZammadMCPServer:
         self._setup_ticket_tools()
         self._setup_user_org_tools()
         self._setup_system_tools()
+        register_knowledge_base_tools(self.mcp, self.get_client, truncate_response, _read_only_annotations)
 
     def _setup_ticket_tools(self) -> None:  # noqa: PLR0915
         """Register ticket-related tools."""
@@ -2469,6 +2471,7 @@ class ZammadMCPServer:
         self._setup_user_resource()
         self._setup_organization_resource()
         self._setup_queue_resource()
+        register_knowledge_base_resources(self.mcp, self.get_client, truncate_response)
 
     def _setup_ticket_resource(self) -> None:
         """Register ticket resource."""

--- a/tests/test_knowledge_base_client.py
+++ b/tests/test_knowledge_base_client.py
@@ -1,0 +1,183 @@
+"""Tests for read-only knowledge-base methods on ZammadClient.
+
+The Zammad API capability is replaced with a controlled ``ZammadAPI`` double so no
+network access or credentials are required.
+"""
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from mcp_zammad.client import ZammadClient
+from mcp_zammad.knowledge_base import KnowledgeBaseNotFoundError, KnowledgeBaseResponseError
+
+KB_ID = 1
+ROOT_CATEGORY_ID = 10
+CHILD_CATEGORY_ID = 11
+ROOT_ANSWER_ID = 100
+CHILD_ANSWER_ID = 101
+ROOT_CONTENT_ID = 500
+
+
+def _init_assets() -> dict[str, Any]:
+    """Return a ``knowledge_bases/init`` payload shaped like Zammad's asset response."""
+    return {
+        "KnowledgeBase": {"1": {"id": KB_ID, "active": True}},
+        "KnowledgeBaseTranslation": {"1": {"id": 1, "knowledge_base_id": KB_ID, "kb_locale_id": 1, "title": "Help"}},
+        "KnowledgeBaseLocale": {"1": {"id": 1, "knowledge_base_id": KB_ID, "primary": True}},
+        "KnowledgeBaseCategory": {
+            "10": {"id": ROOT_CATEGORY_ID, "knowledge_base_id": KB_ID, "parent_id": None},
+            "11": {"id": CHILD_CATEGORY_ID, "knowledge_base_id": KB_ID, "parent_id": ROOT_CATEGORY_ID},
+        },
+        "KnowledgeBaseCategoryTranslation": {
+            "10": {"id": 10, "category_id": ROOT_CATEGORY_ID, "kb_locale_id": 1, "title": "Getting Started"},
+            "11": {"id": 11, "category_id": CHILD_CATEGORY_ID, "kb_locale_id": 1, "title": "VPN"},
+        },
+        "KnowledgeBaseAnswer": {
+            "100": {"id": ROOT_ANSWER_ID, "category_id": ROOT_CATEGORY_ID, "published_at": "2024-01-01T00:00:00Z"},
+            "101": {"id": CHILD_ANSWER_ID, "category_id": CHILD_CATEGORY_ID, "published_at": None},
+        },
+        "KnowledgeBaseAnswerTranslation": {
+            "100": {
+                "id": 100,
+                "answer_id": ROOT_ANSWER_ID,
+                "kb_locale_id": 1,
+                "title": "Reset your password",
+                "content_id": ROOT_CONTENT_ID,
+            },
+            "101": {
+                "id": 101,
+                "answer_id": CHILD_ANSWER_ID,
+                "kb_locale_id": 1,
+                "title": "Connect to the VPN",
+                "content_id": 501,
+            },
+        },
+    }
+
+
+@pytest.fixture
+def api() -> Generator[Mock, None, None]:
+    """Provide a ZammadAPI double whose ``init`` returns a populated knowledge base."""
+    with patch("mcp_zammad.client.ZammadAPI") as api_class:
+        instance = Mock()
+        instance.knowledge_bases.init.return_value = _init_assets()
+        api_class.return_value = instance
+        yield instance
+
+
+@pytest.fixture
+def client(api: Mock) -> ZammadClient:
+    """Provide a client wired to the API double."""
+    return ZammadClient(url="https://test.zammad.com/api/v1", http_token="test-token")
+
+
+def test_list_knowledge_bases_discovers_via_init(client: ZammadClient, api: Mock) -> None:
+    result = client.list_knowledge_bases()
+
+    api.knowledge_bases.init.assert_called_once_with()
+    assert result == [
+        {
+            "id": KB_ID,
+            "title": "Help",
+            "active": True,
+            "root_category_ids": [ROOT_CATEGORY_ID],
+            "category_count": 2,
+            "answer_count": 2,
+        }
+    ]
+
+
+def test_list_knowledge_bases_is_empty_when_nothing_visible(client: ZammadClient, api: Mock) -> None:
+    api.knowledge_bases.init.return_value = {}
+
+    assert client.list_knowledge_bases() == []
+
+
+def test_list_knowledge_bases_propagates_api_errors(client: ZammadClient, api: Mock) -> None:
+    api.knowledge_bases.init.side_effect = requests.HTTPError("401 Unauthorized")
+
+    with pytest.raises(requests.HTTPError):
+        client.list_knowledge_bases()
+
+
+def test_list_knowledge_bases_rejects_unexpected_payload(client: ZammadClient, api: Mock) -> None:
+    api.knowledge_bases.init.return_value = b"<html>login</html>"
+
+    with pytest.raises(KnowledgeBaseResponseError):
+        client.list_knowledge_bases()
+
+
+def test_get_knowledge_base_unknown_id_raises(client: ZammadClient) -> None:
+    with pytest.raises(KnowledgeBaseNotFoundError):
+        client.get_knowledge_base(99)
+
+
+def test_get_kb_category_returns_hierarchy(client: ZammadClient) -> None:
+    assert client.get_kb_category(KB_ID, ROOT_CATEGORY_ID) == {
+        "id": ROOT_CATEGORY_ID,
+        "knowledge_base_id": KB_ID,
+        "parent_id": None,
+        "title": "Getting Started",
+        "child_category_ids": [CHILD_CATEGORY_ID],
+        "answer_ids": [ROOT_ANSWER_ID],
+    }
+
+
+def test_get_kb_category_unknown_id_raises(client: ZammadClient) -> None:
+    with pytest.raises(KnowledgeBaseNotFoundError):
+        client.get_kb_category(KB_ID, 99)
+
+
+def test_list_kb_answers_filters_by_category(client: ZammadClient) -> None:
+    all_ids = [a["id"] for a in client.list_kb_answers(KB_ID)]
+    child_ids = [a["id"] for a in client.list_kb_answers(KB_ID, category_id=CHILD_CATEGORY_ID)]
+
+    assert all_ids == [ROOT_ANSWER_ID, CHILD_ANSWER_ID]
+    assert child_ids == [CHILD_ANSWER_ID]
+
+
+def test_list_kb_answers_unknown_category_raises(client: ZammadClient) -> None:
+    with pytest.raises(KnowledgeBaseNotFoundError):
+        client.list_kb_answers(KB_ID, category_id=99)
+
+
+def test_search_kb_answers_matches_title_case_insensitively(client: ZammadClient) -> None:
+    assert [a["id"] for a in client.search_kb_answers(KB_ID, "PASSWORD")] == [ROOT_ANSWER_ID]
+    assert client.search_kb_answers(KB_ID, "printer") == []
+
+
+def test_get_kb_answer_fetches_body_for_translation_content(client: ZammadClient, api: Mock) -> None:
+    api.knowledge_bases_answers.find_answer.return_value = {
+        "id": ROOT_ANSWER_ID,
+        "assets": {
+            "KnowledgeBaseAnswerTranslationContent": {"500": {"id": ROOT_CONTENT_ID, "body": "<p>Open settings</p>"}}
+        },
+    }
+
+    answer = client.get_kb_answer(KB_ID, ROOT_ANSWER_ID)
+
+    api.knowledge_bases_answers.find_answer.assert_called_once_with(
+        KB_ID, ROOT_ANSWER_ID, include_content_id=ROOT_CONTENT_ID
+    )
+    assert answer["title"] == "Reset your password"
+    assert answer["body"] == "<p>Open settings</p>"
+    assert answer["category_id"] == ROOT_CATEGORY_ID
+    assert answer["published_at"] == "2024-01-01T00:00:00Z"
+
+
+def test_get_kb_answer_unknown_id_raises_without_fetching(client: ZammadClient, api: Mock) -> None:
+    with pytest.raises(KnowledgeBaseNotFoundError):
+        client.get_kb_answer(KB_ID, 999)
+
+    api.knowledge_bases_answers.find_answer.assert_not_called()
+
+
+def test_get_kb_answer_rejects_missing_content(client: ZammadClient, api: Mock) -> None:
+    api.knowledge_bases_answers.find_answer.return_value = {"id": ROOT_ANSWER_ID, "assets": {}}
+
+    with pytest.raises(KnowledgeBaseResponseError):
+        client.get_kb_answer(KB_ID, ROOT_ANSWER_ID)

--- a/tests/test_knowledge_base_resources.py
+++ b/tests/test_knowledge_base_resources.py
@@ -1,0 +1,60 @@
+"""Tests for the ``zammad://kb/...`` MCP resources through FastMCP's public boundary."""
+
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+import requests
+from fastmcp.exceptions import ResourceError
+
+from mcp_zammad.server import ZammadMCPServer
+
+
+def _kb() -> dict[str, Any]:
+    return {"id": 1, "title": "Help", "active": True, "root_category_ids": [10], "category_count": 2, "answer_count": 2}
+
+
+def _category() -> dict[str, Any]:
+    return {
+        "id": 10,
+        "knowledge_base_id": 1,
+        "parent_id": None,
+        "title": "Getting Started",
+        "child_category_ids": [11],
+        "answer_ids": [100],
+    }
+
+
+def _answer() -> dict[str, Any]:
+    return {"id": 100, "knowledge_base_id": 1, "category_id": 10, "title": "Reset", "body": "<p>Open settings</p>"}
+
+
+@pytest.fixture
+def server() -> ZammadMCPServer:
+    """Provide a server whose client capability is a Mock."""
+    instance = ZammadMCPServer()
+    instance.client = Mock()
+    return instance
+
+
+@pytest.mark.asyncio
+async def test_knowledge_base_resources(server: ZammadMCPServer) -> None:
+    server.client.get_knowledge_base.return_value = _kb()
+    server.client.get_kb_category.return_value = _category()
+    server.client.get_kb_answer.return_value = _answer()
+
+    kb = await server.mcp.read_resource("zammad://kb/1")
+    category = await server.mcp.read_resource("zammad://kb/1/category/10")
+    answer = await server.mcp.read_resource("zammad://kb/1/answer/100")
+
+    assert "Help" in str(kb.contents[0].content)
+    assert "Getting Started" in str(category.contents[0].content)
+    assert "<p>Open settings</p>" in str(answer.contents[0].content)
+
+
+@pytest.mark.asyncio
+async def test_knowledge_base_resource_failures_surface_as_errors(server: ZammadMCPServer) -> None:
+    server.client.get_kb_answer.side_effect = requests.HTTPError("500 Server Error")
+
+    with pytest.raises(ResourceError, match="500 Server Error"):
+        await server.mcp.read_resource("zammad://kb/1/answer/100")

--- a/tests/test_knowledge_base_server.py
+++ b/tests/test_knowledge_base_server.py
@@ -1,0 +1,180 @@
+"""Tests for the read-only knowledge-base MCP tools and resources.
+
+Behavior is exercised through FastMCP's public ``call_tool``/``read_resource`` boundary
+with the ZammadClient capability replaced by a controlled double.
+"""
+
+import json
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+import requests
+from fastmcp.exceptions import ToolError
+from pydantic import ValidationError
+
+from mcp_zammad.knowledge_base import KnowledgeBaseNotFoundError
+from mcp_zammad.server import ZammadMCPServer
+
+KB_TOOLS = {
+    "zammad_list_knowledge_bases",
+    "zammad_get_knowledge_base",
+    "zammad_get_kb_category",
+    "zammad_list_kb_answers",
+    "zammad_search_kb_answers",
+    "zammad_get_kb_answer",
+}
+
+
+def _kb() -> dict[str, Any]:
+    return {"id": 1, "title": "Help", "active": True, "root_category_ids": [10], "category_count": 2, "answer_count": 2}
+
+
+def _category() -> dict[str, Any]:
+    return {
+        "id": 10,
+        "knowledge_base_id": 1,
+        "parent_id": None,
+        "title": "Getting Started",
+        "child_category_ids": [11],
+        "answer_ids": [100],
+    }
+
+
+def _answer(body: str | None = None) -> dict[str, Any]:
+    return {
+        "id": 100,
+        "knowledge_base_id": 1,
+        "category_id": 10,
+        "title": "Reset your password",
+        "published_at": "2024-01-01T00:00:00Z",
+        "internal_at": None,
+        "archived_at": None,
+        "promoted": False,
+        "body": body,
+    }
+
+
+@pytest.fixture
+def server() -> ZammadMCPServer:
+    """Provide a server whose client capability is a Mock."""
+    instance = ZammadMCPServer()
+    instance.client = Mock()
+    return instance
+
+
+async def _call(server: ZammadMCPServer, tool: str, **params: Any) -> str:
+    result = await server.mcp.call_tool(tool, {"params": params})
+    return result.content[0].text  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_knowledge_base_tools_are_registered_read_only(server: ZammadMCPServer) -> None:
+    tools = {tool.name: tool for tool in await server.mcp.list_tools()}
+
+    assert KB_TOOLS.issubset(tools)
+    for name in KB_TOOLS:
+        assert tools[name].annotations is not None
+        assert tools[name].annotations.readOnlyHint is True
+        assert tools[name].annotations.destructiveHint is False
+        assert tools[name].description is not None
+        assert "Error Handling:" in tools[name].description
+
+
+@pytest.mark.asyncio
+async def test_list_knowledge_bases_markdown_and_json(server: ZammadMCPServer) -> None:
+    server.client.list_knowledge_bases.return_value = [_kb()]
+
+    markdown = await _call(server, "zammad_list_knowledge_bases")
+    payload = json.loads(await _call(server, "zammad_list_knowledge_bases", response_format="json"))
+
+    assert "Help" in markdown
+    assert "(ID: 1)" in markdown
+    assert payload["items"][0]["title"] == "Help"
+    assert payload["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_list_knowledge_bases_reports_empty(server: ZammadMCPServer) -> None:
+    server.client.list_knowledge_bases.return_value = []
+
+    assert "No knowledge bases" in await _call(server, "zammad_list_knowledge_bases")
+
+
+@pytest.mark.asyncio
+async def test_get_knowledge_base_and_category(server: ZammadMCPServer) -> None:
+    server.client.get_knowledge_base.return_value = _kb()
+    server.client.get_kb_category.return_value = _category()
+
+    kb_text = await _call(server, "zammad_get_knowledge_base", kb_id=1)
+    category_text = await _call(server, "zammad_get_kb_category", kb_id=1, category_id=10)
+
+    server.client.get_knowledge_base.assert_called_once_with(1)
+    server.client.get_kb_category.assert_called_once_with(1, 10)
+    assert "Help" in kb_text
+    assert "Getting Started" in category_text
+    assert "11" in category_text
+    assert "100" in category_text
+
+
+@pytest.mark.asyncio
+async def test_list_and_search_kb_answers(server: ZammadMCPServer) -> None:
+    server.client.list_kb_answers.return_value = [_answer()]
+    server.client.search_kb_answers.return_value = [_answer()]
+
+    listed = await _call(server, "zammad_list_kb_answers", kb_id=1, category_id=10)
+    searched = json.loads(
+        await _call(server, "zammad_search_kb_answers", kb_id=1, query="password", response_format="json")
+    )
+
+    server.client.list_kb_answers.assert_called_once_with(1, category_id=10)
+    server.client.search_kb_answers.assert_called_once_with(1, "password")
+    assert "Reset your password" in listed
+    assert searched["items"][0]["id"] == 100
+
+
+@pytest.mark.asyncio
+async def test_search_kb_answers_reports_no_matches(server: ZammadMCPServer) -> None:
+    server.client.search_kb_answers.return_value = []
+
+    assert "No answers" in await _call(server, "zammad_search_kb_answers", kb_id=1, query="printer")
+
+
+@pytest.mark.asyncio
+async def test_get_kb_answer_includes_body(server: ZammadMCPServer) -> None:
+    server.client.get_kb_answer.return_value = _answer(body="<p>Open settings</p>")
+
+    markdown = await _call(server, "zammad_get_kb_answer", kb_id=1, answer_id=100)
+    payload = json.loads(await _call(server, "zammad_get_kb_answer", kb_id=1, answer_id=100, response_format="json"))
+
+    assert "Reset your password" in markdown
+    assert "<p>Open settings</p>" in markdown
+    assert payload["body"] == "<p>Open settings</p>"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool", "params"),
+    [
+        ("zammad_get_knowledge_base", {"kb_id": 0}),
+        ("zammad_get_kb_answer", {"kb_id": 1, "answer_id": -1}),
+        ("zammad_search_kb_answers", {"kb_id": 1, "query": "   "}),
+        ("zammad_list_kb_answers", {"kb_id": 1, "unknown": True}),
+    ],
+)
+async def test_invalid_parameters_are_rejected(server: ZammadMCPServer, tool: str, params: dict[str, Any]) -> None:
+    with pytest.raises((ToolError, ValidationError)):
+        await _call(server, tool, **params)
+    assert not server.client.method_calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [requests.HTTPError("401 Unauthorized"), KnowledgeBaseNotFoundError("knowledge base 9 not found")],
+)
+async def test_client_failures_surface_as_tool_errors(server: ZammadMCPServer, error: Exception) -> None:
+    server.client.get_knowledge_base.side_effect = error
+
+    with pytest.raises(ToolError, match=str(error)):
+        await _call(server, "zammad_get_knowledge_base", kb_id=9)


### PR DESCRIPTION
## Summary

Adds the first, read-only slice of Zammad Knowledge Base support to the MCP server, so agents can discover and read KB content (#198). This follows the maintainer guidance on #200 to ship KB support in small reviewable slices; writes, visibility changes and attachments are deferred to follow-ups.

**New tools (all annotated read-only):**
- `zammad_list_knowledge_bases`, `zammad_get_knowledge_base`
- `zammad_get_kb_category` (child category IDs + answer IDs)
- `zammad_list_kb_answers` (optionally filtered by category), `zammad_search_kb_answers` (case-insensitive title match)
- `zammad_get_kb_answer` (metadata + primary-locale body)

**New resources:** `zammad://kb/{kb_id}`, `zammad://kb/{kb_id}/category/{category_id}`, `zammad://kb/{kb_id}/answer/{answer_id}`

**Design notes**
- Discovery uses `zammad-py`'s `knowledge_bases.init()` (the supported bootstrap endpoint). Zammad has no flat `GET /knowledge_bases` index, so there is no guessed-ID probing and no raw HTTP calls.
- Answer bodies are fetched via `knowledge_bases_answers.find_answer(kb_id, answer_id, include_content_id=...)` using the primary-locale translation's content ID.
- Not-found, malformed payloads and HTTP errors propagate as MCP tool/resource errors instead of success-shaped error strings.
- KB code lives in small focused modules (`knowledge_base.py` parsing, `kb_models.py`, `kb_format.py`, `kb_docs.py`, `kb_tools.py`) and is wired into `ZammadMCPServer` via two registration calls.

## Test plan

- [x] `uv run pytest tests` — 250 passed (28 new KB tests through FastMCP's public `call_tool`/`read_resource` boundary and a mocked `ZammadAPI`)
- [x] `uv run ruff format --check mcp_zammad tests`, `uv run ruff check mcp_zammad tests`, `uv run mypy mcp_zammad` — clean
- [x] Coverage 89.8% (floor 86%)
- [x] `uv run bandit -r mcp_zammad -ll` — no findings
- [ ] Manual check against a live Zammad instance with a populated KB (reader and editor tokens)

Closes #198 for the read-only slice; write/attachment slices will reference it separately.
